### PR TITLE
Improved "Invalid version" error reporting

### DIFF
--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -231,10 +231,10 @@ class Packager(object):
             raise PackagerError("Version too long")
         components = self.request.version.split(".")
         if len(components) < 1:
-            raise PackagerError("Invalid version")
+            raise PackagerError("Invalid version \"%s\"" % self.request.version)
         for comp in components:
             if not self.re_version.search(comp):
-                raise PackagerError("Invalid version")
+                raise PackagerError("Invalid version component \"%s\"" % comp)
         self.log.debug("version ok")
 
         # Make sure infofile and resources exist and can be read.


### PR DESCRIPTION
Added code that prints out the text that is causing "Invalid version" errors.