### PR TITLE
URLGetter refactoring and HTTP proxy fix

### DIFF
--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -99,10 +99,7 @@ class GitHubReleasesInfoProvider(Processor):
         be of the form 'user/repo'"""
         # pylint: disable=no-self-use
         releases = None
-        if "curl_opts" in self.env:
-            curl_opts = self.env["curl_opts"]
-        else:
-            curl_opts = None
+        curl_opts = self.env.get("curl_opts")
         github = autopkglib.github.GitHubSession(self.env["CURL_PATH"], curl_opts)
         releases_uri = "/repos/%s/releases" % repo
         (releases, status) = github.call_api(releases_uri)

--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -63,6 +63,18 @@ class GitHubReleasesInfoProvider(Processor):
                 "release may be posted later."
             ),
         },
+        "curl_opts": {
+            "required": False,
+            "description": (
+                "Optional array of curl options to include with "
+                "the download request."
+            ),
+        },
+        "CURL_PATH": {
+            "required": False,
+            "default": "/usr/bin/curl",
+            "description": "Path to curl binary. Defaults to /usr/bin/curl.",
+        },
     }
     output_variables = {
         "release_notes": {
@@ -87,7 +99,11 @@ class GitHubReleasesInfoProvider(Processor):
         be of the form 'user/repo'"""
         # pylint: disable=no-self-use
         releases = None
-        github = autopkglib.github.GitHubSession()
+        if "curl_opts" in self.env:
+            curl_opts = self.env["curl_opts"]
+        else:
+            curl_opts = None
+        github = autopkglib.github.GitHubSession(self.env["CURL_PATH"], curl_opts)
         releases_uri = "/repos/%s/releases" % repo
         (releases, status) = github.call_api(releases_uri)
         if status != 200:

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -321,10 +321,7 @@ class SparkleUpdateInfoProvider(URLGetter):
             return
 
         # handle custom xmlns and version attributes
-        if "alternate_xmlns_url" in self.env:
-            self.xmlns = self.env["alternate_xmlns_url"]
-        else:
-            self.xmlns = DEFAULT_XMLNS
+        self.xmlns = self.env.get("alternate_xmlns_url", DEFAULT_XMLNS)
 
         data = self.get_feed_data(self.env.get("appcast_url"))
         items = self.parse_feed_data(data)
@@ -340,10 +337,7 @@ class SparkleUpdateInfoProvider(URLGetter):
         pkginfo = self.handle_pkginfo(latest)
 
         self.env["url"] = latest["url"]
-        if latest.get("human_version"):
-            self.env["version"] = latest["human_version"]
-        else:
-            self.env["version"] = latest["version"]
+        self.env["version"] = latest.get("human_version", latest["version"])
         self.output("Found URL %s" % self.env["url"])
         self.env["additional_pkginfo"] = pkginfo
 

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 #
+# Refactoring 2018 Michal Moravec
 # Copyright 2013-2016 Timothy Sutton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,14 +18,14 @@
 """See docstring for SparkleUpdateInfoProvider class"""
 
 import os
-import subprocess
 import urllib
 import urlparse
 from distutils.version import LooseVersion
 from operator import itemgetter
 from xml.etree import ElementTree
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import ProcessorError
+from autopkglib.URLGetter import URLGetter
 
 __all__ = ["SparkleUpdateInfoProvider"]
 
@@ -32,7 +33,7 @@ DEFAULT_XMLNS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
 SUPPORTED_ADDITIONAL_PKGINFO_KEYS = ["description", "minimum_os_version"]
 
 
-class SparkleUpdateInfoProvider(Processor):
+class SparkleUpdateInfoProvider(URLGetter):
     """Provides URL to the highest version number or latest update."""
 
     description = __doc__
@@ -58,6 +59,12 @@ class SparkleUpdateInfoProvider(Processor):
                 "Alternate URL for the XML namespace, if the "
                 "appcast is using an alternate one. Defaults to "
                 "that used for 'vanilla' Sparkle appcasts."
+            ),
+        },
+        "curl_opts": {
+            "required": False,
+            "description": (
+                "Optional array of options to include with the download " "request."
             ),
         },
         "pkginfo_keys_to_copy_from_sparkle_feed": {
@@ -118,27 +125,88 @@ class SparkleUpdateInfoProvider(Processor):
         },
     }
 
+    def prepare_curl_cmd(self, url, headers=None):
+        """Assemble curl command and return it."""
+
+        curl_cmd = [
+            super(SparkleUpdateInfoProvider, self).curl_binary(),
+            "--location",
+            "--compressed",
+        ]
+        super(SparkleUpdateInfoProvider, self).add_curl_common_opts(curl_cmd)
+        if headers:
+            for header, value in headers.items():
+                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+        curl_cmd.append(url)
+        return curl_cmd
+
     def fetch_content(self, url, headers=None):
         """Returns content retrieved by curl, given a url and an optional
         dictionary of header-name/value mappings. Logic here borrowed from
         URLTextSearcher processor."""
 
+        curl_cmd = self.prepare_curl_cmd(url, headers)
         try:
-            cmd = [self.env["CURL_PATH"], "--location", "--compressed"]
-            if headers:
-                for header, value in headers.items():
-                    cmd.extend(["--header", "%s: %s" % (header, value)])
-            cmd.append(url)
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (data, stderr) = proc.communicate()
-            if proc.returncode:
-                raise ProcessorError("Could not retrieve URL %s: %s" % (url, stderr))
-        except OSError:
+            content = super(SparkleUpdateInfoProvider, self).download(curl_cmd)
+        except ProcessorError:
             raise ProcessorError("Could not retrieve URL: %s" % url)
 
