### PR TITLE
Use `os.makedirs` instead of `os.mkdir` for all core processors.

### DIFF
--- a/Code/autopkglib/FlatPkgUnpacker.py
+++ b/Code/autopkglib/FlatPkgUnpacker.py
@@ -74,7 +74,7 @@ class FlatPkgUnpacker(DmgMounter):
         # Create the directory if needed.
         if not os.path.exists(self.env['destination_path']):
             try:
-                os.mkdir(self.env['destination_path'])
+                os.makedirs(self.env['destination_path'])
             except OSError as err:
                 raise ProcessorError(
                     "Can't create %s: %s"

--- a/Code/autopkglib/PkgPayloadUnpacker.py
+++ b/Code/autopkglib/PkgPayloadUnpacker.py
@@ -54,7 +54,7 @@ class PkgPayloadUnpacker(Processor):
         # Create the destination directory if needed.
         if not os.path.exists(self.env['destination_path']):
             try:
-                os.mkdir(self.env['destination_path'])
+                os.makedirs(self.env['destination_path'])
             except OSError as err:
                 raise ProcessorError(
                     "Can't create %s: %s"

--- a/Code/autopkglib/PkgRootCreator.py
+++ b/Code/autopkglib/PkgRootCreator.py
@@ -82,7 +82,7 @@ class PkgRootCreator(Processor):
                 raise ProcessorError("%s is outside pkgroot" % directory)
 
             try:
-                os.mkdir(dirpath)
+                os.makedirs(dirpath)
                 os.chmod(dirpath, int(mode, 8))
                 self.output("Created %s" % dirpath)
             except OSError as err:


### PR DESCRIPTION
This PR is to replace the use of `os.mkdir` with `os.makedirs` for three of the core processors:
- FlatPkgUnpacker
- PkgPayloadUnpacker
- PkgRootCreator

Existing processors that already use `os.makedirs` are:
- MunkiImporter
- AppPkgCreator
- PkgExtractor
- URLDownloader
- Unarchiver

The thinking being that some of these processors will create intermediary directories if so instructed, while others won't. For the sake of consistency, it makes sense to use `os.makedirs` for all of the above.

`os.makedirs` has the same signature as `os.mkdir`, so there shouldn't be any issues.