### PR TITLE
Added support for launchd 2.0 socket retrieval.

### DIFF
--- a/Code/autopkgserver/autopkgserver
+++ b/Code/autopkgserver/autopkgserver
@@ -82,9 +82,9 @@ import socket
 import plistlib
 import re
 import struct
+import platform
 
 from packager import Packager, PackagerError
-import launch
 
 
 ###############
@@ -365,20 +365,35 @@ def main(argv):
     start_time = time.time()
 
     # Get socket file descriptors from launchd.
-    try:
-        sockets = launch.get_launchd_socket_fds()
-    except launch.LaunchDCheckInError as e:
-        print >>sys.stderr, "launchd check-in failed: %s" % e
-        time.sleep(10)
-        return 1
-
-    if not "AutoPkgServer" in sockets:
-        print >>sys.stderr, "No AutoPkgServer in launchd sockets"
-        time.sleep(10)
-        return 1
+    if int(platform.mac_ver()[0].split(u".")[1]) >= 10:
+        import launch2
+        try:
+            sockets = launch2.launch_activate_socket("AutoPkgServer")
+        except launch2.LaunchDError as e:
+            print >>sys.stderr, "launchd check-in failed: %s" % e
+            time.sleep(10)
+            return 1
+        
+        sock_fd = sockets[0]
+    
+    else:
+        import launch
+        try:
+            sockets = launch.get_launchd_socket_fds()
+        except launch.LaunchDCheckInError as e:
+            print >>sys.stderr, "launchd check-in failed: %s" % e
+            time.sleep(10)
+            return 1
+        
+        if not "AutoPkgServer" in sockets:
+            print >>sys.stderr, "No AutoPkgServer in launchd sockets"
+            time.sleep(10)
+            return 1
+        
+        sock_fd = sockets["AutoPkgServer"][0]
 
     # Create the server object.
-    server = AutoPkgServer(sockets["AutoPkgServer"][0], PkgHandler)
+    server = AutoPkgServer(sock_fd, PkgHandler)
     server.setup_logging()
 
     # Wrap main loop in try/finally to unlink the socket when we exit.

--- a/Code/autopkgserver/launch.py
+++ b/Code/autopkgserver/launch.py
@@ -202,7 +202,7 @@ class LaunchDCheckInError(Exception):
 def get_launchd_socket_fds():
     """Check in with launchd to get socket file descriptors."""
 
-    # Returna dictionary with lists of file descriptors.
+    # Return a dictionary with keys pointing to lists of file descriptors.
     launchd_socket_fds = dict()
 
     # Callback for dict iterator.

--- a/Code/autopkgserver/launch2.py
+++ b/Code/autopkgserver/launch2.py
@@ -1,0 +1,46 @@
+#
+# Copyright 2015 Per Olofsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from ctypes import *
+libc = CDLL("libc.dylib")
+
+
+# int launch_activate_socket(const char *name, int **fds, size_t *cnt)
+libc.launch_activate_socket.restype = c_int
+libc.launch_activate_socket.argtypes = [c_char_p, POINTER(POINTER(c_int)), POINTER(c_size_t)]
+
+
+class LaunchDError(Exception):
+    pass
+
+def launch_activate_socket(name):
+    """Retrieve named socket file descriptors from launchd."""
+
+    # Wrap in try/finally to free resources allocated during lookup.
+    try:
+        fds = POINTER(c_int)()
+        cnt = c_size_t(0)
+        err = libc.launch_activate_socket(name, byref(fds), byref(cnt))
+        if err:
+            raise LaunchDError("Failed to retrieve sockets from launchd: %s" % os.strerror(err))
+        
+        # Return a lists of file descriptors.
+        return list(fds[x] for x in xrange(cnt.value))
+
+    finally:
+        if fds:
+            libc.free(fds)


### PR DESCRIPTION
The API used by Code/autopkgserver/launch.py were deprecated in 10.10 and a much simpler one was added (see man 3 launch). I added launch2.py using the new API and a version check in autopkgserver to call the correct one.

I don't have a 10.9 machine set up for regression testing so I've only tested the new codepath for 10.10.