### PR TITLE
MunkiImporter: Try to match bundle types as well as application types…

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -232,7 +232,7 @@ class MunkiImporter(Processor):
 
         # try to match against installed applications
         applist = [item for item in pkginfo.get('installs', [])
-                   if item.get('type') == 'application' and 'path' in item]
+                   if item.get('type') in ('application', 'bundle') and 'path' in item]
         if applist:
             matching_indexes = []
             for app in applist:


### PR DESCRIPTION
Currently MunkiImporter only looks for applications when trying to match the `installs` keys with previous versions. This PR allows it to also check `bundle` types. Came up in autopkg/jessepeterson-recipes#17