### PR TITLE
Tweak logging behavior with --report-plist as arg

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1060,12 +1060,6 @@ def run_recipes(argv):
     if options.pkg:
         cli_values["PKG"] = options.pkg
 
-    # so that log() can make use of it
-    global _REPORT_PLIST
-    _REPORT_PLIST = options.report_plist
-    if _REPORT_PLIST:
-        options.verbose = 0
-
     recipe_paths = []
     recipe_paths.extend(arguments)
     if options.recipe_list:


### PR DESCRIPTION
I'm guessing the reason nothing is logged to sys.stdout when autopkg is run with --report-plist is to provide a clean .plist file in that pipe once the run is complete (no extraneous code to strip out).  

I was wondering if you would consider sending progress updates to sys.stderr if it is invoked this way.  I'm contributing to a project that uses the .plist generated, but could also use the progress generated when running normally (without --report-plist) to update the UI.

I understand that it may be semantically inappropriate to pipe stdout to stderr, but it would provide the functionality of offering that information without obstructing the desired final stdout.

If there are concerns please let me know and I may be able to rework in a manner more suitable.
But these two lines of code seemed an elegant solution for my particular needs.

Thanks for your consideration.
