### PR TITLE
Move traceback capturing to autopkglib/__init__.py. Update output.

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -40,7 +40,6 @@ import re
 import shutil
 import subprocess
 import time
-import traceback
 import autopkglib.github
 
 from urlparse import urlparse
@@ -1465,7 +1464,7 @@ def run_recipes(argv):
             log_err("Failed.")
             failure["recipe"] = recipe_path
             failure["message"] = unicode(err)
-            failure["traceback"] = traceback.format_exc()
+            failure["traceback"] = err.traceback
             failures.append(failure)
             autopackager.results.append({'RecipeError': unicode(err).rstrip()})
 
@@ -1530,8 +1529,12 @@ def run_recipes(argv):
     if failures:
         log("\nThe following recipes failed:")
         for item in failures:
-            log("    %s" % item["recipe"])
-            log("        %s" % item["message"])
+            log("\n" + 4 * " " + item["recipe"])
+            for line in item["message"].splitlines():
+                log(8 * " " + line)
+            if options.verbose > 1:
+                for line in item["traceback"].splitlines():
+                    log(8 * " " + line)
 
     if summary_results:
         for key, value in summary_results.items():

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -24,6 +24,7 @@ import pprint
 import re
 import subprocess
 import glob
+import traceback
 
 #pylint: disable=no-name-in-module
 try:
@@ -474,9 +475,11 @@ class AutoPackager(object):
                 # from one processor do not prevent execution of
                 # subsequent recipes.
                 print >> sys.stderr, unicode(err)
-                raise AutoPackagerError(
-                    "Error in %s: Processor: %s: Error: %s"
+                error = AutoPackagerError(
+                    "Recipe Identifier: %s\nProcessor: %s\nError: %s"
                     % (identifier, step["Processor"], unicode(err)))
+                error.__setattr__("traceback", traceback.format_exc())
+                raise error
 
             output_dict = {}
             for key in processor.output_variables.keys():


### PR DESCRIPTION
- Get the traceback from autopkglib/**init**.py.
  - The traceback captured by `traceback.format_exc`, in autopkg is
    not the traceback we're interested in seeing.
- Add printing of the traceback if the verbose level is greater than 1.
- Reformat failure printing to be slightly easier to read (break into
  multiple lines of data).
