### PR TITLE
Allow for Less Strict "legal" Package Names.

### DIFF
--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -41,7 +41,7 @@ class Packager(object):
 
     Must be run as root."""
 
-    re_pkgname = re.compile(r'^[a-z0-9][a-z0-9 ._\+\-]*$', re.I)
+    re_pkgname = re.compile(r'^[a-z0-9][a-z0-9 ._\+\@\-]*$', re.I)
     re_id      = re.compile(r'^[a-z0-9]([a-z0-9 \-]*[a-z0-9])?$', re.I)
     re_version = re.compile(r'^[a-z0-9_ ]*[0-9][a-z0-9_ ]*$', re.I)
 

--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -41,7 +41,7 @@ class Packager(object):
 
     Must be run as root."""
 
-    re_pkgname = re.compile(r'^[a-z0-9][a-z0-9 ._\-]*$', re.I)
+    re_pkgname = re.compile(r'^[a-z0-9][a-z0-9 ._\+\-]*$', re.I)
     re_id      = re.compile(r'^[a-z0-9]([a-z0-9 \-]*[a-z0-9])?$', re.I)
     re_version = re.compile(r'^[a-z0-9_ ]*[0-9][a-z0-9_ ]*$', re.I)
 


### PR DESCRIPTION
Updated the re_pkgname regex to allow for a + sign in the package name.
This change will allow your name to contain a + sign when creating a
app.pkg.recipe without throwing an invalid package name error.
