### PR TITLE
Removed trailing colon from URL in error messages.

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -242,7 +242,7 @@ class URLDownloader(Processor):
 
         except BaseException as err:
             raise ProcessorError(
-                "Couldn't download %s: %s" % (self.env["url"], err))
+                "Couldn't download %s (%s)" % (self.env["url"], err))
         finally:
             if url_handle is not None:
                 url_handle.close()


### PR DESCRIPTION
This will allow tools that email AutoPkg error output (like AutoPkgr) to produce clickable URLs. Current behavior causes a trailing colon to render the URL unusable.

![screen shot 2015-08-14 at 9 20 38 am](https://cloud.githubusercontent.com/assets/7801391/9279059/b3e5b97e-4269-11e5-9b18-5d73039a59c0.png)

This change will remove the trailing colon from the URL, and surround the error message with parentheses to call it out.