### PR TITLE
Return the version number from SparkleUpdateInfoProvider

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -76,6 +76,12 @@ class SparkleUpdateInfoProvider(Processor):
         "url": {
             "description": "URL for a download.",
         },
+        "version": {
+            "description": ("Version for the download extracted from the feed. "
+                            "This is a human-readable version if the feed has it "
+                            "(e.g., 2.3.4-pre4), and the basic machine-readable "
+                            "version (e.g., 823a) otherwise.")
+        },
         "additional_pkginfo": {
             "description": ("A pkginfo containing additional keys extracted "
                             "from the appcast feed. Currently this is "
@@ -234,6 +240,10 @@ class SparkleUpdateInfoProvider(Processor):
                             "pkginfo." % copied_key)
 
         self.env["url"] = latest["url"]
+        if latest.get("human_version"):
+            self.env["version"] = latest["human_version"]
+        else:
+            self.env["version"] = latest["version"]
         self.output("Found URL %s" % self.env["url"])
         self.env["additional_pkginfo"] = pkginfo
 

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -176,7 +176,7 @@ class SparkleUpdateInfoProvider(Processor):
                     raise ProcessorError(
                         "Can't extract version info from item in feed!")
 
-                human_version = item_elem.find("{%s}shortVersionString")
+                human_version = enclosure.get("{%s}shortVersionString" % xmlns)
                 if human_version is not None:
                     item["human_version"] = human_version
                 min_version = item_elem.find("{%s}minimumSystemVersion" % xmlns)


### PR DESCRIPTION
For my use case, I have to find the version number for the flat pkg contained in a versioned .dmg file linked from an appcast feed. Since the Sparkle provider already extracts the most reasonable version number possible, I'd like to have it available in my recipes. I hope this seems reasonable!