### PR TITLE
Use a temporary file in CURLDownloader

### DIFF
--- a/Code/autopkglib/CURLDownloader.py
+++ b/Code/autopkglib/CURLDownloader.py
@@ -154,6 +154,10 @@ class CURLDownloader(Processor):
             for header, value in headers.items():
                 curl_cmd.extend(['--header', '%s: %s' % (header, value)])
 
+        # if file already exists and the size is 0, discard it and download again
+        if os.path.exists(pathname) and os.path.getsize(pathname) == 0:
+            os.remove(pathname)
+
         # if file already exists, add some headers to the request
         # so we don't retrieve the content if it hasn't changed
         if os.path.exists(pathname):

--- a/Code/autopkglib/CURLDownloader.py
+++ b/Code/autopkglib/CURLDownloader.py
@@ -239,7 +239,9 @@ class CURLDownloader(Processor):
         # to the pathname
         if os.path.exists(pathname):
             os.remove(pathname)
-        if not os.rename(pathname_temporary, pathname):
+        try:
+            os.rename(pathname_temporary, pathname)
+        except OSError:
             raise ProcessorError(
                     "Can't move %s to %s" % (pathname_temporary, pathname))
 


### PR DESCRIPTION
I decided to go with using a temporary file and move it in place if the processor downloaded something new. This imports the tempfile module.