### PR TITLE
Improved PkgCopier default pkg_path

### DIFF
--- a/Code/autopkglib/PkgCopier.py
+++ b/Code/autopkglib/PkgCopier.py
@@ -87,7 +87,7 @@ class PkgCopier(Copier):
             # do the copy
             pkg_path = (self.env.get("pkg_path") or
                         os.path.join(self.env['RECIPE_CACHE_DIR'],
-                                     os.path.basename(source_pkg)))
+                                     os.path.basename(matched_source_path)))
             self.copy(matched_source_path, pkg_path, overwrite=True)
             self.env["pkg_path"] = pkg_path
             self.env["pkg_copier_summary_result"] = {


### PR DESCRIPTION
Currently if a glob character is used (like *.pkg) and a default pkg_path isn't defined, then the pkg_path will be "*.pkg".

This change switches the default from source_pkg to matched_source_path.  This way if glob character are used the pkg_path will use the actual file name that was matched and not the glob pattern.
