### PR TITLE
Fix class name in docstring

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""See docstring for SparkleUpdateProvider class"""
+"""See docstring for SparkleUpdateInfoProvider class"""
 
 import urllib
 import urlparse


### PR DESCRIPTION
FWIW, I accidentally type "SparkleUpdateProvider" constantly.
