### PR TITLE
Add `repo-log` and `repo-update --check` features

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -661,11 +661,8 @@ def repo_update(argv):
                      "You may also use 'all' to update all installed recipe "
                      "repos." % ("%prog", verb))
 
-    parser.add_option("--check", action="store_true", default=False,
-                      help=("Check for new commits to the specified recipe repo."))
-
     # Parse arguments
-    options, arguments = parser.parse_args(argv[2:])
+    arguments = parser.parse_args(argv[2:])[1]
     if len(arguments) < 1:
         log_err("Need at least one recipe repo path or URL!")
         return -1
@@ -686,23 +683,9 @@ def repo_update(argv):
                 repo_dirs.append(repo_path)
 
     for repo_dir in repo_dirs:
+        log("Attempting git pull for %s..." % (message, repo_dir))
         try:
-            if options.check:
-                git_rem_sha1 = ['ls-remote', '--heads', 'origin', './.', 'master']
-                git_local_sha1 = ['rev-parse', 'master']
-                rem_sha1 = run_git(git_rem_sha1, git_directory=repo_dir)
-                loc_sha1 = run_git(git_local_sha1, git_directory=repo_dir)
-                if not rem_sha1.split()[0].strip() == loc_sha1.strip():
-                    print 'Repo updates available for %s' % os.path.basename(repo_dir)
-                    print 'To see changes run "%s repo-log --new %s"' % \
-                                (os.path.realpath(sys.argv[0]), repo_dir)
-            else:
-                log("Attempting git pull for %s..." % (message, repo_dir))
-                output = run_git('pull', git_directory=repo_dir)
-                if output:
-                    log(output)
-                else:
-                    log("%s is up-to-date..." % (repo_dir))
+            log(run_git(['pull'], git_directory=repo_dir))
         except GitError, err:
             log_err(err)
 
@@ -721,17 +704,19 @@ def repo_log(argv):
     parser.add_option("--diff", action="store_true", default=False,
                       help=("Include file diffs for commits."))
 
-    parser.add_option("--number", action="store",type="int", default=0,
-                      help="Number of commits to show.")
+    parser.add_option("--last", action="store",type="int", default=0,
+                      help="Show the last X number of commits.")
 
     # Parse arguments
     options, arguments = parser.parse_args(argv[2:])
-
+    
     if len(arguments) < 1:
         log_err("Need at least one recipe repo path or URL!")
         return -1
 
-    if 'all' in arguments:
+    show_all = 'all' in arguments
+
+    if show_all:
         # just get all repos
         recipe_repos = get_pref("RECIPE_REPOS") or {}
         repo_dirs = [key for key in recipe_repos.keys()]
@@ -754,23 +739,30 @@ def repo_log(argv):
         message = "Showing commits for: {0}"
 
 
+    git_command.append('--color')
     if options.diff:
         git_command.append('--patch')
+    elif not show_all:
+        git_command.append('--name-status')
 
-    if options.number > 0:
-        git_command.append('-n%d' % options.number)
+
+    if options.last > 0:
+        git_command.append('-n%d' % options.last)
 
     for repo_dir in repo_dirs:
-        pretty_format = '--pretty=format:%CredChanges (%aD):%n  %Creset%s%n'
-        git_command.append(pretty_format)
+        if show_all:
+            git_command.append('--pretty=format:%Cred%aD:%Creset %s')
+        else:
+            pretty_format = '--pretty=format:%Cred%aD%n%Cblue%P:%Creset%n%Creset%s%n'
+            git_command.append(pretty_format)
         try:
             run_git(['fetch'], git_directory=repo_dir)
             results = run_git(git_command, git_directory=repo_dir)
             if results:
                 log(message.format(repo_dir))
-                log(results)
+                log("%s\n" % results)
             elif options.new:
-                log("%s is up-to-date" % os.path.basename(repo_dir))
+                log("%s is up-to-date\n" % os.path.basename(repo_dir))
         except GitError, err:
             log_err(err)
                      

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -661,8 +661,11 @@ def repo_update(argv):
                      "You may also use 'all' to update all installed recipe "
                      "repos." % ("%prog", verb))
 
+    parser.add_option("--check", action="store_true", default=False,
+                      help=("Check for new commits to the specified recipe repo."))
+
     # Parse arguments
-    arguments = parser.parse_args(argv[2:])[1]
+    options, arguments = parser.parse_args(argv[2:])
     if len(arguments) < 1:
         log_err("Need at least one recipe repo path or URL!")
         return -1
@@ -683,13 +686,94 @@ def repo_update(argv):
                 repo_dirs.append(repo_path)
 
     for repo_dir in repo_dirs:
-        log("Attempting git pull for %s..." % repo_dir)
         try:
