### PR TITLE
Update ReadMe to modern terms

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,7 +3,7 @@ AutoPkg
 
 Latest release is [here](https://github.com/autopkg/autopkg/releases/latest).
 
-AutoPkg is an automation framework for OS X software packaging and distribution, oriented towards the tasks one would normally perform manually to prepare third-party software for mass deployment to managed clients.
+AutoPkg is an automation framework for macOS software packaging and distribution, oriented towards the tasks one would normally perform manually to prepare third-party software for mass deployment to managed clients.
 
 These tasks typically involve at least several of the following steps:
 
@@ -13,7 +13,7 @@ These tasks typically involve at least several of the following steps:
 * adding sane versioning information
 * "fixing" poorly-written installer scripts
 * saving these modifications back to a compressed disk image or installer package
-* importing these into a software distribution system like Munki, Casper, Absolute Manage, etc.
+* importing these into a software distribution system like Munki, Jamf Pro, FileWave, etc.
 * customizing the associated metadata for such a system with site-specific data, post-installation scripts, version info or other metadata
 
 Often these tasks follow similar patterns for each individual application, and when managing many applications this becomes a daily task full of sub-tasks that one must remember (and/or maintain documentation for) about exactly what had to be done for a successful deployment of every update for every managed piece of software.
@@ -26,9 +26,9 @@ Installation
 
 Install the [latest release](https://github.com/autopkg/autopkg/releases/latest).
 
-AutoPkg requires OS X 10.6 or later, and Git is highly recommended to have installed so that it can manage recipe repositories. Knowledge of Git itself is not required.
+AutoPkg requires Mac OS X 10.6 or a later version of macOS, and Git is highly recommended to have installed so that it can manage recipe repositories. Knowledge of Git itself is not required.
 
-Git can be installed via Apple's command-line developer tools package, which on 10.9 can be prompted for installation by simply typing 'git' in a Terminal window.
+Git can be installed via Apple's command-line developer tools package, which can be prompted for installation by simply typing 'git' in a Terminal window (OS X 10.9 or later).
 
 
 Usage


### PR DESCRIPTION
Update ReadMe to: reflect current (and previous) names for macOS;
clarify that the ‘git’ terminal trick works in 10.9 and later; update
names of software distribution systems to reflect the current names of the three most popular products in the repo.