-        return data
+        return content
 
     def get_feed_data(self, url):
+        """Downloads raw feed XML"""
+
+        # query string
+        if "appcast_query_pairs" in self.env:
+            queries = self.env["appcast_query_pairs"]
+            new_query = urllib.urlencode([(k, v) for (k, v) in queries.items()])
+            scheme, netloc, path, _, frag = urlparse.urlsplit(url)
+            url = urlparse.urlunsplit((scheme, netloc, path, new_query, frag))
+
+        data = self.fetch_content(url, headers=self.env.get("appcast_request_headers"))
+        return data
+
+    def build_url(self, enclosure):
+        """URL-quote the path component to handle spaces, etc.
+        (Panic apps do this)"""
+
+        url_bits = urlparse.urlsplit(enclosure.get("url"))
+        if self.env.get("urlencode_path_component", True):
+            encoded_path = urllib.quote(url_bits.path)
+        else:
+            encoded_path = url_bits.path
+        built_url = url_bits.scheme + "://" + url_bits.netloc + encoded_path
+        if url_bits.query:
+            built_url += "?" + url_bits.query
+        return built_url
+
+    def determine_version(self, enclosure, url):
+        """Gets version from enclosure"""
+
+        version = enclosure.get("{%s}version" % self.xmlns)
+
+        if version is None:
+            # Sparkle tries to guess a version from the download URL for
+            # rare cases where there is no sparkle:version enclosure
+            # attribute, for the format: AppnameOrAnything_1.2.3.zip
+            # https://github.com/sparkle-project/Sparkle/blob/
+            # 89081ca030c0de218400f7c0f97530df524d687d/Sparkle/
+            # SUAppcastItem.m#L69-L76
+            #
+            # We can even support OmniGroup's alternate appcast format
+            # by cheating and using the '-' as a delimiter to derive
+            # version info
+            filename = os.path.basename(os.path.splitext(url)[0])
+            for delimiter in ["_", "-"]:
+                if delimiter in filename:
+                    version = filename.split(delimiter)[-1]
+                    break
+        # if we still found nothing, fail
+        if version is None:
+            raise ProcessorError("Can't extract version info from item in feed!")
+        return version
+
+    def parse_feed_data(self, data):
         """Returns an array of dicts, one per update item, structured like:
         version: 1234
         human_version: 1.2.3.4 (optional)
@@ -153,20 +221,6 @@ class SparkleUpdateInfoProvider(Processor):
         metadata we're never going to use. If it's a URL, this must be handled
         by whoever calls this function."""
 
-        # handle custom xmlns and version attributes
-        if "alternate_xmlns_url" in self.env:
-            xmlns = self.env["alternate_xmlns_url"]
-        else:
-            xmlns = DEFAULT_XMLNS
-
-        # query string
-        if "appcast_query_pairs" in self.env:
-            queries = self.env["appcast_query_pairs"]
-            new_query = urllib.urlencode([(k, v) for (k, v) in queries.items()])
-            scheme, netloc, path, _, frag = urlparse.urlsplit(url)
-            url = urlparse.urlunsplit((scheme, netloc, path, new_query, frag))
-
-        data = self.fetch_content(url, headers=self.env.get("appcast_request_headers"))
         try:
             xmldata = ElementTree.fromstring(data)
         except:
@@ -181,98 +235,34 @@ class SparkleUpdateInfoProvider(Processor):
             enclosure = item_elem.find("enclosure")
             if enclosure is not None:
                 item = {}
-                # URL-quote the path component to handle spaces, etc.
-                # (Panic apps do this)
-                url_bits = urlparse.urlsplit(enclosure.get("url"))
-                if self.env.get("urlencode_path_component", True):
-                    encoded_path = urllib.quote(url_bits.path)
-                else:
-                    encoded_path = url_bits.path
-                built_url = url_bits.scheme + "://" + url_bits.netloc + encoded_path
-                if url_bits.query:
-                    built_url += "?" + url_bits.query
-                item["url"] = built_url
+                item["url"] = self.build_url(enclosure)
+                item["version"] = self.determine_version(enclosure, item["url"])
 
-                item["version"] = enclosure.get("{%s}version" % xmlns)
-                if item["version"] is None:
-                    # Sparkle tries to guess a version from the download URL for
-                    # rare cases where there is no sparkle:version enclosure
-                    # attribute, for the format: AppnameOrAnything_1.2.3.zip
-                    # https://github.com/sparkle-project/Sparkle/blob/
-                    # 89081ca030c0de218400f7c0f97530df524d687d/Sparkle/
-                    # SUAppcastItem.m#L69-L76
-                    #
-                    # We can even support OmniGroup's alternate appcast format
-                    # by cheating and using the '-' as a delimiter to derive
-                    # version info
-                    filename = os.path.basename(os.path.splitext(item["url"])[0])
-                    for delimiter in ["_", "-"]:
-                        if delimiter in filename:
-                            item["version"] = filename.split(delimiter)[-1]
-                            break
-                # if we still found nothing, fail
-                if item["version"] is None:
-                    raise ProcessorError(
-                        "Can't extract version info from item in feed!"
-                    )
-
-                human_version = enclosure.get("{%s}shortVersionString" % xmlns)
+                human_version = enclosure.get("{%s}shortVersionString" % self.xmlns)
                 if human_version is not None:
                     item["human_version"] = human_version
-                min_version = item_elem.find("{%s}minimumSystemVersion" % xmlns)
+
+                min_version = item_elem.find("{%s}minimumSystemVersion" % self.xmlns)
                 if min_version is not None:
                     item["minimum_os_version"] = min_version.text