-            log(run_git(['pull'], git_directory=repo_dir))
+            if options.check:
+                git_rem_sha1 = ['ls-remote', '--heads', 'origin', './.', 'master']
+                git_local_sha1 = ['rev-parse', 'master']
+                rem_sha1 = run_git(git_rem_sha1, git_directory=repo_dir)
+                loc_sha1 = run_git(git_local_sha1, git_directory=repo_dir)
+                if not rem_sha1.split()[0].strip() == loc_sha1.strip():
+                    print 'Repo updates available for %s' % os.path.basename(repo_dir)
+                    print 'To see changes run "%s repo-log --new %s"' % \
+                                (os.path.realpath(sys.argv[0]), repo_dir)
+            else:
+                log("Attempting git pull for %s..." % (message, repo_dir))
+                output = run_git('pull', git_directory=repo_dir)
+                if output:
+                    log(output)
+                else:
+                    log("%s is up-to-date..." % (repo_dir))
         except GitError, err:
             log_err(err)
 
+def repo_log(argv):
+    '''Update one or more recipe repos'''
+    verb = argv[1]
+    parser = optparse.OptionParser()
+    parser.set_usage("Usage: %s %s recipe_repo_path_or_url [...]\n"
+                     "Show commit history of recipe repos.\n"
+                     "You may also use 'all' to check all installed recipe "
+                     "repos." % ("%prog", verb))
 
+    parser.add_option("--new", action="store_true", default=False,
+                      help=("Show only unmerged commits to the recipe repo."))
+
+    parser.add_option("--diff", action="store_true", default=False,
+                      help=("Include file diffs for commits."))
+
+    parser.add_option("--number", action="store",type="int", default=0,
+                      help="Number of commits to show.")
+
+    # Parse arguments
+    options, arguments = parser.parse_args(argv[2:])
+
+    if len(arguments) < 1:
+        log_err("Need at least one recipe repo path or URL!")
+        return -1
+
+    if 'all' in arguments:
+        # just get all repos
+        recipe_repos = get_pref("RECIPE_REPOS") or {}
+        repo_dirs = [key for key in recipe_repos.keys()]
+    else:
+        repo_dirs = []
+        for path_or_url in arguments:
+            path_or_url = expand_repo_url(path_or_url)
+            repo_path = get_repo_info(path_or_url).get('path')
+            if not repo_path:
+                log_err("ERROR: Can't find an installed repo for %s"
+                        % path_or_url)
+            else:
+                repo_dirs.append(repo_path)
+
+    if options.new:
+        git_command = ['log', 'master..origin/master']
+        message = "Updates available: {0}"
+    else:
+        git_command = ['log', 'master']
+        message = "Showing commits for: {0}"
+
+
+    if options.diff:
+        git_command.append('--patch')
+
+    if options.number > 0:
+        git_command.append('-n%d' % options.number)
+
+    for repo_dir in repo_dirs:
+        pretty_format = '--pretty=format:%CredChanges (%aD):%n  %Creset%s%n'
+        git_command.append(pretty_format)
+        try:
+            run_git(['fetch'], git_directory=repo_dir)
+            results = run_git(git_command, git_directory=repo_dir)
+            if results:
+                log(message.format(repo_dir))
+                log(results)
+            elif options.new:
+                log("%s is up-to-date" % os.path.basename(repo_dir))
+        except GitError, err:
+            log_err(err)
+                     
 def search_recipes(argv):
     '''Search recipes on GitHub'''
     default_user = "autopkg"
@@ -1436,6 +1520,9 @@ def main(argv):
         "repo-update": {
             "function": repo_update,
             "help": "Update one or more recipe repos"},
+        "repo-log": {
+            "function": repo_log,
+            "help": "Show commit history of recipe repos"},
         "run": {
             "function": run_recipes,
             "help": "Run one or more recipes"},


### PR DESCRIPTION
This PR adds the ability to view a simple commit history natively in autopkgr using `repo-log`.

```
$ autopkg repo-log --help
Usage: autopkg repo-log recipe_repo_path_or_url [...]
Show commit history of recipe repos.
You may also use 'all' to check all installed recipe repos.

Options:
  -h, --help       show this help message and exit
  --new            Show only unmerged commits to the recipe repo.
  --diff           Include file diffs for commits.
  --number=NUMBER  Number of commits to show.
```

There are a few issues which need ironed out.

1) **Paging.** Currently this uses `subprocess.Popen` which will spit out everything at once, which for older repos can be quite a lot. If switched to `subprocess.call()` git log paging is preserved, but if running 'all' repos chosen you would need to 'q' out of a git log for each repo. We could set this up to page unless 'all' is selected. Suggestions?

2) **Pretty format.** What I've put together is pretty minimal but I think registers nicely. Feel free to make any change.

3) **repo-update --check** I've added a simple `--check` argument to `repo-update` that compares the SHA-1 of the last commit on the remote server with that of the local repo and informs the user if there are updates available. It's nice in that it doesn't need to do a full `git fetch` to detect changes, but may make more sense for this to be synonymous with `repo-log --new` instead and redirect there.

Let me know if you have any suggestions or recommendations.
Thanks.
