### PR TITLE
Add "find" as alias of "search" in verbs

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1406,6 +1406,9 @@ def main(argv):
     """Main routine"""
     # define our subcommands ('verbs')
     subcommands = {
+        "find": {
+            "function": search_recipes,
+            "help": "Search for recipes on GitHub."},
         "help": {
             "function": display_help,
             "help": "Display this help"},


### PR DESCRIPTION
I keep writing find instead of search, it also makes more sense grammatically.