-                description_elem = item_elem.find("{%s}releaseNotesLink" % xmlns)
+
+                description_elem = item_elem.find("{%s}releaseNotesLink" % self.xmlns)
                 # Strip possible surrounding whitespace around description_url
                 # element text as we'll be passing this as an argument to a
                 # curl process
                 if description_elem is not None:
                     item["description_url"] = description_elem.text.strip()
+
                 if item_elem.find("description") is not None:
                     item["description_data"] = item_elem.find("description").text
                 versions.append(item)
 
         return versions
 
-    def main(self):
-        """Get URL for latest version in update feed"""
-
-        def compare_version(this, that):
-            """Compare loose versions"""
-            # cmp() doesn't exist in Python3, so this uses the suggested
-            # solutions from What's New In Python 3.0:
-            # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
-            # This will be refactored in Python 3.
-            this_comparison = LooseVersion(this) > LooseVersion(that)
-            that_comparison = LooseVersion(this) < LooseVersion(that)
-            return this_comparison - that_comparison
-
-        if "PKG" in self.env:
-            self.output("Local PKG provided, no downloaded needed.")
-            self.output(
-                "WARNING: Skipping this processor means output "
-                "variables 'version', 'additional_pkginfo' will "
-                "not contain useful info. If these are needed "
-                "in other recipe steps, this may give unexpected "
-                "results."
-            )
-            self.env["url"] = self.env.get("PKG")
-            self.env["additional_pkginfo"] = {}
-            self.env["version"] = "NotSetBySparkleUpdateInfoProvider"
-            return
-
-        items = self.get_feed_data(self.env.get("appcast_url"))
-        sorted_items = sorted(items, key=itemgetter("version"), cmp=compare_version)
-        latest = sorted_items[-1]
-        self.output("Version retrieved from appcast: %s" % latest["version"])
-        if latest.get("human_version"):
-            self.output(
-                "User-facing version retrieved from appcast: %s"
-                % latest["human_version"]
-            )
+    def handle_pkginfo(self, latest):
+        """Handles any keys we may have defined"""
 
         pkginfo = {}
-        # Handle any keys we may have defined
         sparkle_pkginfo_keys = self.env.get("pkginfo_keys_to_copy_from_sparkle_feed")
         if sparkle_pkginfo_keys:
             for k in sparkle_pkginfo_keys:
@@ -301,6 +291,53 @@ class SparkleUpdateInfoProvider(Processor):
                     "Copied key %s from Sparkle feed to additional "
                     "pkginfo." % copied_key
                 )
+        return pkginfo
+
+    def main(self):
+        """Get URL for latest version in update feed"""
+
+        def compare_version(this, that):
+            """Compare loose versions"""
+            # cmp() doesn't exist in Python3, so this uses the suggested
+            # solutions from What's New In Python 3.0:
+            # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
+            # This will be refactored in Python 3.
+            this_comparison = LooseVersion(this) > LooseVersion(that)
+            that_comparison = LooseVersion(this) < LooseVersion(that)
+            return this_comparison - that_comparison
+
+        if "PKG" in self.env:
+            self.output("Local PKG provided, no downloaded needed.")
+            self.output(
+                "WARNING: Skipping this processor means output "
+                "variables 'version', 'additional_pkginfo' will "
+                "not contain useful info. If these are needed "
+                "in other recipe steps, this may give unexpected "
+                "results."
+            )
+            self.env["url"] = self.env.get("PKG")
+            self.env["additional_pkginfo"] = {}
+            self.env["version"] = "NotSetBySparkleUpdateInfoProvider"
+            return
+
+        # handle custom xmlns and version attributes
+        if "alternate_xmlns_url" in self.env:
+            self.xmlns = self.env["alternate_xmlns_url"]
+        else:
+            self.xmlns = DEFAULT_XMLNS
+
+        data = self.get_feed_data(self.env.get("appcast_url"))
+        items = self.parse_feed_data(data)
+        sorted_items = sorted(items, key=itemgetter("version"), cmp=compare_version)
+        latest = sorted_items[-1]
+        self.output("Version retrieved from appcast: %s" % latest["version"])
+        if latest.get("human_version"):
+            self.output(
+                "User-facing version retrieved from appcast: %s"
+                % latest["human_version"]
+            )
+
+        pkginfo = self.handle_pkginfo(latest)
 
         self.env["url"] = latest["url"]
         if latest.get("human_version"):

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 #
+# Refactoring 2018 Michal Moravec
 # Copyright 2015 Greg Neagle
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +17,10 @@
 """See docstring for URLDownloader class"""
 
 import os.path
-import subprocess
 import tempfile
-import time
 
-from autopkglib import BUNDLE_ID, Processor, ProcessorError, is_mac
+from autopkglib import BUNDLE_ID, ProcessorError, is_mac
+from autopkglib.URLGetter import URLGetter
 
 if is_mac():
     import xattr
@@ -28,20 +28,8 @@ if is_mac():
 
 __all__ = ["URLDownloader"]
 
-# XATTR names for Etag and Last-Modified headers
-XATTR_ETAG = "%s.etag" % BUNDLE_ID
-XATTR_LAST_MODIFIED = "%s.last-modified" % BUNDLE_ID
 
-
-def getxattr(pathname, attr):
-    """Get a named xattr from a file. Return None if not present"""
-    if attr in xattr.listxattr(pathname):
-        return xattr.getxattr(pathname, attr)
-    else:
-        return None
-
-
-class URLDownloader(Processor):
+class URLDownloader(URLGetter):
     """Downloads a URL to the specified download_dir using curl."""
 
     description = __doc__
