### PR TITLE
Fix munkiimport

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -279,11 +279,11 @@ class MunkiImporter(Processor):
                         matching_indexes = (
                             matching_indexes.intersection(set(match)))
 
-            # if we get here, we may have found matches
-            if matching_indexes:
-                return pkgdb['items'][list(matching_indexes)[0]]
-            else:
-                return None
+        # if we get here, we may have found matches
+        if matching_indexes:
+            return pkgdb['items'][list(matching_indexes)[0]]
+        else:
+            return None
 
         # try to match against install md5checksums
         filelist = [item for item in pkginfo.get('installs', [])


### PR DESCRIPTION
Munkiimport was returning 'duplicate pkg' if the first pkgid was found
in the pkgdb.