### PR TITLE
Discard temp file after matching file sizes

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -283,6 +283,10 @@ class URLDownloader(Processor):
                             "fallback mechanism that does not guarantee "
                             "that a build is unchanged.")
                 self.output("Using existing %s" % pathname)
+
+                # Discard the temp file
+                os.remove(pathname_temporary)
+
                 return
 
         if header['http_result_code'] == '304':


### PR DESCRIPTION
Ensure that `temporary_file` is removed if URLdownloader determines that the file hasn't changed by matching the new and existing file sizes.