### PR TITLE
Copier processor: also copy mode bits from file

### DIFF
--- a/Code/autopkglib/Copier.py
+++ b/Code/autopkglib/Copier.py
@@ -73,6 +73,7 @@ class Copier(DmgMounter):
                 shutil.copytree(source_item, dest_item, symlinks=True)
             elif not os.path.isdir(dest_item):
                 shutil.copyfile(source_item, dest_item)
+                shutil.copymode(source_item, dest_item)
             else:
                 shutil.copy(source_item, dest_item)
             self.output("Copied %s to %s" % (source_item, dest_item))


### PR DESCRIPTION
Copy mode bits for a file that is copied with the Copier process. Note the `shutil.copy` copies the mode, as does `shutil.copytree`. To consider changing the code block to be simpler and just use `copy()` for anything not a directory.
