### PR TITLE
Add code to strip alpha characters from front of sparkle:version.

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -20,6 +20,7 @@ import urllib
 import urllib2
 import urlparse
 import os
+import re
 from xml.etree import ElementTree
 
 from autopkglib import Processor, ProcessorError
@@ -190,8 +191,11 @@ class SparkleUpdateInfoProvider(Processor):
     def main(self):
         """Get URL for latest version in update feed"""
         def compare_version(this, that):
+            leadingcharacters = re.compile('^\D+')
+            stripped_this = regexp.sub('', this)
+            stripped_that = regexp.sub('', that)
             """Compare loose versions"""
-            return cmp(LooseVersion(this), LooseVersion(that))
+            return cmp(LooseVersion(stripped_this), LooseVersion(stripped_that))
 
         items = self.get_feed_data(self.env.get("appcast_url"))
         sorted_items = sorted(items,


### PR DESCRIPTION
Some apps use sparkle:versions with leading letters; e.g. "v134".
This change removes leading letters, leaving a version number that
can be correctly parsed and sorted by LooseVersion.

One app with this issue is Skim, the PDF viewer.
