### PR TITLE
Add kext codesignatureVerification

### DIFF
--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -254,7 +254,7 @@ class CodeSignatureVerifier(DmgMounter):
 
             # Currently we support only .app, .pkg, .mpkg or .xip types
             file_extension = os.path.splitext(matched_input_path)[1]
-            if file_extension == ".app":
+            if file_extension in [".kext", ".app"]:
                 self.process_app_bundle(matched_input_path)
             elif file_extension in [".pkg", ".mpkg", ".xip"]:
                 # Check the kernel version to make sure we're running on


### PR DESCRIPTION
Currently the CodeSigVerifier processor only allows app bundles to have the code signature checked. This expands file types to allow signed kexts to be checked as well.