### PR TITLE
SparkleUpdateInfoProvider: Raise ProcessorError if channel items list empty

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -144,10 +144,8 @@ class SparkleUpdateInfoProvider(Processor):
         except:
             raise ProcessorError("Error parsing XML from appcast feed.")
 
-        try:
-            items = xmldata.findall("channel/item")
-            assert len(items) > 0
-        except:
+        items = xmldata.findall("channel/item")
+        if not items:
             raise ProcessorError("No channel items were found in appcast feed.")
 
         versions = []

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -144,7 +144,11 @@ class SparkleUpdateInfoProvider(Processor):
         except:
             raise ProcessorError("Error parsing XML from appcast feed.")
 
-        items = xmldata.findall("channel/item")
+        try:
+            items = xmldata.findall("channel/item")
+            assert len(items) > 0
+        except:
+            raise ProcessorError("No channel items were found in appcast feed.")
 
         versions = []
         for item_elem in items:


### PR DESCRIPTION
* `get_feed_data()` did not check that any `channel/item` items were
actually found/returned, which would lead to an `IndexError` in `main()`.
* Discovered when running for  'com.github.jps3.download.fseventer’
which is returning `200 OK` for a `text/html` document (contents of
which simply state that site is temporarily offline). Hence the Processor
would chug along without a care in the world.