@@ -116,57 +104,16 @@ class URLDownloader(Processor):
         },
     }
 
-    def main(self):
-        if not is_mac():
-            raise ProcessorError("This processor is Mac-only!")
-        # clear any pre-exising summary result
-        if "url_downloader_summary_result" in self.env:
-            del self.env["url_downloader_summary_result"]
+    def getxattr(self, attr):
+        """Get a named xattr from a file. Return None if not present"""
+        if attr in xattr.listxattr(self.env["pathname"]):
+            return xattr.getxattr(self.env["pathname"], attr)
+        return None
 
-        self.env["last_modified"] = ""
-        self.env["etag"] = ""
-        existing_file_size = None
-
-        if "PKG" in self.env:
-            self.env["pathname"] = os.path.expanduser(self.env["PKG"])
-            self.env["download_changed"] = True
-            self.output("Given %s, no download needed." % self.env["pathname"])
-            return
-
-        if "filename" not in self.env:
-            # Generate filename.
-            filename = self.env["url"].rpartition("/")[2]
-        else:
-            filename = self.env["filename"]
-        download_dir = self.env.get("download_dir") or os.path.join(
-            self.env["RECIPE_CACHE_DIR"], "downloads"
-        )
-        pathname = os.path.join(download_dir, filename)
-        # Save pathname to environment
-        self.env["pathname"] = pathname
-
-        # create download_dir if needed
-        if not os.path.exists(download_dir):
-            try:
-                os.makedirs(download_dir)
-            except OSError as err:
-                raise ProcessorError(
-                    "Can't create %s: %s" % (download_dir, err.strerror)
-                )
-
-        # Create a temp file
-        temporary_file = tempfile.NamedTemporaryFile(dir=download_dir, delete=False)
-        pathname_temporary = temporary_file.name
-        # Set permissions on the temp file as curl would set for a newly-downloaded
-        # file. NamedTemporaryFile uses mkstemp(), which sets a mode of 0600, and
-        # this can cause issues if this item is eventually copied to a Munki repo
-        # with the same permissions and the file is inaccessible by (for example)
-        # the webserver.
-        os.chmod(pathname_temporary, 0o644)
-
-        # construct curl command.
+    def prepare_curl_cmd(self, pathname_temporary):
+        """Assemble curl command and return it."""
         curl_cmd = [
-            self.env["CURL_PATH"],
+            super(URLDownloader, self).curl_binary(),
             "--silent",
             "--show-error",
             "--no-buffer",
@@ -182,117 +129,86 @@ class URLDownloader(Processor):
             pathname_temporary,
         ]
 
-        if "request_headers" in self.env:
-            headers = self.env["request_headers"]
-            for header, value in headers.items():
-                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+        super(URLDownloader, self).add_curl_common_opts(curl_cmd)
 
-        if "curl_opts" in self.env:
-            for item in self.env["curl_opts"]:
-                curl_cmd.extend([item])
-
-        # if file already exists and the size is 0, discard it and download
-        # again
-        if os.path.exists(pathname) and os.path.getsize(pathname) == 0:
-            os.remove(pathname)
+        # if file already exists and the size is 0, discard it and download again
+        if (
+            os.path.exists(self.env["pathname"])
+            and os.path.getsize(self.env["pathname"]) == 0
+        ):
+            os.remove(self.env["pathname"])
 
         # if file already exists, add some headers to the request
         # so we don't retrieve the content if it hasn't changed
-        if os.path.exists(pathname):
-            existing_file_size = os.path.getsize(pathname)
-            etag = getxattr(pathname, XATTR_ETAG)
-            last_modified = getxattr(pathname, XATTR_LAST_MODIFIED)
+        if os.path.exists(self.env["pathname"]):
+            self.existing_file_size = os.path.getsize(self.env["pathname"])
+            etag = self.getxattr(self.xattr_etag)
+            last_modified = self.getxattr(self.xattr_last_modified)
             if etag:
                 curl_cmd.extend(["--header", "If-None-Match: %s" % etag])
             if last_modified:
                 curl_cmd.extend(["--header", "If-Modified-Since: %s" % last_modified])
 
