### PR TITLE
MunkiImporter: add bundle types when making catalog db

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -176,7 +176,7 @@ class MunkiImporter(Processor):
             # add to table of installed applications
             for install in item.get('installs', []):
                 try:
-                    if install.get('type') == 'application':
+                    if install.get('type') in ('application', 'bundle'):
                         if 'path' in install:
                             if 'version_comparison_key' in install:
                                 app_version = (


### PR DESCRIPTION
I found that I needed to add this for an item where an installs array of a single `bundle` type was merged into `pkginfo` using `MunkiPkginfoMerger` prior to calling `MunkiImporter`.

It's not quite obvious to me why this wasn't needed originally in #216, but it seems like without it, the item never gets added to the pkgdb. Current the applications "table" only contains keys which are also valid for `bundle` types, so this seems safe enough, but would appreciate a sanity check.