### PR TITLE
Timeout addition for curl

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -68,6 +68,10 @@ class URLDownloader(Processor):
             "required": False,
             "description": "Filename to override the URL's tail.",
         },
+        "timeout_seconds": {
+        	"required": False,
+        	"description": "Sets curl to timeout if it can't make a connection in supplied seconds",
+        },
         "CHECK_FILESIZE_ONLY": {
             "default": False,
             "required": False,
@@ -172,6 +176,9 @@ class URLDownloader(Processor):
             for header, value in headers.items():
                 curl_cmd.extend(['--header', '%s: %s' % (header, value)])
 
+		if "timeout_seconds" in self.env:
+			curl_cmd.extend(['--connect-timeout', '%s' % timeout_seconds.itmes()])
+		
         # if file already exists and the size is 0, discard it and download
         # again
         if os.path.exists(pathname) and os.path.getsize(pathname) == 0:

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -68,9 +68,9 @@ class URLDownloader(Processor):
             "required": False,
             "description": "Filename to override the URL's tail.",
         },
-        "timeout_seconds": {
-        	"required": False,
-        	"description": "Sets curl to timeout if it can't make a connection in supplied seconds",
+		"timeout_seconds": {
+			"required": False,
+			"description": "Sets curl to timeout if it can't make a connection in supplied seconds",
         },
         "CHECK_FILESIZE_ONLY": {
             "default": False,
@@ -179,7 +179,7 @@ class URLDownloader(Processor):
         if "timeout_seconds" in self.env:
             seconds = self.env["timeout_seconds"]
             curl_cmd.extend(['--connect-timeout', '%s' % seconds])
-		
+
         # if file already exists and the size is 0, discard it and download
         # again
         if os.path.exists(pathname) and os.path.getsize(pathname) == 0:

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -168,7 +168,7 @@ class URLDownloader(Processor):
                     '--dump-header', '-',
                     '--speed-time', '30',
                     '--location',
-                    '--connect-timeout', '2',
+                    '--connect-timeout', '10',
                     '--url', self.env["url"],
                     '--output', pathname_temporary]
 

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -168,6 +168,7 @@ class URLDownloader(Processor):
                     '--dump-header', '-',
                     '--speed-time', '30',
                     '--location',
+                    '--connect-timeout', '2',
                     '--url', self.env["url"],
                     '--output', pathname_temporary]
 

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -176,8 +176,9 @@ class URLDownloader(Processor):
             for header, value in headers.items():
                 curl_cmd.extend(['--header', '%s: %s' % (header, value)])
 
-		if "timeout_seconds" in self.env:
-			curl_cmd.extend(['--connect-timeout', '%s' % timeout_seconds.itmes()])
+        if "timeout_seconds" in self.env:
+            seconds = self.env["timeout_seconds"]
+            curl_cmd.extend(['--connect-timeout', '%s' % seconds])
 		
         # if file already exists and the size is 0, discard it and download
         # again

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -68,9 +68,9 @@ class URLDownloader(Processor):
             "required": False,
             "description": "Filename to override the URL's tail.",
         },
