### PR TITLE
Extend functionality of list-recipe with additional optargs:  --with-identifiers,--with-paths,--show-all,--plist

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -36,7 +36,7 @@ from autopkglib import set_pref, PreferenceError
 from autopkglib import AutoPackagerError, AutoPackager
 from autopkglib import get_processor, processor_names
 from autopkglib import get_autopkg_version, version_equal_or_greater
-from autopkglib import find_recipe_by_identifier, get_identifier
+from autopkglib import find_recipe_by_identifier, get_identifier, get_identifer_from_recipe_file
 
 
 
@@ -143,20 +143,6 @@ def find_recipe(id_or_name, search_dirs):
     or a name'''
     return (find_recipe_by_identifier(id_or_name, search_dirs) or
             find_recipe_by_name(id_or_name, search_dirs))
-
-
-def get_identifier_from_recipe(recipe_file):
-    '''Return the identifier from a recipe file, if it fails for any
-    reason just pass'''
-    try:
-        recipe = FoundationPlist.readPlist(recipe_file)
-        if 'Identifier' in recipe:
-            return recipe['Identifier']
-        elif "IDENTIFIER" in recipe["Input"]:
-            return recipe["Input"]["IDENTIFIER"]
-    except Exception ,e:
-        # do nothing on error
-        pass    
 
 def get_identifier_from_override(override):
     '''Return the identifier from an override, falling back with a
@@ -903,7 +889,10 @@ def list_recipes(argv):
     parser.add_option("-p", "--with-paths", action="store_true",
                       help="Include recipe's path in the list.")
 
-    parser.add_option("-x","--plist", action="store_true",
+    parser.add_option("-a", "--show-all", action="store_true",
+                      help="Show all recipes including ones that are overridden.")
+
+    parser.add_option("--plist", action="store_true",
                       help="Print output in plist format.")
 
     # Parse options
@@ -912,37 +901,8 @@ def list_recipes(argv):
 
     override_dirs = options.override_dirs or get_override_dirs()
     search_dirs = options.search_dirs or get_search_dirs()
+
     recipes = []
-
-    # find all valid overrides first
-    for directory in override_dirs:
-        normalized_dir = os.path.abspath(os.path.expanduser(directory))
-        if not os.path.isdir(normalized_dir):
-            continue
-        for filename in os.listdir(normalized_dir):
-            if filename.endswith(".recipe"):
-                pathname = os.path.join(normalized_dir, filename)
-                if valid_override(pathname):
-                    override = FoundationPlist.readPlist(pathname)
-                    id_or_name = get_identifier_from_override(override)
-                    # find and validate recipe that will be overridden
-                    recipe_path = find_recipe(id_or_name, search_dirs)
-                    if recipe_path and valid_recipe(recipe_path):
-                        # override points to a valid recipe
-                        result = {'name':os.path.splitext(filename)[0]}
-
-                        if options.with_paths:
-                            result['path'] = pathname
-
-                        if options.with_identifiers:
-                            identifier = get_identifier_from_recipe(pathname);
-                            if identifier:
-                                result['identifier'] = identifier
-
-                        if not result in recipes:
-                            recipes.append(result)
-
-
     for directory in search_dirs:
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         if not os.path.isdir(normalized_dir):
@@ -957,44 +917,89 @@ def list_recipes(argv):
             if valid_recipe(match):
                 recipe_name = os.path.basename(match)
                 # get rid of file extension
-                result = {"name":os.path.splitext(recipe_name)[0]}
+                recipe = {"name": os.path.splitext(recipe_name)[0],
+                          "path": match}
 
-                if options.with_paths:
-                    result['path'] = match
+                identifier = get_identifer_from_recipe_file(match);
+                if identifier:
+                    recipe["identifier"] = identifier
 
-                if options.with_identifiers:
-                    identifier = get_identifier_from_recipe(match);
-                    if identifier:
-                        result['identifier'] = identifier
+                if not recipe in recipes:
+                    recipes.append(recipe)
 
-                if not result in recipes:
-                    recipes.append(result)
+    # Find all valid overrides. Use new list here so we don't need to iterate
+    # over these items as they're added if the --show-all option is set.
+    recipe_overrides = []
+    for directory in override_dirs:
+        normalized_dir = os.path.abspath(os.path.expanduser(directory))
+        if not os.path.isdir(normalized_dir):
+            continue
+        for filename in os.listdir(normalized_dir):
+            if filename.endswith(".recipe"):
+                pathname = os.path.join(normalized_dir, filename)
+                if valid_override(pathname):
+                    override = FoundationPlist.readPlist(pathname)
+                    id_or_name = get_identifier_from_override(override)
+                    # find and validate recipe that will be overridden
+                    recipe_path = find_recipe(id_or_name, search_dirs)
+                    if recipe_path and valid_recipe(recipe_path):
+                        # override points to a valid recipe
+
+                        recipe = {"name": os.path.splitext(filename)[0],
+                                  "path": pathname}
+
+                        # determine which identifier to use
+                        if options.show_all:
+                            identifier = get_identifer_from_recipe_file(pathname);
+                        else:
+                            identifier = id_or_name;
+
+                        if identifier:
+                            recipe["identifier"] = get_identifer_from_recipe_file(pathname)
+
+                        # If --show-all is not opted, iterate over the recipe list
+                        # to locate the parent recipe and replace it with the current recipe
+                        if not options.show_all:
+                            for r in recipes:
+                                if r["name"] == recipe["name"] and \
+                                r.get("identifier") == id_or_name:
+                                    recipes.remove(r)
+
+                        recipe_overrides.append(recipe)
+
+    recipes.extend(recipe_overrides)
 
     if options.plist:
         print FoundationPlist.writePlistToString(sorted(recipes,
-                                    key=lambda s: s['name'].lower()))
+                                    key=lambda s: s["name"].lower()))
     else:
         column_spacer = 1
 
         max_name_length = (
             max([len(r["name"]) for r in recipes]) + column_spacer)