-        # Open URL.
-        proc = subprocess.Popen(
-            curl_cmd,
-            shell=False,
-            bufsize=1,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        return curl_cmd
+
+    def clear_vars(self):
+        """Clear and initializace variables"""
+        # Delete summary result if exists
+        if "url_downloader_summary_result" in self.env:
+            del self.env["url_downloader_summary_result"]
+
+        # XATTR names for Etag and Last-Modified headers
+        self.xattr_etag = "%s.etag" % BUNDLE_ID
+        self.xattr_last_modified = "%s.last-modified" % BUNDLE_ID
+
+        self.env["last_modified"] = ""
+        self.env["etag"] = ""
+        self.existing_file_size = None
+
+    def get_filename(self):
+        """Obtain filename from PKG variable or URL."""
+        if "PKG" in self.env:
+            self.env["pathname"] = os.path.expanduser(self.env["PKG"])
+            self.env["download_changed"] = True
+            self.output("Given %s, no download needed." % self.env["pathname"])
+            return None
+
+        if "filename" in self.env:
+            filename = self.env["filename"]
+        else:
+            # Generate filename from URL.
+            filename = self.env["url"].rpartition("/")[2]
+
+        return filename
+
+    def get_download_dir(self):
+        """Create download dir and return its path."""
+        download_dir = self.env.get("download_dir") or os.path.join(
+            self.env["RECIPE_CACHE_DIR"], "downloads"
         )
-
-        donewithheaders = False
-        maxheaders = 15
-        header = {}
-        header["http_result_code"] = "000"
-        header["http_result_description"] = ""
-        while True:
-            if not donewithheaders:
-                info = proc.stdout.readline().strip("\r\n")
-                if info.startswith("HTTP/"):
-                    try:
-                        header["http_result_code"] = info.split(None, 2)[1]
-                        header["http_result_description"] = info.split(None, 2)[2]
-                    except IndexError:
-                        pass
-                elif ": " in info:
-                    # got a header line
-                    part = info.split(None, 1)
-                    fieldname = part[0].rstrip(":").lower()
-                    try:
-                        header[fieldname] = part[1]
-                    except IndexError:
-                        header[fieldname] = ""
-                elif self.env["url"].startswith("ftp://"):
-                    part = info.split(None, 1)
-                    responsecode = part[0]
-                    if responsecode == "213":
-                        # This is the reply to curl's SIZE command on the file
-                        # We can map it to the HTTP content-length header
-                        try:
-                            header["content-length"] = part[1]
-                        except IndexError:
-                            pass
-                    elif responsecode.startswith("55"):
-                        header["http_result_code"] = "404"
-                        header["http_result_description"] = info
-                    elif responsecode == "150" or responsecode == "125":
-                        header["http_result_code"] = "200"
-                        header["http_result_description"] = info
-                        donewithheaders = True
-                elif info == "":
-                    # we got an empty line; end of headers (or curl exited)
-                    if header.get("http_result_code") in [
-                        "301",
-                        "302",
-                        "303",
-                        "307",
-                        "308",
-                    ]:
-                        # redirect, so more headers are coming.
-                        # Throw away the headers we've received so far
-                        header = {}
-                        header["http_result_code"] = "000"
-                        header["http_result_description"] = ""
-                    else:
-                        donewithheaders = True
-            else:
-                time.sleep(0.1)
-
-            if proc.poll() is not None:
-                # For small download files curl may exit before all headers
-                # have been parsed, don't immediately exit.
-                maxheaders -= 1
-                if donewithheaders or maxheaders <= 0:
-                    break
-
-        retcode = proc.poll()
-        if retcode:  # Non-zero exit code from curl => problem with download
-            curlerr = ""
+        if not os.path.exists(download_dir):
             try:
-                curlerr = proc.stderr.read().rstrip("\n")
-                curlerr = curlerr.split(None, 2)[2]
-            except IndexError:
-                pass
+                os.makedirs(download_dir)
+            except OSError as err:
+                raise ProcessorError(
+                    "Can't create %s: %s" % (download_dir, err.strerror)
+                )
+        return download_dir
 
-            raise ProcessorError("Curl failure: %s (exit code %s)" % (curlerr, retcode))
+    def create_temp_file(self, download_dir):
+        """Create temporary file and return its path."""
+        temporary_file = tempfile.NamedTemporaryFile(dir=download_dir, delete=False)
+        pathname_temporary = temporary_file.name
+        # Set permissions on the temp file as curl would set for a newly-downloaded
+        # file. NamedTemporaryFile uses mkstemp(), which sets a mode of 0600, and
+        # this can cause issues if this item is eventually copied to a Munki repo
+        # with the same permissions and the file is inaccessible by (for example)
+        # the webserver.
+        os.chmod(pathname_temporary, 0o644)
+        return pathname_temporary
 
+    def download_changed(self, header):
+        """Check if downloaded file changed on server."""
         # If Content-Length header is present and we had a cached
         # file, see if it matches the size of the cached file.
         # Useful for webservers that don't provide Last-Modified
@@ -301,7 +217,7 @@ class URLDownloader(Processor):
             "CHECK_FILESIZE_ONLY"
         ]:
             size_header = header.get("content-length")
-            if size_header and int(size_header) == existing_file_size:
+            if size_header and int(size_header) == self.existing_file_size:
                 self.env["download_changed"] = False
                 self.output(
                     "File size returned by webserver matches that "
@@ -312,50 +228,90 @@ class URLDownloader(Processor):
                     "fallback mechanism that does not guarantee "
                     "that a build is unchanged."
                 )
-                self.output("Using existing %s" % pathname)
-                return
+                self.output("Using existing %s" % self.env["pathname"])
+                return False
 
         if header["http_result_code"] == "304":
             # resource not modified
             self.env["download_changed"] = False
             self.output("Item at URL is unchanged.")
-            self.output("Using existing %s" % pathname)
+            self.output("Using existing %s" % self.env["pathname"])
+            return False
 
-            # Discard the temp file
-            os.remove(pathname_temporary)
+        return True
 
-            return
-
-        self.env["download_changed"] = True
-
-        # New resource was downloaded. Move the temporary download file
-        # to the pathname
-        if os.path.exists(pathname):
-            os.remove(pathname)
+    def move_temp_file(self, pathname_temporary):
+        """Move temporary download file to pathname."""
+        if os.path.exists(self.env["pathname"]):
+            os.remove(self.env["pathname"])
         try:
-            os.rename(pathname_temporary, pathname)
+            os.rename(pathname_temporary, self.env["pathname"])
         except OSError:
-            raise ProcessorError("Can't move %s to %s" % (pathname_temporary, pathname))
+            raise ProcessorError(
+                "Can't move %s to %s" % (pathname_temporary, self.env["pathname"])
+            )
 
-        # save last-modified header if it exists
+    def store_headers(self, header):
+        """Store last-modified and etag headers in pathname xattr."""
         if header.get("last-modified"):
             self.env["last_modified"] = header.get("last-modified")
