### PR TITLE
Unescape URLs found with URLTextSearcher

### DIFF
--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -18,6 +18,7 @@
 
 import re
 import subprocess
+import HTMLParser
 
 from autopkglib import Processor, ProcessorError
 
@@ -104,8 +105,11 @@ class URLTextSearcher(Processor):
         if not match:
             raise ProcessorError('No match found on URL: %s' % url)
 
-        # return the last matched group with the dict of named groups
-        return (match.group(match.lastindex or 0), match.groupdict(), )
+        # Unescape last matched group to get rid of html escape characters
+        unescaped_url = HTMLParser.HTMLParser().unescape(match.group(match.lastindex or 0))
+
+        # return the last matched group as unescaped url with the dict of named groups
+        return (unescaped_url, match.groupdict(), )
 
     def main(self):
         output_var_name = self.env['result_output_var_name']


### PR DESCRIPTION
### Proposed Change
This pull request adds a method to handle developers that only provide escaped urls on their download page. As an example see [this download recipe.](https://github.com/ITS-Unibas/autopkg-recipes/blob/F5/F5transkript/F5transkript.download.recipe)

Output now: `{'Output': {'match': '/audot/downloadfile.php?k=1&amp;d=13&amp;l=de&amp;c=2d9cf5ca79'}}`

Output after the change to `URLTextSearcher`: `{'Output': {'match': u'/audot/downloadfile.php?k=1&d=13&l=de&c=2d9cf5ca79'}}`

### Reasons for change:
We use a [a custom URLProvider](https://github.com/ITS-Unibas/autopkg-recipes/blob/master/F5transkript/F5transkriptURLProvider.py) in our autopkg recipe for [F5transkript](https://github.com/ITS-Unibas/autopkg-recipes/blob/master/F5transkript/F5transkriptURLProvider.py). The reason for this being that the developer only publishes an unescaped URL on the download page and that there is not currently a way to unescape urls with curl - as far as I know.

I would like to add our repo to the autopkg organisation (See issue https://github.com/autopkg/autopkg/issues/376) and this pull request is a possible way to get rid of our custom URLProvider.

I know that such a change because of one piece of software is probably undesired - also, there might be a simpler way to get the correct url. But maybe there are others out there who face the same problem and would benefit from such a change as well.

I'm putting this up for discussion.