### PR TITLE
Removing temporary file when CHECK_FILESIZE_ONLY is true and download_changed is false

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -266,6 +266,10 @@ class URLDownloader(Processor):
                             "fallback mechanism that does not guarantee "
                             "that a build is unchanged.")
                 self.output("Using existing %s" % pathname)
+
+                # Discard the temp file
+                os.remove(pathname_temporary)
+
                 return
 
         if header['http_result_code'] == '304':


### PR DESCRIPTION
I think this explains why foigus was seeing this issue https://groups.google.com/forum/#!topic/autopkg-discuss/z7_jMuioOJU/discussion and hopefully fixes it.