-            xattr.setxattr(pathname, XATTR_LAST_MODIFIED, header.get("last-modified"))
+            xattr.setxattr(
+                self.env["pathname"],
+                self.xattr_last_modified,
+                header.get("last-modified"),
+            )
             self.output(
                 "Storing new Last-Modified header: %s" % header.get("last-modified")
             )
 
-        # save etag if it exists
         self.env["etag"] = ""
         if header.get("etag"):
             self.env["etag"] = header.get("etag")
-            xattr.setxattr(pathname, XATTR_ETAG, header.get("etag"))
+            xattr.setxattr(self.env["pathname"], self.xattr_etag, header.get("etag"))
             self.output("Storing new ETag header: %s" % header.get("etag"))
 
-        self.output("Downloaded %s" % pathname)
+    def main(self):
+        if not is_mac():
+            raise ProcessorError("This processor is Mac-only!")
+
+        # Clear and initiazize data structures
+        self.clear_vars()
+
+        # Ensure existence of necessary files, directories and paths
+        filename = self.get_filename()
+        if filename is None:
+            return
+        download_dir = self.get_download_dir()
+        self.env["pathname"] = os.path.join(download_dir, filename)
+        pathname_temporary = self.create_temp_file(download_dir)
+
+        # Prepare curl command
+        curl_cmd = self.prepare_curl_cmd(pathname_temporary)
+
+        # Execute curl command and parse headers
+        raw_header = super(URLDownloader, self).download(curl_cmd)
+        header = {}
+        super(URLDownloader, self).clear_header(header)
+        super(URLDownloader, self).parse_headers(raw_header, header)
+
+        if self.download_changed(header):
+            self.env["download_changed"] = True
+        else:
+            # Discard the temp file
+            os.remove(pathname_temporary)
+            return
+
+        # New resource was downloaded. Move the temporary download file to the pathname
+        self.move_temp_file(pathname_temporary)
+
+        # Save last-modified and etag headers to files xattr
+        self.store_headers(header)
+
+        # Generate output messages and variables
+        self.output("Downloaded %s" % self.env["pathname"])
         self.env["url_downloader_summary_result"] = {
             "summary_text": "The following new items were downloaded:",
-            "data": {"download_path": pathname},
+            "data": {"download_path": self.env["pathname"]},
         }
 
 

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -78,7 +78,7 @@ class URLGetter(Processor):
             curl_cmd.extend([item])
 
     def clear_header(self, header):
-        """Initialize dictionary for parsed headers and return it"""
+        """Clear header dictionary"""
         header.clear()
         header["http_result_code"] = "000"
         header["http_result_description"] = ""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -168,7 +168,7 @@ class URLGetter(Processor):
         return proc_stdout, proc_stderr, retcode
 
     def download(self, curl_cmd):
