### PR TITLE
Use GitHub's settings/tokens path rather than settings/applications.

### DIFF
--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -59,7 +59,7 @@ account in order to create an API token. This token has only
 a 'public' scope, meaning it cannot be used to retrieve
 personal information from your account, or push to any repos
 you may have access to. You can verify this token within your
-profile page at https://github.com/settings/applications and
+profile page at https://github.com/settings/tokens and
 revoke it at any time. This token will be stored in your user's
 home folder at %s.""" % TOKEN_LOCATION
             username = raw_input("Username: ")


### PR DESCRIPTION
I just noticed that when I crated an API token using `autopkg search -t ...` it listed the `AutoPkg CLI` token at https://github.com/settings/tokens but was not showing up at https://github.com/settings/applications. This simply updates the info string.