### PR TITLE
Perform deep verification only if running on 10.9.5 or later

### DIFF
--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -20,6 +20,7 @@ import subprocess
 import re
 
 from glob import glob
+from distutils.version import StrictVersion
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 
@@ -94,9 +95,9 @@ class CodeSignatureVerifier(DmgMounter):
                    "--verify",
                    "--verbose=1"]
         
-        # No --deep option in Snow Leopard
+        # Only use --deep option in OS X 10.9.5 or later
         darwin_version = os.uname()[2]
-        if not darwin_version.startswith("10."):
+        if StrictVersion(darwin_version) >= StrictVersion('13.4.0'):
             process.append("--deep")
         
         if test_requirement:
@@ -232,7 +233,7 @@ class CodeSignatureVerifier(DmgMounter):
                 # Check the kernel version to make sure we're running on
                 # Snow Leopard:
                 # Mac OS X 10.6.8 == Darwin Kernel Version 10.8.0
-                if darwin_version.startswith("10."):
+                if StrictVersion(darwin_version) < StrictVersion('11.0'):
                     self.output("Warning: Installer package signature "
                                 "verification not supported on Mac OS X 10.6")
                 else:


### PR DESCRIPTION
And as it turns out, the deep option does not work properly with the requirements check even though it is available on 10.7+ (noticed when testing the recipes PR). This pull request also adds a proper version checking with StrictVersion.