-        """Downloads file using curl and returns raw headers."""
+        """Launches curl returns its output and handles failures."""
 
         proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)
 

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python
+#
+# Copyright 2018 Michal Moravec
+# Based on code from Greg Neagle, Timothy Sutton and Per Olofsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for URLGetter class"""
+
+import os.path
+import subprocess
+
+from autopkglib import Processor, ProcessorError, get_pref, log_err
+
+__all__ = ["URLGetter"]
+
+
+class URLGetter(Processor):
+    """Handles curl HTTP operatios. Server only as superclass. Not for direct use."""
+
+    description = __doc__
+
+    def curl_binary(self):
+        """Returns a path to a curl binary, priority in the order below.
+        Returns None if none found.
+        1. env['CURL_PATH']
+        2. app pref 'CURL_PATH'
+        3. a 'curl' binary that can be found in the PATH environment variable
+        4. '/usr/bin/curl'
+        """
+
+        def is_executable(exe_path):
+            """Is exe_path executable?"""
+            return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
+
+        if "CURL_PATH" in self.env and is_executable(self.env["CURL_PATH"]):
+            return self.env["CURL_PATH"]
+
+        curl_path_pref = get_pref("CURL_PATH")
+        if curl_path_pref:
+            if is_executable(curl_path_pref):
+                # take a CURL_PATH pref
+                return curl_path_pref
+            else:
+                log_err(
+                    "WARNING: Curl path given in the 'CURL_PATH' preference:'%s' "
+                    "either doesn't exist or is not executable! Falling back "
+                    "to one set in PATH, or /usr/bin/curl." % curl_path_pref
+                )
+
+        for path_env in os.environ["PATH"].split(":"):
+            curlbin = os.path.join(path_env, "curl")
+            if is_executable(curlbin):
+                # take the first 'curl' in PATH that we find
+                return curlbin
+
+        if is_executable("/usr/bin/curl"):
+            # fall back to /usr/bin/curl
+            return "/usr/bin/curl"
+
+        raise ProcessorError("Unable to execute any curl binary")
+
+    def add_curl_common_opts(self, curl_cmd):
+        """Adds request_headers and curl_opts to curl_cmd"""
+        if "request_headers" in self.env:
+            headers = self.env["request_headers"]
+            for header, value in headers.items():
+                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+        if "curl_opts" in self.env:
+            for item in self.env["curl_opts"]:
+                curl_cmd.extend([item])
+
+    def clear_header(self, header):
+        """Initialize dictionary for parsed headers and return it"""
+        header.clear()
+        header["http_result_code"] = "000"
+        header["http_result_description"] = ""
+
+    def parse_http_protocol(self, line, header):
+        """Parse first HTTP header line"""
+        try:
+            header["http_result_code"] = line.split(None, 2)[1]
+            header["http_result_description"] = line.split(None, 2)[2]
+        except IndexError:
+            pass
+
+    def parse_http_header(self, line, header):
+        """Parse single HTTP header line."""
+        part = line.split(None, 1)
+        fieldname = part[0].rstrip(":").lower()
+        try:
+            header[fieldname] = part[1]
+        except IndexError:
+            header[fieldname] = ""
+
+    def parse_curl_error(self, proc_stderr):
+        """Report Curl failure."""
+        curl_err = ""
+        try:
+            curl_err = proc_stderr.rstrip("\n")
+            curl_err = curl_err.split(None, 2)[2]
+        except IndexError:
+            pass
+
+        return curl_err
+
+    def parse_ftp_header(self, line, header):
+        """Parse single FTP header line."""
+        part = line.split(None, 1)
+        responsecode = part[0]
+        if responsecode == "213":
+            # This is the reply to curl's SIZE command on the file
+            # We can map it to the HTTP content-length header
+            try:
+                header["content-length"] = part[1]
+            except IndexError:
+                pass
+        elif responsecode.startswith("55"):
+            header["http_result_code"] = "404"
+            header["http_result_description"] = line
+        elif responsecode == "150" or responsecode == "125":
+            header["http_result_code"] = "200"
+            header["http_result_description"] = line
+
+    def parse_headers(self, proc_stdout, header):
+        """Parse headers from Curl."""
+        for line in proc_stdout.splitlines():
+            if line.startswith("HTTP/"):
+                self.parse_http_protocol(line, header)
+            elif ": " in line:
+                self.parse_http_header(line, header)
+            elif self.env["url"].startswith("ftp://"):
+                self.parse_ftp_header(line, header)
+            elif line == "":
+                # we got an empty line; end of headers (or curl exited)
+                if header.get("http_result_code") in [
+                    "301",
+                    "302",
+                    "303",
+                    "307",
+                    "308",
+                ]:
+                    # redirect, so more headers are coming.
+                    # Throw away the headers we've received so far
+                    self.clear_header(header)
+
+    def execute_curl(self, curl_cmd):
+        """Executes curl comamnd. Returns stdout, stderr and return code."""
+        proc = subprocess.Popen(
+            curl_cmd,
+            shell=False,
+            bufsize=1,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        proc_stdout, proc_stderr = proc.communicate()
+        retcode = proc.returncode
+
+        return proc_stdout, proc_stderr, retcode
+
+    def download(self, curl_cmd):
+        """Downloads file using curl and returns raw headers."""
+
+        proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)
+
+        if retcode:  # Non-zero exit code from curl => problem with download
+            curl_err = self.parse_curl_error(proc_stderr)
+            raise ProcessorError(
+                "Curl failure: %s (exit code %s)" % (curl_err, retcode)
+            )
+
+        return proc_stdout
+
+    def main(self):
+        pass
+
+
+if __name__ == "__main__":
+    PROCESSOR = URLGetter()
+    PROCESSOR.execute_shell()

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -71,13 +71,11 @@ class URLGetter(Processor):
 
     def add_curl_common_opts(self, curl_cmd):
         """Adds request_headers and curl_opts to curl_cmd"""
-        if "request_headers" in self.env:
-            headers = self.env["request_headers"]
-            for header, value in headers.items():
-                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
-        if "curl_opts" in self.env:
-            for item in self.env["curl_opts"]:
-                curl_cmd.extend([item])
+        for header, value in self.env.get("request_headers", {}).items():
+            curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+
+        for item in self.env.get("curl_opts", []):
+            curl_cmd.extend([item])
 
     def clear_header(self, header):
         """Initialize dictionary for parsed headers and return it"""

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 #
+# Refactoring 2018 Michal Moravec
 # Copyright 2015 Greg Neagle
 # Based on URLTextSearcher.py, Copyright 2014 Jesse Peterson
 #
@@ -17,14 +18,14 @@
 """See docstring for URLTextSearcher class"""
 
 import re
-import subprocess
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import ProcessorError
+from autopkglib.URLGetter import URLGetter
 
 __all__ = ["URLTextSearcher"]
 
 
