### PR TITLE
App versioner

### DIFF
--- a/Code/autopkglib/PlistReader.py
+++ b/Code/autopkglib/PlistReader.py
@@ -25,10 +25,10 @@ from DmgMounter import DmgMounter
 from autopkglib import Processor, ProcessorError
 
 
-__all__ = ["AppInfo"]
+__all__ = ["PlistReader"]
 
 
-class AppInfo(DmgMounter):
+class PlistReader(DmgMounter):
     description = "Extracts information from a plist file."
     input_variables = {
         "info_path": {
@@ -113,5 +113,5 @@ class AppInfo(DmgMounter):
 
 
 if __name__ == '__main__':
-    processor = AppInfo()
+    processor = PlistReader()
     processor.execute_shell()


### PR DESCRIPTION
To streamline the process of making packages of Evernote without having to make a dmg, I needed a processor which could pull more than just version. While it's possible to pull whatever key you really want with Versioner.py, I thought it would make sense to include some of the logic from Versioner with the slightly expanded set of output variables of AppDmgVersioner.py

So this version is happy to take either a path to an app enclosed in a .dmg or outside and handle the mounting should it need it. Also, it allows you to specify the key to use for the version, like Versioner.py. Just in testing, I noticed that, for example, the GoogleEarth CFBundleVersion is more helpful than the CFBundleShortVersionString, but on Evernote it's their build number, not a version in the normal sense.

A couple of questions I have regarding this, however:
1. I don't imagine that AppVersioner.py is probably the best name for this, since it does more than just get version info.
2. The original AppDmgVersioner.py uses a method to search within a dmg for the first .app file it finds and uses that. This is slick, but I wonder if there are packages out there which have more than one app bundle at the root level of the .dmg. Therefore, this code expects a path to the specific app. (However, like AppDmgVersioner, it expects and app path, and then adds on the Contents/Info.plist). I'm guessing that Greg prefers you specify the complete URL, like in Versioner.py. This may be something that needs to be standardized a little more.
3. Didn't know what to do with the copyright info stuff at the top. Just tell me what's correct!
4. Timothy Sutton mentioned yesterday that a "PlistReader"-like processor would be of use, which seems like logical next thing to work on. I wonder if there really is any information beyond that which is included here that people will really want to get. Perhaps minimum version information? Anyway, just wondering if it would be overkill or useful.
