### PR TITLE
Fix URLDownloader tripping over 307 redirect

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -248,7 +248,7 @@ class URLDownloader(Processor):
                 elif info == '':
                     # we got an empty line; end of headers (or curl exited)
                     if header.get('http_result_code') in [
-                            '301', '302', '303']:
+                            '301', '302', '303', '307', '308']:
                         # redirect, so more headers are coming.
                         # Throw away the headers we've received so far
                         header = {}


### PR DESCRIPTION
We noticed a lot of unnecessary re-downloads for the current Tower.zip package. It turns out that URLDownloader ignored header results (etag, last-modified) after a HTTP 307 redirect. Curl downloads the files, but autopkg did not store the final etag value.

Example path for tower:

```
curl  --silent --show-error --no-buffer --fail --dump-header - --speed-time 30 --location --url https://www.git-tower.com/download  --output /dev/null
HTTP/1.1 301 Moved Permanently
Date: Tue, 11 Sep 2018 15:05:00 GMT
Server: Apache/2.4.29
Location: https://updates.fournova.com/tower3-mac/stable/releases/latest/download
Cache-Control: max-age=900
Expires: Tue, 11 Sep 2018 15:20:00 GMT
Content-Length: 354
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 307 Temporary Redirect
Server: Cowboy
Connection: keep-alive
Strict-Transport-Security: max-age=31536000
Location: https://fournova-app-updates.s3.amazonaws.com/apps/tower3-mac/158-2f17351b/Tower-3.1.1-158.zip
Content-Type: text/html; charset=utf-8
X-Ua-Compatible: IE=Edge,chrome=1
Cache-Control: no-cache
X-Request-Id: c43e91e4-0177-477e-b064-4cf2273b5d0a
X-Runtime: 0.043404
Date: Tue, 11 Sep 2018 15:05:01 GMT
X-Rack-Cache: miss
Transfer-Encoding: chunked
Via: 1.1 vegur

HTTP/1.1 200 OK
x-amz-id-2: lP+6ogHtjEvvUXQCgNR/nfsFAAPg47WgpZCZCwH91QXzNv7Q9Fiv0t9/EI6CJ2yN46k3KGZsCtQ=
x-amz-request-id: 455C5E0F13A26D00
Date: Tue, 11 Sep 2018 15:05:03 GMT
Last-Modified: Mon, 30 Jul 2018 10:58:26 GMT
ETag: "158876c5515e8d0d1567974c9eec910b"
Content-Encoding: 
Accept-Ranges: bytes
Content-Type: application/octet-stream
Content-Length: 29507472
Server: AmazonS3
```

Is that intended? And if not, can we get `307` into the list of redirect status codes to follow?