### PR TITLE
Force created disk images to use zlib compression level 9

### DIFF
--- a/Code/autopkglib/DmgCreator.py
+++ b/Code/autopkglib/DmgCreator.py
@@ -53,6 +53,10 @@ class DmgCreator(Processor):
             p = subprocess.Popen(("/usr/bin/hdiutil",
                                   "create",
                                   "-plist",
+                                  "-format",
+                                  "UDZO",
+                                  "-imagekey",
+                                  "zlib-level=9",
                                   "-srcfolder", self.env['dmg_root'],
                                   self.env['dmg_path']),
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Specific the disk image format as UDZO and force use of zlib compression level 9 when creating images.

In a small amount of informal testing, this appeared to save as much as 5% disk space.
