### PR TITLE
Support for verifying signature requirements

### DIFF
--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -93,8 +93,12 @@ class CodeSignatureVerifier(DmgMounter):
 
         process = ["/usr/bin/codesign",
                    "--verify",
-                   "--deep",
                    "--verbose=1"]
+
+        # No --deep option in Snow Leopard
+        darwin_version = os.uname()[2]
+        if not darwin_version.startswith("10."):
+            process.append("--deep")
 
         if test_requirement:
             process.append("-R=%s" % test_requirement)


### PR DESCRIPTION
This pull will add a new 'requirement' input variable to CodeSignatureVerifier which is used for verifying app bundle signature with a custom codesign test requirement.

Requirement should be set to the original designated requirement which can be found by running:

```
$ codesign --display -r- /Applications/Firefox.app
Executable=/Applications/Firefox.app/Contents/MacOS/firefox
designated => identifier "org.mozilla.firefox" and (anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "43AQ936H96")
library => identifier "libobjc.A.dylib" and anchor apple or identifier "libstdc++.6.0.9.dylib" and anchor apple or identifier "libSystem.B.dylib" and anchor apple
```

And a corresponding processor definition in a recipe would be:

```
<dict>
    <key>Processor</key>
    <string>CodeSignatureVerifier</string>
    <key>Arguments</key>
    <dict>
        <key>input_path</key>
        <string>%pathname%/Firefox.app</string>
        <key>requirement</key>
        <string>identifier "org.mozilla.firefox" and (anchor apple generic and certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "43AQ936H96")</string>
    </dict>
</dict>
```

Note that the requirement can be copy/pasted from the codesign output so even though they are complicated, this is a one time operation to add and there's no need for manual modifications. Should be a far more reliable way for verification than using the expected_authority_names.

For most recipes, this works in 10.6 and up (depending on the requirement) but for example from my own recipes, AppCode and LibreOffice show different requirements in SL vs. Mavericks:

10.6:

```
$ codesign --display -r- /Applications/AppCode.app/
Executable=/Applications/AppCode.app/Contents/MacOS/appcode
library => identifier "com.apple.Cocoa" and anchor apple or identifier "com.apple.Foundation" and anchor apple or identifier "libobjc.A" and anchor apple or identifier "libSystem.B" and anchor apple or identifier "libSystem.B" and anchor apple or identifier "com.apple.CoreFoundation" and anchor apple
# designated => identifier "com.jetbrains.AppCode" and anchor apple
```

10.7:

```
$ codesign --display -r- /Applications/AppCode.app/
Executable=/Applications/AppCode.app/Contents/MacOS/appcode
library => identifier "com.apple.Cocoa" and anchor apple or identifier "com.apple.Foundation" and anchor apple or identifier "libobjc.A" and anchor apple or identifier "libSystem.B" and anchor apple or identifier "libSystem.B" and anchor apple or identifier "com.apple.CoreFoundation" and anchor apple
# designated => identifier "com.jetbrains.AppCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"
```

10.9:

```
$ codesign --display -r- /Applications/AppCode.app/
Executable=/Applications/AppCode.app/Contents/MacOS/appcode
library => identifier "com.apple.Cocoa" and anchor apple or identifier "com.apple.Foundation" and anchor apple or identifier "libobjc.A" and anchor apple or identifier "libSystem.B" and anchor apple or identifier "libSystem.B" and anchor apple or identifier "com.apple.CoreFoundation" and anchor apple
# designated => identifier "com.jetbrains.AppCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"
```

I've updated most of my recipes for testing this:
https://github.com/autopkg/hjuutilainen-recipes/tree/download-verification-tests

Thoughts?
