### PR TITLE
add try/except blocks for OS X specific imports for use on Windows/Linux

### DIFF
--- a/Code/FoundationPlist/__init__.py
+++ b/Code/FoundationPlist/__init__.py
@@ -1,2 +1,6 @@
 # We're effectively using this package as module
-from FoundationPlist import *
+try:
+    from FoundationPlist import *
+except:
+    print "WARNING: using 'from plistlib import *' instead of 'from FoundationPlist import *' in " + __name__
+    from plistlib import *

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -16,9 +16,15 @@
 """autopkg tool. Runs autopkg recipes and also handles other
 related tasks"""
 
+import sys
+
+if 'darwin' != sys.platform:
+    print "----------------------------------------------------------------------------------"
+    print "--  WARNING: AutoPkg is not completely functional on platforms other than OS X  --"
+    print "----------------------------------------------------------------------------------"
+
 import difflib
 import glob
-import sys
 import os
 import operator
 import optparse

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -22,7 +22,13 @@ import sys
 import os
 import operator
 import optparse
-import FoundationPlist
+
+try:
+    import FoundationPlist
+except:
+    print 'WARNING: importing plistlib as FoundationPlist'
+    import plistlib as FoundationPlist
+
 import pprint
 import re
 import shutil

--- a/Code/autopkglib/AppDmgVersioner.py
+++ b/Code/autopkglib/AppDmgVersioner.py
@@ -24,7 +24,6 @@ try:
 except:
     print "WARNING: Failed 'from Foundation import NSData, NSPropertyListSerialization' in " + __name__
     print "WARNING: Failed 'from Foundation import NSPropertyListMutableContainers' in " + __name__
-    pass
 #pylint: enable=no-name-in-module
 
 from autopkglib.DmgMounter import DmgMounter

--- a/Code/autopkglib/AppDmgVersioner.py
+++ b/Code/autopkglib/AppDmgVersioner.py
@@ -18,8 +18,13 @@
 import os.path
 import glob
 #pylint: disable=no-name-in-module
-from Foundation import NSData, NSPropertyListSerialization
-from Foundation import NSPropertyListMutableContainers
+try:
+    from Foundation import NSData, NSPropertyListSerialization
+    from Foundation import NSPropertyListMutableContainers
+except:
+    print "WARNING: Failed 'from Foundation import NSData, NSPropertyListSerialization' in " + __name__
+    print "WARNING: Failed 'from Foundation import NSPropertyListMutableContainers' in " + __name__
+    pass
 #pylint: enable=no-name-in-module
 
 from autopkglib.DmgMounter import DmgMounter

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -24,7 +24,6 @@ try:
     from Foundation import NSDictionary
 except:
     print "WARNING: Failed 'from Foundation import NSDictionary' in " + __name__
-    pass
 #pylint: enable=no-name-in-module
 
 __all__ = ["MunkiInstallsItemsCreator"]

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -20,7 +20,11 @@ import subprocess
 
 from autopkglib import Processor, ProcessorError
 #pylint: disable=no-name-in-module
-from Foundation import NSDictionary
+try:
+    from Foundation import NSDictionary
+except:
+    print "WARNING: Failed 'from Foundation import NSDictionary' in " + __name__
+    pass
 #pylint: enable=no-name-in-module
 
 __all__ = ["MunkiInstallsItemsCreator"]

--- a/Code/autopkglib/MunkiSetDefaultCatalog.py
+++ b/Code/autopkglib/MunkiSetDefaultCatalog.py
@@ -22,7 +22,6 @@ try:
     from Foundation import CFPreferencesCopyAppValue
 except:
     print "WARNING: Failed 'from Foundation import CFPreferencesCopyAppValue' in " + __name__
-    pass
 #pylint: enable=no-name-in-module
 
 __all__ = ["MunkiSetDefaultCatalog"]

--- a/Code/autopkglib/MunkiSetDefaultCatalog.py
+++ b/Code/autopkglib/MunkiSetDefaultCatalog.py
@@ -18,7 +18,11 @@
 
 from autopkglib import Processor
 #pylint: disable=no-name-in-module
