### PR TITLE
URLTextSearcher: Use last regexp match group rather than first

### DIFF
--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -62,7 +62,8 @@ class URLTextSearcher(Processor):
         if not m:
             raise ProcessorError('No match found on URL: %s' % url)
 
-        return (m.group(0), m.groupdict(), )
+        # return the last matched group with the dict of named groups
+        return (m.group(m.lastindex), m.groupdict(), )
 
     def main(self):
         output_var_name = None
@@ -76,10 +77,11 @@ class URLTextSearcher(Processor):
 
         flags = self.env.get('re_flags', {})
 
-        group0, groupdict = self.get_url_and_search(self.env['url'], self.env['re_pattern'], headers, flags)
+        groupmatch, groupdict = self.get_url_and_search(self.env['url'], self.env['re_pattern'], headers, flags)
 
+        # favor a named group over a normal group match
         if output_var_name not in groupdict.keys():
-            groupdict[output_var_name] = group0
+            groupdict[output_var_name] = groupmatch
 
         self.output_variables = {}
         for k in groupdict.keys():


### PR DESCRIPTION
Per comments in #64, reproduced here:

> In addition to #65 I found another problem. For regexp normal groups (non-named) that have a sub-pattern it currently only returns the first group (0). This means that, for example, the regexp `Version ([0-9a-z\.]*)` will, without a named group, will return `Version 1.0a` instead of what is wanted: the second group (1) (just the `1.0a`).
> 
> To solve this I see a few choices:
> 1. Have an input variable to select the match you want.
> 2. Return all matches with a suffix to the output variable. E.g. `match`, `match1`, `match2`, or in the case of a `result_output_var_name` (say, `url`) it would be `url`, `url1`, etc. This could get messy with many output vars for a regexp with many groups named or otherwise (since we can't really tell named vs. non-named).
> 3. Simply return the _last_ group of the regexp (instead of the _first_ as it operates now). This has the benefit that if there are no sub-patterns it works as it does now.
> 
> Or a combination of those or something I haven't thought of. My vote would go to number 3. Thoughts? I can squeeze this into the PR on #65 if pick a solution is picked.
