### PR TITLE
Remove temporary download on file size match.

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -266,6 +266,10 @@ class URLDownloader(Processor):
                             "fallback mechanism that does not guarantee "
                             "that a build is unchanged.")
                 self.output("Using existing %s" % pathname)
+
+                # Discard the temp file
+                os.remove(pathname_temporary)
+
                 return
 
         if header['http_result_code'] == '304':


### PR DESCRIPTION
When `CHECK_FILESIZE_ONLY` is in use the `URLDownloader` processor does not remove the temporary downloaded file.