### PR TITLE
PkgCreator path joining

### DIFF
--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -358,7 +358,11 @@ class Packager(object):
                      str(entry.user),
                      str(entry.group)))
 
-            chownpath = os.path.join(self.tmp_pkgroot, entry.path)
+            if entry.path.startswith('/'):
+                chownpath = os.path.join(self.tmp_pkgroot,
+                    entry.path.lstrip('/'))
+            else:
+                chownpath = os.path.join(self.tmp_pkgroot, entry.path)
             if "mode" in entry.keys():
                 chmod_present = True
             else:

--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -358,11 +358,10 @@ class Packager(object):
                      str(entry.user),
                      str(entry.group)))
 
-            if entry.path.startswith('/'):
-                chownpath = os.path.join(self.tmp_pkgroot,
-                    entry.path.lstrip('/'))
-            else:
-                chownpath = os.path.join(self.tmp_pkgroot, entry.path)
+            # If an absolute path is passed in entry.path, os.path.join
+            # will not join it to the tmp_pkgroot. We need to strip out
+            # the leading / to make sure we only touch the pkgroot.
+            chownpath = os.path.join(self.tmp_pkgroot, entry.path.lstrip('/'))
             if "mode" in entry.keys():
                 chmod_present = True
             else:


### PR DESCRIPTION
Initial fix for allowing PkgCreator to handle absolute paths in a chown dict.  Currently if an absolute path is provided, autopkgserver will attempt to change owner, group, and mode on that absolute path.  It should always only ever touch things within the pkgroot.