### PR TITLE
Fix issue with autopkg (URLTextSearcher) referencing output variables during processing.

### DIFF
--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -81,9 +81,11 @@ class URLTextSearcher(Processor):
         if output_var_name not in groupdict.keys():
             groupdict[output_var_name] = group0
 
+        self.output_variables = {}
         for k in groupdict.keys():
             self.env[k] = groupdict[k]
             self.output('Found matching text (%s): %s' % (k, self.env[k], ))
+            self.output_variables[k] = {'description': 'Matched regular expression group'}
 
 if __name__ == '__main__':
     processor = URLTextSearcher()


### PR DESCRIPTION
Fixes an issue with autopkg, specifically here:

https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/__init__.py#L401

.. where autopkg is expecting to reference the output variables. So we just dynamically generate the `output_variables` dictionary during execution which works as `output_variables` is references after this processing.
