### PR TITLE
Minor CodeSignatureVerifier improvement

### DIFF
--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -92,7 +92,12 @@ class CodeSignatureVerifier(DmgMounter):
         
         process = ["/usr/bin/codesign",
                    "--verify",
-                   "--verbose"]
+                   "--verbose=1"]
+        
+        # No --deep option in Snow Leopard
+        darwin_version = os.uname()[2]
+        if not darwin_version.startswith("10."):
+            process.append("--deep")
         
         if test_requirement:
             process.append("-R=%s" % test_requirement)


### PR DESCRIPTION
This pull request adds the `--deep` option to codesign verification if not running on 10.6.
Documentation by Apple: https://developer.apple.com/library/mac/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG203
