### PR TITLE
Add repo as submodule when autopkg settings is versioned

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -529,11 +529,25 @@ def get_recipe_repo(git_path):
     if not gitcmd:
         log_err("No git binary could be found!")
         return None
+    
+    # check if recipe_repo_dir is versionned with git or not
+    # if so, we should use submodule instead of clone
+    # `git rev-parse --is-inside-work-tree` will return "true"
+    # and exit with 0 if we are already under a git tree.
+    try:
+        is_inside_work_tree_output = run_git(['rev-parse', '--is-inside-work-tree'], git_directory=recipe_repo_dir).rstrip()
+        if is_inside_work_tree_output == "true":
+            is_under_git_tree = True
+        else:
+            is_under_git_tree = False
+    except GitError, err:
+        is_under_git_tree = False
+
 
     if os.path.exists(dest_dir):
         # probably should attempt a git pull
         # check to see if this is really a git repo first
-        if not os.path.isdir(os.path.join(dest_dir, '.git')):
+        if not is_under_git_tree:
             log_err("%s exists and is not a git repo!" % dest_dir)
             return None
         log("Attempting git pull...")
@@ -544,9 +558,13 @@ def get_recipe_repo(git_path):
             log_err(err)
             return None
     else:
-        log("Attempting git clone...")
         try:
-            log(run_git(['clone', git_path, dest_dir]))
+            if is_under_git_tree:
+                log("Attempting git submodule...")
+                log(run_git(['submodule', 'add', git_path, dest_dir], git_directory=recipe_repo_dir))
+            else:
+                log("Attempting git clone...")
+                log(run_git(['clone', git_path, dest_dir]))
             return dest_dir
         except GitError, err:
             log_err(err)

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -562,7 +562,7 @@ def get_recipe_repo(git_path):
         try:
             if is_under_git_tree:
                 log("Attempting git submodule...")
-                log(run_git(['submodule', 'add', git_path, dest_dir], git_directory=recipe_repo_dir))
+                log(run_git(['submodule', 'add', git_path, os.path.relpath(dest_dir, recipe_repo_dir)], git_directory=recipe_repo_dir))
             else:
                 log("Attempting git clone...")
                 log(run_git(['clone', git_path, dest_dir]))

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -765,8 +765,28 @@ def repo_delete(argv):
         if repo_path in recipe_search_dirs:
             recipe_search_dirs.remove(repo_path)
         # now remove the repo files
+        
+        repo_parent_path=os.path.dirname(repo_path)
         try:
-            shutil.rmtree(repo_path)
+            is_inside_work_tree_output = run_git(['rev-parse', '--is-inside-work-tree'], git_directory=repo_parent_path).rstrip()
+            if is_inside_work_tree_output == "true":
+                is_under_git_tree = True
+            else:
+                is_under_git_tree = False
+        except GitError, err:
+            is_under_git_tree = False
+            
+        try:
+            if is_under_git_tree:
+                git_repo_top_level = run_git(['rev-parse', '--show-toplevel'], git_directory=repo_parent_path).rstrip()
+                repo_relative_path=os.path.relpath(repo_path, git_repo_top_level)
+                log("Removing git submodule: "+repo_relative_path)
+                log(run_git(['submodule', 'deinit', repo_relative_path], git_directory=git_repo_top_level))
+                log(run_git(['rm', '--cache', repo_relative_path], git_directory=git_repo_top_level))
+                log(run_git(['config', '-f', '.gitmodules', '--remove-section', 'submodule.' + repo_relative_path], git_directory=git_repo_top_level))
+                shutil.rmtree(repo_path)
+            else:
+                shutil.rmtree(repo_path)
         except (OSError, IOError), err:
             log_err("ERROR: Could not remove %s: %s" % (repo_path, err))
         else:

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -547,7 +547,8 @@ def get_recipe_repo(git_path):
     if os.path.exists(dest_dir):
         # probably should attempt a git pull
         # check to see if this is really a git repo first
-        if not is_under_git_tree:
+        dest_dir_is_git_tree = run_git(['rev-parse', '--is-inside-work-tree'], git_directory=dest_dir).rstrip()
+        if not dest_dir_is_git_tree == "true":
             log_err("%s exists and is not a git repo!" % dest_dir)
             return None
         log("Attempting git pull...")


### PR DESCRIPTION
This change allow the autopkg working folder to be versioned by git.

The goal is to allow IT to manage the whole autopkg setup under git and so, repo should be added as submodule instead of simple clone.

Managing repo as submodule with a versioned autopkg config will allow a team to execute autopkg on multiple workstation and still relying on the same list of repo with the same validated version for each.

For example, if the IT team do its security job and check each repo update before accepting it, submodule can be used to track this validation.