### PR TITLE
Use curl for GitHub API calls instead of urllib2

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -820,18 +820,22 @@ def do_gh_code_search(query, use_token=False):
     if use_token:
         gh_session.setup_token()
     # Do the search, including text match metadata
-    results = gh_session.call_api(
+    (results, code) = gh_session.call_api(
         "/search/code",
         query=query,
         accept="application/vnd.github.v3.text-match+json")
     
-    gh_message = results.get("message", None)
-    gh_documentation_url = results.get("documentation_url", None)
-    if gh_message:
-        log_err(gh_message)
-        log_err(gh_documentation_url)
-    
-    if results is None:
+    if code == 403:
+        log_err(
+                "You've probably hit the GitHub's search rate limit, officially 5 "
+                "requests per minute.\n")
+        if results:
+            log_err("Server response follows:\n")
+            log_err(results.get("message", None))
+            log_err(results.get("documentation_url", None))
+            
+        return None
+    if results is None or code is None:
         log_err("A GitHub API error occurred!")
         return None
     return results

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -820,18 +820,18 @@ def do_gh_code_search(query, use_token=False):
     if use_token:
         gh_session.setup_token()
     # Do the search, including text match metadata
-    (results, code) = gh_session.call_api(
+    results = gh_session.call_api(
         "/search/code",
         query=query,
         accept="application/vnd.github.v3.text-match+json")
-    if code == 403:
-        log_err(
-            "You've probably hit the GitHub's search rate limit, officially 5 "
-            "requests per minute. Server response follows:\n")
-        log_err(results["message"])
-        log_err(results["documentation_url"])
-        return None
-    if results is None or code is None:
+    
+    gh_message = results.get("message", None)
+    gh_documentation_url = results.get("documentation_url", None)
+    if gh_message:
+        log_err(gh_message)
+        log_err(gh_documentation_url)
+    
+    if results is None:
         log_err("A GitHub API error occurred!")
         return None
     return results
@@ -909,7 +909,7 @@ def search_recipes(argv):
     if not results:
         return
 
-    count = results["total_count"]
+    count = results.get("total_count", 0)
     if count == 0:
         print "No results."
         return

--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -82,7 +82,10 @@ class GitHubReleasesInfoProvider(Processor):
         releases = None
         github = autopkglib.github.GitHubSession()
         releases_uri = "/repos/%s/releases" % repo
-        releases = github.call_api(releases_uri)
+        (releases, status) = github.call_api(releases_uri)
+        if status != 200:
+            raise ProcessorError(
+                "Unexpected GitHub API status code %s." % status)
 
         if not releases:
             raise ProcessorError("No releases found for repo '%s'" % repo)

--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -82,14 +82,7 @@ class GitHubReleasesInfoProvider(Processor):
         releases = None
         github = autopkglib.github.GitHubSession()
         releases_uri = "/repos/%s/releases" % repo
-        try:
-            (releases, status) = github.call_api(releases_uri)
-        # Catch a 404
-        except urllib2.HTTPError as err:
-            raise ProcessorError("GitHub API returned an error: '%s'." % err)
-        if status != 200:
-            raise ProcessorError(
-                "Unexpected GitHub API status code %s." % status)
+        releases = github.call_api(releases_uri)
 
         if not releases:
             raise ProcessorError("No releases found for repo '%s'" % repo)

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -199,6 +199,38 @@ def update_data(a_dict, key, value):
 
     a_dict[key] = do_variable_substitution(value)
 
+
+def curl_cmd():
+    """Returns a path to a curl binary, priority in the order below.
+    Returns None if none found.
+    1. app pref 'CURL_PATH'
+    2. a 'curl' binary that can be found in the PATH environment variable
+    3. '/usr/bin/curl'
+    """
+
+    def is_executable(exe_path):
+        '''Is exe_path executable?'''
+        return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
+
+    curl_path_pref = get_pref('CURL_PATH')
+    if curl_path_pref:
+        if is_executable(curl_path_pref):
+            # take a CURL_PATH pref
+            return curl_path_pref
+        else:
+            log_err("WARNING: Curl path given in the 'CURL_PATH' preference:'%s' "
+                    "either doesn't exist or is not executable! Falling back "
+                    "to one set in PATH, or /usr/bin/curl." % curl_path_pref)
+    for path_env in os.environ["PATH"].split(":"):
+        curlbin = os.path.join(path_env, "curl")
+        if is_executable(curlbin):
+            # take the first 'curl' in PATH that we find
+            return curlbin
+    if is_executable("/usr/bin/curl"):
+        # fall back to /usr/bin/curl
+        return "/usr/bin/curl"
+    return None
+
 # Processor and ProcessorError base class definitions
 
 class ProcessorError(Exception):

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -116,11 +116,13 @@ home folder at %s.""" % TOKEN_LOCATION
         accept: optional Accept media type for exceptional APIs (like release
                 assets)."""
 
+        # Compose the URL
         url = BASE_URL + endpoint
         if query:
             url += "?" + query 
 
         try:
+            # Compose the curl command
             curl_path = curl_cmd()
             if not curl_path:
                 return None
@@ -128,17 +130,30 @@ home folder at %s.""" % TOKEN_LOCATION
             cmd.extend(['-X', method])
             cmd.extend(['--header', '%s: %s' % ("User-Agent", "AutoPkg")])
             cmd.extend(['--header', '%s: %s' % ("Accept", accept)])
-            if data:
-                data = json.dumps(data)
-                cmd.extend(['-d', data, '--header', 'Content-Type: application/json'])
+
+            # Pass the GitHub token as a header
             if self.token:
                 cmd.extend(['--header', '%s: %s' % ("Authorization", "token %s" % self.token)])
+
+            # Additional headers if defined
             if headers:
                 for header, value in headers.items():
                     cmd.extend(['--header', '%s: %s' % (header, value)])
+
+            # Set the data header if defined
+            if data:
+                data = json.dumps(data)
+                cmd.extend(['-d', data, '--header', 'Content-Type: application/json'])
+
+            # Final argument to curl is the URL
             cmd.append(url)
+            
+            # Start the curl process
             proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
             (content, stderr) = proc.communicate()
             if content:
                 resp_data = json.loads(content)

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -18,6 +18,7 @@
 import json
 import os
 import sys
+import re
 import subprocess
 from autopkglib import curl_cmd
 
@@ -72,8 +73,9 @@ To save the token, paste it to the following prompt."""
 
     def call_api(self, endpoint, method="GET", query=None, data=None,
                  headers=None, accept="application/vnd.github.v3+json"):
-        """Return a serialized JSON response from a call to a GitHub API endpoint.
-        Certain APIs return no JSON result and so the response might be None.
+        """Return a tuple of a serialized JSON response and HTTP status code
+        from a call to a GitHub API endpoint. Certain APIs return no JSON
+        result and so the first item in the tuple (the response) will be None.
 
         endpoint: REST endpoint, beginning with a forward-slash
         method: optional alternate HTTP method to use other than GET
@@ -92,8 +94,15 @@ To save the token, paste it to the following prompt."""
             # Compose the curl command
             curl_path = curl_cmd()
             if not curl_path:
-                return None
-            cmd = [curl_path, '--location']
+                return (None, None)
+            cmd = [
+                curl_path,
+                '--location',
+                '--silent',
+                '--show-error',
+                '--fail',
+                '--dump-header', '-'
+            ]
             cmd.extend(['-X', method])
             cmd.extend(['--header', '%s: %s' % ("User-Agent", "AutoPkg")])
             cmd.extend(['--header', '%s: %s' % ("Accept", accept)])
@@ -118,20 +127,80 @@ To save the token, paste it to the following prompt."""
             # Start the curl process
             proc = subprocess.Popen(
                 cmd,
+                shell=False,
+                bufsize=1,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE
             )
-            (content, stderr) = proc.communicate()
-            if content:
-                resp_data = json.loads(content)
+            
+            header = {}
+            header['http_result_code'] = '000'
+            header['http_result_description'] = ''
+            donewithheaders = False
+            maxheaders = 15
+    
+            page_content = ""
+
+            # Parse the headers and the JSON from curl output
+            while True:
+                info = proc.stdout.readline()
+                if not donewithheaders:
+                    info = info.strip('\r\n')
+                    if info:
+                        if info.startswith('HTTP/'):
+                            part = info.split(None, 2)
+                            header['http_result_code'] = part[1]
+                            try:
+                                header['http_result_description'] = part[2]
+                            except IndexError:
+                                pass
+                        elif ': ' in info:
+                            part = info.split(None, 1)
+                            fieldname = part[0].rstrip(':').lower()
+                            try:
+                                header[fieldname] = part[1]
+                            except IndexError:
+                                pass
+                    else:
+                        donewithheaders = True
+                else:
+                    page_content += info
+
+                if (proc.poll() != None):
+                    # For small download files curl may exit before all headers
+                    # have been parsed, don't immediately exit.
+                    maxheaders -= 1
+                    if donewithheaders or maxheaders <= 0:
+                        break
+
+            # All curl output should now be parsed
+            retcode = proc.poll()
+            if retcode:
+                curlerr = ''
+                try:
+                    curlerr = proc.stderr.read().rstrip('\n')
+                    curlerr = curlerr.split(None, 2)[2]
+                except IndexError:
+                    pass
+                if retcode == 22:
+                    # 22 means any 400 series return code. Note: header seems not to
+                    # be dumped to STDOUT for immediate failures. Hence
+                    # http_result_code is likely blank/000. Read it from stderr.
+                    if re.search(r'URL returned error: [0-9]+', curlerr):
+                        m = re.match(r".* (?P<status_code>\d+) .*", curlerr)
+                        if m.group('status_code'):
+                            header['http_result_code'] = m.group('status_code')
+                print >> sys.stderr, 'Could not retrieve URL %s: %s' % (url, curlerr)
+            
+            if page_content:
+                resp_data = json.loads(page_content)
             else:
                 resp_data = None
-            if proc.returncode:
-                print >> sys.stderr, 'Could not retrieve URL %s: %s' % (url, stderr)
-                resp_data = None
+
         except OSError:
             print >> sys.stderr, 'Could not retrieve URL: %s' % url
             resp_data = None
-
-        return resp_data
+        
+        http_result_code = int(header.get('http_result_code'))
+        return (resp_data, http_result_code)
 

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -18,29 +18,11 @@
 import json
 import os
 import sys
-import urllib2
 import subprocess
 from autopkglib import curl_cmd
 
-from base64 import b64encode
-from getpass import getpass
-from pprint import pprint
-
 BASE_URL = "https://api.github.com"
 TOKEN_LOCATION = os.path.expanduser("~/.autopkg_gh_token")
-
-
-class RequestWithMethod(urllib2.Request):
-    """Custom Request class that can accept arbitrary methods besides
-    GET/POST"""
-    # http://benjamin.smedbergs.us/blog/2008-10-21/
-    #        putting-and-deleteing-in-python-urllib2/
-    def __init__(self, method, *args, **kwargs):
-        self._method = method
-        urllib2.Request.__init__(self, *args, **kwargs)
-
-    def get_method(self):
-        return self._method
 
 
 class GitHubSession(object):

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -20,7 +20,7 @@ import os
 import sys
 import re
 import subprocess
-from autopkglib import curl_cmd
+from autopkglib import curl_cmd, get_pref
 
 BASE_URL = "https://api.github.com"
 TOKEN_LOCATION = os.path.expanduser("~/.autopkg_gh_token")
@@ -29,7 +29,20 @@ TOKEN_LOCATION = os.path.expanduser("~/.autopkg_gh_token")
 class GitHubSession(object):
     """Handles a session with the GitHub API"""
     def __init__(self):
-        self.token = None
+        token = get_pref('GITHUB_TOKEN')
+        if token:
+            self.token = token
+        elif os.path.exists(TOKEN_LOCATION):
+            try:
+                with open(TOKEN_LOCATION, "r") as tokenf:
+                    self.token = tokenf.read()
+            except IOError as err:
+                print >> sys.stderr, (
+                    "Couldn't read token file at %s! Error: %s"
+                    % (TOKEN_LOCATION, err))
+                self.token = None
+        else:
+            self.token = None
 
     def setup_token(self):
         """Setup a GitHub OAuth token string. Will help to create one if necessary.


### PR DESCRIPTION
These changes swap out urllib2 for curl when making GitHub API calls. I tried to keep changes to existing behaviour at minimum but some things are different:

- When using curl, we can't easily get the HTTP status code. I therefore removed the status code from the `call_api()` return value and just return the json response.
- When doing `autopkg search -t`, we're not trying to create a new token over the GH API. Instead just display a link where a token can be manually created and wait for user to copy/paste it back in.

This PR doesn't include any changes to the token behaviour, that will be a separate PR.