### PR TITLE
Update description of PkgRootCreator

### DIFF
--- a/Code/autopkglib/PkgRootCreator.py
+++ b/Code/autopkglib/PkgRootCreator.py
@@ -29,7 +29,8 @@ CHUNK_SIZE = 256 * 1024
 
 
 class PkgRootCreator(Processor):
-    """Creates a package root and a directory structure."""
+    """Creates a package root and a directory structure. 
+    (Can also be used to create directory structures for other purposes.)"""
     description = __doc__
     input_variables = {
         "pkgroot": {


### PR DESCRIPTION
As per discussion on MacAdmins Slack on 2019-01-21, added text to the PkgRootCreator description to highlight that it can be used for generic directory creation.