### PR TITLE
Code signature verification

### DIFF
--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -35,17 +35,17 @@ class CodeSignatureVerifier(DmgMounter):
             "required": True,
             "description":
                 ("File path to an application bundle (.app) or installer package (.pkg or .mpkg). "
-                "Can point to a globbed path inside a .dmg which will be mounted."),
+                 "Can point to a globbed path inside a .dmg which will be mounted."),
         },
         "expected_authority_names": {
             "required": False,
             "description":
-                ("List of expected certificate authority names. Complete list of the certificate "
-                "name chain is required and it needs to be in the correct order. "
-                "These can be found by running: "
-                "\n\t$ codesign -d -vvvv <path_to_app>"
-                "\n\tor"
-                "\n\t$ pkgutil --check-signature <path_to_pkg>"),
+                ("An array of strings defining a list of expected certificate authority names. "
+                 "Complete list of the certificate name chain is required and it needs to be "
+                 "in the correct order. These can be determined by running: "
+                 "\n\t$ codesign -d -vvvv <path_to_app>"
+                 "\n\tor"
+                 "\n\t$ pkgutil --check-signature <path_to_pkg>"),
         },
     }
     output_variables = {


### PR DESCRIPTION
I'd like to start a discussion about verifying downloaded item code signature. This pull request includes a new processor (CodeSignatureVerifier) that verifies app bundle or installer package signatures (with codesign or pkgutil) and optionally verifies certificate name chain.

The processor always verifies the signature by using builtin system tools and raises if this fails. After the verification we can optionally get the certificate name chain and compare that to an expected value. I still haven't decided whether this name check is a good idea or not or if it provides any real security but here's my reasoning so far: I intentionally chose to verify names (instead of hashes etc.) since at this point we already have a properly signed item which is trusted by system. The situation that someone could create certs with the same name chain and get your computer to trust them is really far fetched. But the situation where a download could be intercepted and replaced by another properly signed binary is not. Thoughts?

Example usages in a recipe:

```
<dict>
    <key>Processor</key>
    <string>CodeSignatureVerifier</string>
    <key>Arguments</key>
    <dict>
        <key>input_path</key>
        <string>%RECIPE_CACHE_DIR%/%NAME%/1Password 4.app</string>
    </dict>
</dict>
```

```
<dict>
    <key>Processor</key>
    <string>CodeSignatureVerifier</string>
    <key>Arguments</key>
    <dict>
        <key>input_path</key>
        <string>%RECIPE_CACHE_DIR%/%NAME%/1Password 4.app</string>
        <key>expected_authority_names</key>
        <array>
            <string>Developer ID Application: Agilebits Inc.</string>
            <string>Developer ID Certification Authority</string>
            <string>Apple Root CA</string>
        </array>
    </dict>
</dict>
```

A successful run outputs:

```
CodeSignatureVerifier
CodeSignatureVerifier: Verifying application bundle signature...
CodeSignatureVerifier: ...autopkg-cache/io.github.hjuutilainen.munki.1Password/1Password/1Password 4.app: valid on disk
CodeSignatureVerifier: ...autopkg-cache/io.github.hjuutilainen.munki.1Password/1Password/1Password 4.app: satisfies its Designated Requirement
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
```

A failed run outputs:

```
CodeSignatureVerifier
CodeSignatureVerifier: Verifying application bundle signature...
CodeSignatureVerifier: ...autopkg-cache/io.github.hjuutilainen.munki.Subler/Subler/Subler.app: code object is not signed at all
CodeSignatureVerifier: In architecture: i386
Code signature verification failed
Failed.
Receipt written to ...autopkg-cache/io.github.hjuutilainen.munki.Subler/receipts/Subler.munki-receipt-20140521-092107.plist

The following recipes failed:
    Subler.munki.recipe
        Error in io.github.hjuutilainen.munki.Subler: Processor: CodeSignatureVerifier: Error: Code signature verification failed
```

And a failed name check outputs:

```
CodeSignatureVerifier
CodeSignatureVerifier: Verifying application bundle signature...
CodeSignatureVerifier: ...autopkg-cache/io.github.hjuutilainen.munki.1Password/1Password/1Password 4.app: valid on disk
CodeSignatureVerifier: ...autopkg-cache/io.github.hjuutilainen.munki.1Password/1Password/1Password 4.app: satisfies its Designated Requirement
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Mismatch in authority names
CodeSignatureVerifier: Expected: Developer ID Application: Some random company. -> Developer ID Certification Authority -> Apple Root CA
CodeSignatureVerifier: Found:    Developer ID Application: Agilebits Inc. -> Developer ID Certification Authority -> Apple Root CA
Mismatch in authority names
Failed.
Receipt written to ...autopkg-cache/io.github.hjuutilainen.munki.1Password/receipts/1Password.munki-receipt-20140521-082813.plist

The following recipes failed:
    1Password.munki.recipe
        Error in io.github.hjuutilainen.munki.1Password: Processor: CodeSignatureVerifier: Error: Mismatch in authority names
```
