### PR TITLE
Fixed SparkleUpdateInfoProvider ignoring appcast_request_headers

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -152,7 +152,7 @@ class SparkleUpdateInfoProvider(Processor):
             scheme, netloc, path, _, frag = urlparse.urlsplit(url)
             url = urlparse.urlunsplit((scheme, netloc, path, new_query, frag))
 
-        data = self.fetch_content(url, self.env.get("appcast_query_pairs"))
+        data = self.fetch_content(url, headers=self.env.get("appcast_request_headers"))
         try:
             xmldata = ElementTree.fromstring(data)
         except:


### PR DESCRIPTION
* It would appear that the recent change from using urllib to curl
introduced a subtle bug wherein the SparkleUpdateInfoProvider processor
was effectively ignoring `appcast_request_headers`.
* The fix: within the `get_feed_data()` function, the line calling
`self.fetch_content()` was giving `appcast_query_pairs` as the second
argument (which `get_feed_data()` took as its `headers=` argument).
Since `appcast_query_pairs` are url encoded in the code block
immediately before this call, all that’s missing was to remove the
extraneous argument with a corrected `headers=` one.