### PR TITLE
Make sure output sent from processor is utf-8 encoded.

### DIFF
--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -222,7 +222,7 @@ class Processor(object):
     def output(self, msg, verbose_level=1):
         """Print a message if verbosity is >= verbose_level"""
         if self.env.get('verbose', 0) >= verbose_level:
-            print "%s: %s" % (self.__class__.__name__, msg)
+            print "%s: %s" % (self.__class__.__name__, msg.encode('utf-8'))
 
     def main(self):
         """Stub method"""


### PR DESCRIPTION
This addresses an issue when an eight bit ascii characters is sent to a processors output (like this from JSSImporter)
```
self.output("Category type: '%s'-'%s' already exists "
                            "according to JSS, moving on..." %
                            (category_type, category_name))
```

Here's the report we got...
https://github.com/lindegroup/autopkgr/issues/293

There's an example override on that page which I've tested and was able to reproduce the error. 
Strange thing, like with this issue, for me it doesn't error when run from shell, only when run from AutoPkgr.

This PR simply makes sure the message passed in from a processor is converted to UTF-8.

Thanks.