### PR TITLE
Switch to fetch and reset for repo-update

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -771,9 +771,10 @@ def repo_update(argv):
                 repo_dirs.append(repo_path)
 
     for repo_dir in repo_dirs:
-        log("Attempting git pull for %s..." % repo_dir)
+        log("Attempting git fetch and update for %s..." % repo_dir)
         try:
-            log(run_git(['pull'], git_directory=repo_dir))
+            log(run_git(['fetch', '--all'], git_directory=repo_dir))
+            log(run_git(['reset', '--hard', 'origin/HEAD'], git_directory=repo_dir))
         except GitError, err:
             log_err(err)
 


### PR DESCRIPTION
This changes the `autopkg repo-update` command to use `git fetch` and `git reset` instead of `git pull`. It slightly changes the behavior, but will make it seamless if a repo is force updated.  It is also the behavior that most would expect from `git pull` if they have never had conflicts.
