### PR TITLE
MunkiImporter empty extension fix

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -377,17 +377,17 @@ class MunkiImporter(Processor):
                 raise ProcessorError("Could not create %s: %s"
                                      % (destination_path, err.strerror))
 
-        extension = "plist"
-        if self.env.get("MUNKI_PKGINFO_FILE_EXTENSION"):
-            extension = self.env["MUNKI_PKGINFO_FILE_EXTENSION"].strip(".")
-        pkginfo_name = "%s-%s.%s" % (pkginfo["name"],
+        extension = self.env.get("MUNKI_PKGINFO_FILE_EXTENSION", "plist")
+        if len(extension) > 0:
+            extension = '.' + extension.strip(".")
+        pkginfo_name = "%s-%s%s" % (pkginfo["name"],
                                      pkginfo["version"].strip(),
                                      extension)
         pkginfo_path = os.path.join(destination_path, pkginfo_name)
         index = 0
         while os.path.exists(pkginfo_path):
             index += 1
-            pkginfo_name = "%s-%s__%s.%s" % (
+            pkginfo_name = "%s-%s__%s%s" % (
                 pkginfo["name"], pkginfo["version"], index, extension)
             pkginfo_path = os.path.join(destination_path, pkginfo_name)
 


### PR DESCRIPTION
Empty pkginfo extension is supported by munkiimport but autopkg doesn't handle it well. This fix took munkiimport's original codes as reference and has been working for me for a year.