### PR TITLE
Fixed preprocessors erroneously assigned as postprocessors

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1866,7 +1866,7 @@ def run_recipes(argv):
     if options.preprocessors:
         preprocessors = options.preprocessors
     if options.postprocessors:
-        preprocessors = options.postprocessors
+        postprocessors = options.postprocessors
 
     # Add variables from environment
     cli_values = {}


### PR DESCRIPTION
Noticed when virustotal processor was not running after recipe runs. Not sure if there are other places where this is defined or whether this is enough to fix it but here goes :)