### PR TITLE
Make run_recipes() except block handle failures more broadly.

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -258,20 +258,20 @@ def load_recipe(name, override_dirs, recipe_dirs, preprocessors=None, postproces
                 log_err('Could not find parent recipe for %s' % name)
         else:
             recipe["RECIPE_PATH"] = recipe_file
-    
+
     if recipe and preprocessors:
         steps = []
         for preprocessor_name in preprocessors:
             steps.append({"Processor": preprocessor_name})
         steps.extend(recipe["Process"])
         recipe["Process"] = steps
-    
+
     if recipe and postprocessors:
         steps = recipe["Process"]
         for postprocessor_name in postprocessors:
             steps.append({"Processor": postprocessor_name})
         recipe["Process"] = steps
-    
+
     return recipe
 
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -27,6 +27,7 @@ import re
 import shutil
 import subprocess
 import time
+import traceback
 import autopkglib.github
 
 from urlparse import urlparse
@@ -1291,6 +1292,7 @@ def run_recipes(argv):
             log_err("Failed.")
             failure["recipe"] = recipe_path
             failure["message"] = unicode(err)
+            failure["traceback"] = traceback.format_exc()
             failures.append(failure)
             autopackager.results.append({'RecipeError': unicode(err).rstrip()})
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -18,7 +18,6 @@
 
 import os
 import sys
-
 import imp
 import FoundationPlist
 import pprint
@@ -286,7 +285,7 @@ class Processor(object):
                 self.env[variable] = flags["default"]
                 self.output("No value supplied for %s, setting default value "
                             "of: %s" % (variable, self.env[variable]),
-                           verbose_level=2)
+                            verbose_level=2)
             # Make sure all required arguments have been supplied.
             if flags.get("required") and (variable not in self.env):
                 raise ProcessorError(
@@ -468,15 +467,15 @@ class AutoPackager(object):
                 print >> sys.stderr, unicode(err)
                 raise AutoPackagerError(
                     "Error in %s: Processor: %s: Error: %s"
-                    %(identifier, step["Processor"], unicode(err)))
+                    % (identifier, step["Processor"], unicode(err)))
 
             output_dict = {}
             for key in processor.output_variables.keys():
                 # Safety workaround for Processors that may output
-                # differently-named output variables than are given in their
-                # output_variables
-                # TODO: develop a generic solution for processors that can
-                #       dynamically set their output_variables
+                # differently-named output variables than are given in
+                # their output_variables
+                # TODO: develop a generic solution for processors that
+                #       can dynamically set their output_variables
                 if processor.env.get(key):
                     output_dict[key] = self.env[key]
             if self.verbose > 1:
@@ -534,17 +533,17 @@ def add_processor(name, processor_object):
 
 #pylint: disable=invalid-name
 def extract_processor_name_with_recipe_identifier(processor_name):
-    '''Returns a tuple of (processor_name, identifier), given a Processor name.
-    This is to handle a processor name that may include a recipe identifier, in
-    the format:
+    '''Returns a tuple of (processor_name, identifier), given a Processor
+    name.  This is to handle a processor name that may include a recipe
+    identifier, in the format:
 
     com.github.autopkg.recipes.somerecipe/ProcessorName
 
     identifier will be None if one was not extracted.'''
     identifier, delim, processor_name = processor_name.partition('/')
     if not delim:
-        # if no '/' was found, the first item in the tuple will be the full
-        # string, the processor name
+        # if no '/' was found, the first item in the tuple will be the
+        # full string, the processor name
         processor_name = identifier
         identifier = None
     return (processor_name, identifier)
@@ -596,8 +595,8 @@ def get_processor(processor_name, recipe=None, env=None):
                     # we've added a Processor, so stop searching
                     break
                 except (ImportError, AttributeError), err:
-                    # if we aren't successful, that might be OK, we're going
-                    # see if the processor was already imported
+                    # if we aren't successful, that might be OK, we're
+                    # going see if the processor was already imported
                     print >> sys.stderr, (
                         "WARNING: %s: %s" % (processor_filename, err))
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -463,7 +463,12 @@ class AutoPackager(object):
 
             try:
                 self.env = processor.process()
-            except ProcessorError as err:
+            except Exception as err:
+                # Well-behaved processors should handle exceptions and
+                # raise ProcessorError. However, we catch Exception
+                # here to ensure that unexpected/unhandled exceptions
+                # from one processor do not prevent execution of
+                # subsequent recipes.
                 print >> sys.stderr, unicode(err)
                 raise AutoPackagerError(
                     "Error in %s: Processor: %s: Error: %s"


### PR DESCRIPTION
# Exception handling during multiple recipe runs
When running a single recipe, a recipe failure is either handled by the individual failing processor and passed up as a ProcessorError and AutoPkg reports a failure, or AutoPkg stops with an exception. Either way, one recipe failed, and you get immediate information about it.

However, when running multiple recipes, an unhandled exception halts AutoPkg execution, rather than continuing with the next recipe. This *should* only be a problem with custom processors, but in practice, and as non standard-library processors (included in recipe repos?) proliferate, those which don't look for exceptions and in-turn raise ```ProcessorError``` have the potential to halt multiple-recipe runs.

This isn't a huge problem, but it does prevent the final reporting from happening. When running a long list of recipes that could take a significant period of time, if one recipe failed, I want to know what *else* happened: which new products were downloaded, uploaded to Munki, etc, as well as the failure.

One could argue that *any* error should halt AutoPkg if it isn't handled. I know that personally I want an individual recipe error to *not* stop execution, but I guess that depends on how severe the consequences would be for different organizations. (I don't see any...)

The wiki could include some information about making sure to wrap failure-prone sections with a try/except that percolates a ProcessorError up, but that seems to be beyond the scope of the standard expectations of an AutoPkg user or recipe-author.

It would be nice if the individual processors all handle this, but in practice, some higher level insurance seems appropriate. 

# CTRL-C Handling
It appears that a lot of the std-lib processors are checking for ```BaseException```, which is the base class for *all* exceptions, including the CTRL-C/```KeyboardInterrupt``` exception. Therefore, during a multiple-recipe ```autopkg run```, some processors will just fail and continue with the next recipe, whereas those without the 
```
except BaseException as e:
	raise ProcessorError()
```
idiom will stop AutoPkg execution. I think it's safe to assume that CTRL-C should make everything stop, no matter what.

If you'd like me to go through stdlib processors and switch them to use ```Exception``` instead of ```BaseException``` to make CTRL-C handling consistent, let me know and I'll update the PR.

