### PR TITLE
Adding -f/--force option for make-override

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1736,6 +1736,8 @@ def make_override(argv):
     add_search_and_override_dir_options(parser)
     parser.add_option("-n", "--name", metavar="FILENAME",
                       help="Name for override file.")
+    parser.add_option("-f", "--force", action="store_true",
+                      help="Force overwrite an override file.")
     options, arguments = parser.parse_args(argv[2:])
 
     override_dirs = options.override_dirs or get_override_dirs()
@@ -1801,13 +1803,14 @@ def make_override(argv):
 
     override_file = os.path.join(override_dir, "%s.recipe" % override_name)
     if os.path.exists(override_file):
-        log_err("An override plist already exists at %s, "
-                "will not overwrite it." % override_file)
-        return -1
-    else:
-        FoundationPlist.writePlist(override_plist, override_file)
-        log("Override file saved to %s" % override_file)
-        return 0
+        if not options.force:
+            log_err("An override plist already exists at %s, "
+                    "will not overwrite it." % override_file)
+            return -1
+        os.unlink(override_file)
+    FoundationPlist.writePlist(override_plist, override_file)
+    log("Override file saved to %s" % override_file)
+    return 0
 
 
 def parse_recipe_list(filename):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1805,7 +1805,8 @@ def make_override(argv):
     if os.path.exists(override_file):
         if not options.force:
             log_err("An override plist already exists at %s, "
-                    "will not overwrite it." % override_file)
+                    "will not overwrite it. Use --force to overwrite "
+                    "anyway." % override_file)
             return -1
         os.unlink(override_file)
     FoundationPlist.writePlist(override_plist, override_file)


### PR DESCRIPTION
This adds a "-f"/"--force" option to `autopkg make-override`, which allows the admin to force create a new override even if one already exists. This is useful if a recipe has completely changed behavior/input variables, and the admin wants to start over. 

Testing when an override already exists:
```
$ autopkg make-override XcodeResigned.munki
An override plist already exists at /Users/nmcspadden/Library/AutoPkg/RecipeOverrides/XcodeResigned.munki.recipe, will not overwrite it.
$ autopkg make-override XcodeResigned.munki --force
Override file saved to /Users/nmcspadden/Library/AutoPkg/RecipeOverrides/XcodeResigned.munki.recipe
$ autopkg make-override XcodeResigned.munki -f
Override file saved to /Users/nmcspadden/Library/AutoPkg/RecipeOverrides/XcodeResigned.munki.recipe
```

Testing when no override exists and still using `-f`:
```
$ rm /Users/nmcspadden/Library/AutoPkg/RecipeOverrides/XcodeResigned.munki.recipe
$ autopkg make-override XcodeResigned.munki -f
Override file saved to /Users/nmcspadden/Library/AutoPkg/RecipeOverrides/XcodeResigned.munki.recipe
```

Testing when no override exists and not using `-f`:
```
$ rm /Users/nmcspadden/Library/AutoPkg/RecipeOverrides/XcodeResigned.munki.recipe
$ autopkg make-override XcodeResigned.munki
Override file saved to /Users/nmcspadden/Library/AutoPkg/RecipeOverrides/XcodeResigned.munki.recipe
```

Final test to ensure that `-f`/`--force` is required to overwrite existing one:
```
$ autopkg make-override XcodeResigned.munki
An override plist already exists at /Users/nmcspadden/Library/AutoPkg/RecipeOverrides/XcodeResigned.munki.recipe, will not overwrite it.
```