### PR TITLE
Normalize recipe path in recipe_in_override_dir

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1477,10 +1477,11 @@ def recipe_from_external_repo(recipe_path):
 
 def recipe_in_override_dir(recipe_path, override_dirs):
     '''Returns True if the recipe is in a path in override_dirs'''
+    normalized_recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
     normalized_override_dirs = [os.path.abspath(os.path.expanduser(directory))
                                 for directory in override_dirs]
     for override_dir in normalized_override_dirs:
-        if recipe_path.startswith(override_dir):
+        if normalized_recipe_path.startswith(override_dir):
             return True
     return False
 


### PR DESCRIPTION
## Overview

Normalize the `recipe_path` variable in `recipe_in_override_dir` so that we can check if a recipe override file provided with a relative path is within an override directory.

Right now, if my working directory is `~/AutoPkg`, and my override directory is set to `~/AutoPkg/RecipeOverrides`, and I pass `./RecipeOverrides/MyRecipe.recipe` to this function, it will fail. 

This will fail because the function checks to see if the string `./RecipeOverrides/MyRecipe.recipe` starts with `~/AutoPkg/RecipeOverrides`.

Fixes #436 

## Testing Instructions

Run `verify-trust-info` and get an `OK` response for both relative and absolute paths:

```bash
$ autopkg verify-trust-info -vv ./RecipeOverrides/MSWord2016.munki.recipe
./RecipeOverrides/MSWord2016.munki.recipe: OK
```

```bash
$ autopkg verify-trust-info -vv /Users/rbreslow/Projects/autopkg/RecipeOverrides/MSWord2016.munki.recipe
/Users/rbreslow/Projects/autopkg/RecipeOverrides/MSWord2016.munki.recipe: OK
```