-		"timeout_seconds": {
-			"required": False,
-			"description": "Sets curl to timeout if it can't make a connection in supplied seconds",
+        "timeout_seconds": {
+            "required": False,
+            "description": "Sets curl to timeout if it can't make a connection in supplied seconds",
         },
         "CHECK_FILESIZE_ONLY": {
             "default": False,
@@ -256,7 +256,7 @@ class URLDownloader(Processor):
             except IndexError:
                 pass
 
-            raise ProcessorError( "Curl failure: %s (exit code %s)" % (curlerr, retcode) )
+            raise ProcessorError("Curl failure: %s (exit code %s)" % (curlerr, retcode))
 
         # If Content-Length header is present and we had a cached
         # file, see if it matches the size of the cached file.

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -120,7 +120,7 @@ class URLTextSearcher(Processor):
 
         flags = self.env.get('re_flags', {})
 
-        timeout = self.env.get('timeout_seconds', {})
+        timeout = self.env.get('timeout_seconds', 2)
 
         groupmatch, groupdict = self.get_url_and_search(
             self.env['url'], self.env['re_pattern'], headers, flags, timeout)

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -120,7 +120,7 @@ class URLTextSearcher(Processor):
 
         flags = self.env.get('re_flags', {})
 
-        timeout = self.env.get('timeout_seconds', 2)
+        timeout = self.env.get('timeout_seconds', 10)
 
         groupmatch, groupdict = self.get_url_and_search(
             self.env['url'], self.env['re_pattern'], headers, flags, timeout)

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -77,7 +77,7 @@ class URLTextSearcher(Processor):
 
     description = __doc__
 
-    def get_url_and_search(self, url, re_pattern, headers=None, flags=None):
+    def get_url_and_search(self, url, re_pattern, headers=None, flags=None, timeout=None):
         '''Get data from url and search for re_pattern'''
         #pylint: disable=no-self-use
         flag_accumulator = 0
@@ -93,9 +93,8 @@ class URLTextSearcher(Processor):
             if headers:
                 for header, value in headers.items():
                     cmd.extend(['--header', '%s: %s' % (header, value)])
-            if timeout_seconds:
-                seconds = timeout_seconds.items()
-                cmd.extend(['--connect-timeout', '%s' % seconds])
+            if timeout:
+                cmd.extend(['--connect-timeout', '%s' % timeout])
             cmd.append(url)
             proc = subprocess.Popen(
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -121,8 +120,10 @@ class URLTextSearcher(Processor):
 
         flags = self.env.get('re_flags', {})
 
+        timeout = self.env.get('timeout_seconds', {})
+
         groupmatch, groupdict = self.get_url_and_search(
-            self.env['url'], self.env['re_pattern'], headers, flags)
+            self.env['url'], self.env['re_pattern'], headers, flags, timeout)
 
         # favor a named group over a normal group match
         if output_var_name not in groupdict.keys():

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -94,8 +94,8 @@ class URLTextSearcher(Processor):
                 for header, value in headers.items():
                     cmd.extend(['--header', '%s: %s' % (header, value)])
             if timeout_seconds:
-				seconds = timeout_seconds.items()
-				cmd.extend(['--connect-timeout %s' % seconds])
+                seconds = timeout_seconds.items()
+                cmd.extend(['--connect-timeout', '%s' % seconds])
             cmd.append(url)
             proc = subprocess.Popen(
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -55,6 +55,10 @@ class URLTextSearcher(Processor):
                             'expression flags. E.g. IGNORECASE.'),
             'required': False,
         },
+        'timeout_seconds': {
+        	'description': ("Sets curl to timeout if it can't make a connection in supplied seconds"),
+        	'required': False,
+        },
         "CURL_PATH": {
             "required": False,
             "default": "/usr/bin/curl",
@@ -89,6 +93,9 @@ class URLTextSearcher(Processor):
             if headers:
                 for header, value in headers.items():
                     cmd.extend(['--header', '%s: %s' % (header, value)])
+            if timeout_seconds:
+				seconds = timeout_seconds.items()
+				cmd.extend(['--connect-timeout %s' % seconds])
             cmd.append(url)
             proc = subprocess.Popen(
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
This is an attempt at the issue I opened at https://github.com/autopkg/autopkg/issues/315

In this incarnation there is a default timeout value of 2 seconds but can be overridden in a recipe by the admin.  The recipe receipt shows the error (with a 10 second timeout override from the recipe) as

```
        <key>RecipeError</key>
        <string>Error in com.github.poundbangbash.eholtam-recipes.download.SnapzPro: Processor: URLTextSearcher: Error: Could not retrieve URL http://www.ambrosiasw.com/dl/snapzprox:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:07 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:08 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:09 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:10 --:--:--     0
curl: (28) Connection timed out after 10001 milliseconds</string>
```

The option used for curl is only a timeout for establishing a connection.  Once a connection is made the timeout is ignored.
