### PR TITLE
Removing trailing period from make-override path output

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1270,7 +1270,7 @@ def make_override(argv):
         return -1
     else:
         FoundationPlist.writePlist(override_plist, override_file)
-        log("Override file saved to %s." % override_file)
+        log("Override file saved to %s" % override_file)
         return 0
 
 


### PR DESCRIPTION
Currently there is a trailing period in the output of the 'make-override' command that makes it a pain to quickly copy and paste the path from the output.

Example: http://i.imgur.com/XwMh3kD.gifv

This PR removes that trailing period to making copying and pasting this path easier; especially when making multiple override files back to back for a new setup.