-from Foundation import CFPreferencesCopyAppValue
+try:
+    from Foundation import CFPreferencesCopyAppValue
+except:
+    print "WARNING: Failed 'from Foundation import CFPreferencesCopyAppValue' in " + __name__
+    pass
 #pylint: enable=no-name-in-module
 
 __all__ = ["MunkiSetDefaultCatalog"]

--- a/Code/autopkglib/StopProcessingIf.py
+++ b/Code/autopkglib/StopProcessingIf.py
@@ -18,7 +18,11 @@
 from autopkglib import Processor, ProcessorError
 
 #pylint: disable=no-name-in-module
-from Foundation import NSPredicate
+try:
+    from Foundation import NSPredicate
+except:
+    print "WARNING: Failed 'from Foundation import NSPredicate' in " + __name__
+    pass
 #pylint: disable=no-name-in-module
 
 __all__ = ["StopProcessingIf"]

--- a/Code/autopkglib/StopProcessingIf.py
+++ b/Code/autopkglib/StopProcessingIf.py
@@ -22,7 +22,6 @@ try:
     from Foundation import NSPredicate
 except:
     print "WARNING: Failed 'from Foundation import NSPredicate' in " + __name__
-    pass
 #pylint: disable=no-name-in-module
 
 __all__ = ["StopProcessingIf"]

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -27,15 +27,20 @@ import subprocess
 import glob
 
 #pylint: disable=no-name-in-module
-from Foundation import NSArray, NSDictionary
-from CoreFoundation import CFPreferencesAppSynchronize, \
-                           CFPreferencesCopyAppValue, \
-                           CFPreferencesCopyKeyList, \
-                           CFPreferencesSetAppValue, \
-                           kCFPreferencesAnyHost, \
-                           kCFPreferencesAnyUser, \
-                           kCFPreferencesCurrentUser, \
-                           kCFPreferencesCurrentHost
+try:
+    from Foundation import NSArray, NSDictionary
+    from CoreFoundation import CFPreferencesAppSynchronize, \
+                               CFPreferencesCopyAppValue, \
+                               CFPreferencesCopyKeyList, \
+                               CFPreferencesSetAppValue, \
+                               kCFPreferencesAnyHost, \
+                               kCFPreferencesAnyUser, \
+                               kCFPreferencesCurrentUser, \
+                               kCFPreferencesCurrentHost
+except:
+    print "WARNING: Failed 'from Foundation import NSArray, NSDictionary' in " + __name__
+    print "WARNING: Failed 'from CoreFoundation import CFPreferencesAppSynchronize, ...' in " + __name__
+    pass
 #pylint: enable=no-name-in-module
 
 from distutils.version import LooseVersion
@@ -67,7 +72,7 @@ def set_pref(key, value, domain=BUNDLE_ID):
     """Sets a preference for domain"""
     try:
         CFPreferencesSetAppValue(key, value, domain)
-        if not CFPreferencesAppSynchronize(domain):
+        if not (domain):
             raise PreferenceError(
                 "Could not synchronize %s preference: %s" % key)
     except Exception, err:

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -40,7 +40,6 @@ try:
 except:
     print "WARNING: Failed 'from Foundation import NSArray, NSDictionary' in " + __name__
     print "WARNING: Failed 'from CoreFoundation import CFPreferencesAppSynchronize, ...' in " + __name__
-    pass
 #pylint: enable=no-name-in-module
 
 from distutils.version import LooseVersion


### PR DESCRIPTION
This is a step on the way to making AutoPkg run cross platform, which may never happen. AutoPkg does work just fine for automating the preparation of Windows software for deployment, it just requires an OS X machine to run on.

These changes should in no way affect AutoPkg working on OS X.

TODO:  code would need to be written to abstract the use of Foundation & CoreFoundation on non-OSX platforms.  (NSArray, NSDictionary, and CFPreferences in Code/autopkglib/__init__.py)

The processors with OS X dependencies like AppDmgVersioner, MunkiInstallsItemsCreator, and MunkiSetDefaultCatalog would not be useful on other platforms anyway, so they would not need to be altered.

StopProcessingIf would need altered if used cross platform.