### PR TITLE
New options for CodeSignatureVerifier

### DIFF
--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -106,7 +106,7 @@ class CodeSignatureVerifier(DmgMounter):
         # Use --deep option in OS X 10.9.5 or later
         darwin_version = os.uname()[2]
         if StrictVersion(darwin_version) >= StrictVersion('13.4.0'):
-            if deep_verification is True:
+            if deep_verification:
                 self.output("Deep verification enabled...")
                 process.append("--deep")
             else:
@@ -116,12 +116,14 @@ class CodeSignatureVerifier(DmgMounter):
         if StrictVersion(darwin_version) >= StrictVersion('15.0'):
             if strict_verification is None:
                 self.output("Strict verification not defined. Using codesign defaults...")
-            elif strict_verification is True:
+            elif strict_verification:
                 self.output("Strict verification enabled...")
                 process.append("--strict")
-            elif strict_verification is False:
+            elif not strict_verification:
                 self.output("Strict verification disabled...")
                 process.append("--no-strict")
+            else:
+                self.output("Strict verification value type unknown. Using codesign defaults...")
 
         # Add additional arguments (if any).
         for argument in codesign_additional_arguments:

--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -212,13 +212,13 @@ class CodeSignatureVerifier(DmgMounter):
 
         if self.env.get('expected_authority_names', None):
             self.output("ERROR: Using 'expected_authority_names' to verify code "
-                        "signature is deprecated. Recipes should use the "
+                        "signature is no longer supported. Recipes should use the "
                         "'requirement' argument instead.")
             self.output("See https://github.com/autopkg/autopkg/wiki/Using-"
                         "CodeSignatureVerification for more information.")
             raise ProcessorError(
                 "Using 'expected_authority_names' to verify code signature "
-                "is deprecated. Note that all verifications can be disabled "
+                "is no longer supported. Note that all verifications can be disabled "
                 "by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION "
                 "to a non-empty value.")
 


### PR DESCRIPTION
This PR adds a number of new things and modernizations to CodeSignatureVerifier without changing current behavior too much.

- Added `strict_verification` variable to control whether to pass `--strict`, `--no-strict` or nothing at all to codesign. The default is to not pass anything unless specifically defined. This will make the strict verification an opt-in for recipe writers but I think it's better than breaking things. Using this in a recipe might look like this:

```
<dict>
	<key>Processor</key>
	<string>CodeSignatureVerifier</string>
	<key>Arguments</key>
	<dict>
		<key>input_path</key>
		<string>%pathname%/Google Chrome.app</string>
		<key>requirement</key>
		<string>(identifier "com.google.Chrome" or identifier "com.google.Chrome.beta" or identifier "com.google.Chrome.dev" or identifier "com.google.Chrome.canary") and (certificate leaf = H"85cee8254216185620ddc8851c7a9fc4dfe120ef" or certificate leaf = H"c9a99324ca3fcb23dbcc36bd5fd4f9753305130a")</string>
		<key>strict_verification</key>
		<false />
	</dict>
</dict>
```

Or one could replicate all the different verification steps the Chromium project is using: https://chromium.googlesource.com/chromium/src/+/lkgr/chrome/installer/mac/sign_app.sh.in

- Added `deep_verification` variable to control whether to pass `--deep` to codesign or not. Deep verification was previously on by default (and still is) but it can now be explicitly disabled.

- Added `codesign_additional_arguments` variable for specifying additional arguments for `codesign` tool.

- Removed the .app file extension checking and no longer require the input to be a specific file type. Only check for .pkg, .mpkg or .xip extensions and pass those to pkgutil, everything else should go to codesign.

The only breaking change in this PR should be this: Removed functionality to use `expected_authority_names` key with codesign. This was already printing a warning message but I think it's time for it to go away completely. The last time I checked, there was 5 recipes using this combo and they will break. I will personally find and fix these through pull requests.