+        
         max_identifier_length = (
-            max([len(r.get("identifier") or '') for r in recipes])
-            + column_spacer)
+            max([len(r.get("identifier","")) for r in recipes])
+            + column_spacer) if options.with_identifiers else column_spacer
 
         spacers = (max_name_length, max_identifier_length)
         format_str = "%-{0}s %-{1}s %-20s".format(*spacers)
 
         output = set()
-        for recipe in recipes:
-            # To make display cleaner, switch out a ~ for the users home
-            recipe_path = None
-            if 'path' in recipe:
-                recipe_path = recipe['path'].replace(os.environ['HOME'], '~')
+        user_home = os.environ.get("HOME")
 
-            output.add(format_str % (recipe.get('name'),
-                                     recipe.get('identifier') or '',
-                                     recipe_path or ''))
+        for recipe in recipes:
+            # only display identifier string if enabled
+            identifier = recipe.get("identifier","") if options.with_identifiers else ""
+
+            # To make display cleaner, switch out a ~ for the users home
+            recipe_path = ""
+            if options.with_paths and "path" in recipe and user_home:
+                recipe_path = recipe["path"].replace(user_home, "~")
+
+            output.add(format_str % (recipe.get("name"),
+                                     identifier,
+                                     recipe_path))
 
         print "\n".join(sorted(list(output),key=lambda s: s.lower()))
 


### PR DESCRIPTION
Hey @timsutton,

I put this PR together after thinking about #133.
It extends the `../autopkg/list-recipe` functionality by allowing a `-w | --with-identifiers` optarg

```
$ /usr/local/bin/autopkg list-recipes --with-identifiers

Adium.download                           com.github.autopkg.download.Adium
Adium.munki                              com.github.autopkg.munki.Adium
Adium.pkg                                com.github.autopkg.pkg.Adium
AdobeAIR.pkg                             com.github.autopkg.pkg.AdobeAIR
AdobeAcrobatPro9Update.download          com.github.autopkg.download.AdobeAcrobatPro9Update
AdobeAcrobatPro9Update.munki             com.github.autopkg.munki.AdobeAcrobatPro9Update
AdobeAcrobatProXUpdate.download          com.github.autopkg.download.AdobeAcrobatProXUpdate
...

```

If no identifier is found for a recipe column 2 will be left empty.
Obviously if `-w` is left off, it will continue with current behavior.

I also removed some duplicate code by concatenation the match array for top level and one level down recipes.

Thanks for your consideration.
-- Eldon