-class URLTextSearcher(Processor):
+class URLTextSearcher(URLGetter):
     """Downloads a URL using curl and performs a regular expression match
     on the text.
 
@@ -85,37 +86,30 @@ class URLTextSearcher(Processor):
 
     description = __doc__
 
-    def get_url_and_search(self, url, re_pattern, headers=None, flags=None, opts=None):
-        """Get data from url and search for re_pattern"""
-        # pylint: disable=no-self-use
+    def prepare_curl_cmd(self):
+        """Assemble curl command and return it."""
+        curl_cmd = [
+            super(URLTextSearcher, self).curl_binary(),
+            "--location",
+            "--compressed",
+        ]
+        super(URLTextSearcher, self).add_curl_common_opts(curl_cmd)
+        curl_cmd.append(self.env["url"])
+        return curl_cmd
+
+    def re_search(self, content):
+        """Search for re_pattern in content"""
         flag_accumulator = 0
+        flags = self.env.get("re_flags", {})
         if flags:
             for flag in flags:
                 if flag in re.__dict__:
                     flag_accumulator += re.__dict__[flag]
-
-        re_pattern = re.compile(re_pattern, flags=flag_accumulator)
-
-        try:
-            cmd = [self.env["CURL_PATH"], "--location", "--compressed"]
-            if headers:
-                for header, value in headers.items():
-                    cmd.extend(["--header", "%s: %s" % (header, value)])
-            if opts:
-                for item in opts:
-                    cmd.extend([item])
-            cmd.append(url)
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (content, stderr) = proc.communicate()
-            if proc.returncode:
-                raise ProcessorError("Could not retrieve URL %s: %s" % (url, stderr))
-        except OSError:
-            raise ProcessorError("Could not retrieve URL: %s" % url)
-
+        re_pattern = re.compile(self.env["re_pattern"], flags=flag_accumulator)
         match = re_pattern.search(content)
 
         if not match:
-            raise ProcessorError("No match found on URL: %s" % url)
+            raise ProcessorError("No match found on URL: %s" % self.env["url"])
 
         # return the last matched group with the dict of named groups
         return (match.group(match.lastindex or 0), match.groupdict())
@@ -123,15 +117,12 @@ class URLTextSearcher(Processor):
     def main(self):
         output_var_name = self.env["result_output_var_name"]
 
-        headers = self.env.get("request_headers", {})
+        # Prepare curl command
+        curl_cmd = self.prepare_curl_cmd()
 
-        flags = self.env.get("re_flags", {})
-
-        opts = self.env.get("curl_opts", [])
-
-        groupmatch, groupdict = self.get_url_and_search(
-            self.env["url"], self.env["re_pattern"], headers, flags, opts
-        )
+        # Execute curl command and search in content
+        content = super(URLTextSearcher, self).download(curl_cmd)
+        groupmatch, groupdict = self.re_search(content)
 
         # favor a named group over a normal group match
         if output_var_name not in groupdict.keys():

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -100,11 +100,9 @@ class URLTextSearcher(URLGetter):
     def re_search(self, content):
         """Search for re_pattern in content"""
         flag_accumulator = 0
-        flags = self.env.get("re_flags", {})
-        if flags:
-            for flag in flags:
-                if flag in re.__dict__:
-                    flag_accumulator += re.__dict__[flag]
+        for flag in self.env.get("re_flags", {}):
+            if flag in re.__dict__:
+                flag_accumulator += re.__dict__[flag]
         re_pattern = re.compile(self.env["re_pattern"], flags=flag_accumulator)
         match = re_pattern.search(content)
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -265,40 +265,6 @@ def update_data(a_dict, key, value):
     a_dict[key] = do_variable_substitution(value)
 
 
-def curl_cmd():
-    """Returns a path to a curl binary, priority in the order below.
-    Returns None if none found.
-    1. app pref 'CURL_PATH'
-    2. a 'curl' binary that can be found in the PATH environment variable
-    3. '/usr/bin/curl'
-    """
-
-    def is_executable(exe_path):
-        """Is exe_path executable?"""
-        return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
-
-    curl_path_pref = get_pref("CURL_PATH")
-    if curl_path_pref:
-        if is_executable(curl_path_pref):
-            # take a CURL_PATH pref
-            return curl_path_pref
-        else:
-            log_err(
-                "WARNING: Curl path given in the 'CURL_PATH' preference:'%s' "
-                "either doesn't exist or is not executable! Falling back "
-                "to one set in PATH, or /usr/bin/curl." % curl_path_pref
-            )
-    for path_env in os.environ["PATH"].split(":"):
-        curlbin = os.path.join(path_env, "curl")
-        if is_executable(curlbin):
-            # take the first 'curl' in PATH that we find
-            return curlbin
-    if is_executable("/usr/bin/curl"):
-        # fall back to /usr/bin/curl
-        return "/usr/bin/curl"
-    return None
-
-
 # Processor and ProcessorError base class definitions
 
 

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -61,7 +61,7 @@ class GitHubSession(URLGetter):
         if it exists."""
 
         if not os.path.exists(TOKEN_LOCATION):
-            log(
+            print(
                 """Create a new token in your GitHub settings page:
 
     https://github.com/settings/tokens


### PR DESCRIPTION
My original goal was to fix problem with autopkg not downloading files through HTTP proxy #416 
However when going through the code I found out it was somewhat unsatisfactory (very long functions, bad coding habits , etc.). Only thing to do was the *Right Thing* -> bit of refactoring.

- This PR introduces `URLGetter` class (suggested in https://github.com/autopkg/autopkg/issues/416#issuecomment-386764735). `URLGetter` is responsible for launching `curl` via subprocess and handling generic `curl` functionality like parsing HTTP headers. Classes `URLDownloader`, `URLTextSearcher`, `GitHubSession`, and `SparkleUpdateInfoProvider` are now subclasses of `URLGetter`. 
- HTTP header parsing is now done after the download. There is no infinite loop with break conditions, polling the subprocesses for output and magic constants like `maxheaders`.
- Code in classes  `URLDownloader`, `URLTextSearcher`, `GitHubSession`, and `SparkleUpdateInfoProvider` has been refactored. I tried to split it into sensible methods. Almost all `pylint` issues are now fixed.
- Refactoring the code handling `subprocess` and HTTP header parsing Fixes #416 by itself
- Fixes [issue](https://groups.google.com/forum/#!topic/autopkg-discuss/E6o9iHsSLSs) with redownloading files when using proxy 
- `curl_opts` input variable is now present in all subclasses of `URLGetter`.
- ~~https://github.com/MichalMMac/autopkg/commit/c0024278099cf3841a776c9005a7426ca0df9802  attempts to deal with #432. There is  a new `rename_after_redirect` input variable in `URLDownloader`. See the description.~~

I tried to [reach out](https://groups.google.com/forum/#!topic/autopkg-discuss/i4FswIat6GA) to AutoPkg google group and MacSysAdmin slack channel without much success. Fellow admins with same problem #416 tested my code successfully. However I belive this PR could use more testing (and RC version if merged).