### PR TITLE
URLDownloader: add check of HTTP Status code

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -22,6 +22,9 @@ import time
 import xattr
 import tempfile
 
+from types import StringType
+from string import atoi
+
 from autopkglib import Processor, ProcessorError
 try:
     from autopkglib import BUNDLE_ID
@@ -91,6 +94,11 @@ class URLDownloader(Processor):
             "required": False,
             "default": "/usr/bin/curl",
             "description": "Path to curl binary. Defaults to /usr/bin/curl.",
+        },
+        "HTTP_FAILURE_CODE_MIN": {
+            "default": 400,
+            "required": False,
+            "description": ("If the HTTP Status code is larger than or equal to this value, consider the download to be failed") 
         },
     }
     output_variables = {
@@ -253,6 +261,21 @@ class URLDownloader(Processor):
                 # http_result_code is likely blank/000. Read it from stderr.
                 if re.search(r'URL returned error: [0-9]+$', curlerr):
                     header['http_result_code'] = curlerr[curlerr.rfind(' ')+1:]
+
+        # Attempt to fail if there is a bad HTTP Status code.
+        # Sometimes, curl successfully exits, having not downloaded
+        # anything useful (e.g. we received a 404 message code, but 
+        # got some HTML, but this is flagged as success)
+        self.output( '%s has HTTP Status code %s' % ( self.env['url'], header['http_result_code'] ), verbose_level = 3 )
+        if self.env['HTTP_FAILURE_CODE_MIN']:
+            failure_min = self.env['HTTP_FAILURE_CODE_MIN']
+            http_status = header['http_result_code']
+            if type(failure_min) == StringType:
+                failure_min = atoi(failure_min)
+            if type(http_status) == StringType:
+                http_status = atoi(http_status)
+            if http_status >= failure_min:
+                raise ProcessorError( "Failed to download %s due to HTTP Status code %d being larger than %d" % (self.env['url'], http_status, failure_min)  )
 
         # If Content-Length header is present and we had a cached
         # file, see if it matches the size of the cached file.

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -22,7 +22,7 @@ import time
 import xattr
 import tempfile
 
-from types import StringType
+from types import IntType
 from string import atoi
 
 from autopkglib import Processor, ProcessorError
@@ -270,9 +270,9 @@ class URLDownloader(Processor):
         if self.env['HTTP_FAILURE_CODE_MIN']:
             failure_min = self.env['HTTP_FAILURE_CODE_MIN']
             http_status = header['http_result_code']
-            if type(failure_min) == StringType:
+            if type(failure_min) != IntType:
                 failure_min = atoi(failure_min)
-            if type(http_status) == StringType:
+            if type(http_status) != IntType:
                 http_status = atoi(http_status)
             if http_status >= failure_min:
                 raise ProcessorError( "Failed to download %s due to HTTP Status code %d being larger than %d" % (self.env['url'], http_status, failure_min)  )


### PR DESCRIPTION

Add a check of the HTTP Status code returned via curl; this is to cope
with the situations the status code is being set as 404 but some HTML
is being downloaded, which is incorrectly being interpreted as the
package content.

This check is implemented as a minimum acceptable status code
defaulting to 400; this can be changed by an option to the processor
if there are other options about what a HTTP Status code error is.

As a motivating example, we are currently seeing problems downloading
the with the ATLAS.ti package, but these are not failing on the
package download, but the signature check:

```
hostname:~ autopkg$ autopkg version
0.6.1
hostname:~ autopkg$ autopkg run ATLAS.ti.download.recipe 
Processing ATLAS.ti.download.recipe...
SparkleUpdateInfoProvider
SparkleUpdateInfoProvider: Version retrieved from appcast: 208
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.0.46
SparkleUpdateInfoProvider: Found URL http://update.atlasti.com/spk/mac/10_8_5/ATLAS.ti.app.zip
URLDownloader
URLDownloader: Downloaded <snip full path>/downloads/ATLAS.ti.app.zip
EndOfCheckPhase
CodeSignatureVerifier
Error processing path '<snip full path>/downloads/ATLAS.ti.app.zip/ATLAS.ti.app'
with glob. 
Failed.
Receipt written to
/<snip full path>/receipts/ATLAS.ti.download-receipt-20160422-112158.plist

The following recipes failed:
    ATLAS.ti.download.recipe
        Error in io.github.hjuutilainen.download.ATLAS.ti: Processor: CodeSignatureVerifier: Error: Error processing path '/<snip full path>/downloads/ATLAS.ti.app.zip/ATLAS.ti.app' with glob. 

The following new items were downloaded:
    Download Path                                       
            
    -------------
/<snip full path>/downloads/ATLAS.ti.app.zip
```

However, using CURL directly, we see:

```
hostname:~ autopkg$ curl --silent  --dump-header - -o /tmp/atlas-download http://update.atlasti.com/spk/mac/10_8_5/ATLAS.ti.app.zip; echo "Exit status: $?"
HTTP/1.1 404 Not Found
Date: Fri, 22 Apr 2016 10:27:29 GMT
Server: Apache
Content-Length: 1363
X-Frame-Options: deny
Content-Type: text/html

Exit status: 0
hostname:~ autopkg$  file /tmp/atlas-download 
/tmp/atlas-download: HTML document text
```

As an aside: an alternative approach, which may have been used in the
past from the code, would be to pass the --fail option to curl. 
