### PR TITLE
URLTextSearcher: Correct for lastindex being None on singular non-named group

### DIFF
--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -63,7 +63,7 @@ class URLTextSearcher(Processor):
             raise ProcessorError('No match found on URL: %s' % url)
 
         # return the last matched group with the dict of named groups
-        return (m.group(m.lastindex), m.groupdict(), )
+        return (m.group(m.lastindex or 0), m.groupdict(), )
 
     def main(self):
         output_var_name = None


### PR DESCRIPTION
Okay, this passes all my examples for named groups, non-named groups, and non-named group sub pattern matches. Apparently if there is a match but no _group_ matches then `lastindex` is `None` despite `group(0)` returning a result. Here's hoping it's last darn one on this Processor for a bit!
