### PR TITLE
Added option to Stop Processing if the URLDownloader reports the download did not change

### DIFF
--- a/Code/autopkglib/StopProcessingIf.py
+++ b/Code/autopkglib/StopProcessingIf.py
@@ -33,11 +33,12 @@ class StopProcessingIf(Processor):
     description = __doc__
     input_variables = {
         "predicate": {
-            "required": True,
+            "required": False,
             "description":
                 ("NSPredicate-style comparison against an environment key. See "
                  "http://developer.apple.com/library/mac/#documentation/"
                  "Cocoa/Conceptual/Predicates/Articles/pSyntax.html"),
+            "default": 'FALSEPREDICATE'
         },
     }
     output_variables = {
@@ -56,7 +57,9 @@ class StopProcessingIf(Processor):
                 % (predicate_string, err))
 
         result = predicate.evaluateWithObject_(self.env)
-        self.output("(%s) is %s" % (predicate_string, result))
+        # Do not output when FALSEPREDICATE set
+        if predicate_string != 'FALSEPREDICATE':
+            self.output("(%s) is %s" % (predicate_string, result))
         return result
 
     def main(self):

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -79,9 +79,9 @@ class URLDownloader(StopProcessingIf):
             "required": False,
             "default": False,
             "description":
-                ("NSPredicate-style comparison against an environment key. See "
-                 "http://developer.apple.com/library/mac/#documentation/"
-                 "Cocoa/Conceptual/Predicates/Articles/pSyntax.html"),
+                ("If True, the StopProcessingIf processor is induced at the"
+                 "end of the process based on the predicate"
+                 "'download_changed == False'"),
         },
         "CHECK_FILESIZE_ONLY": {
             "default": False,


### PR DESCRIPTION
This PR is to give users the option to override recipes to stop processing after `URLDownloader` in the case that the download has not changed. 

There are two parts to this change:

1. This change adds a default of `FALSEPREDICATE` to the `StopProcessingIf` processor. This means that the processor can be added to recipes with no arguments in a recipe, so that users could override the `predicate` value. The default value of `FALSEPREDICATE` always evaluates to `False`, so the processor will do nothing without supplying an argument or being overridden.

2. The `StopProcessingIf` processor is imported into the `URLDownloader` processor. An additional, optional boolean input is added to the `URLDownloader` processor, named `STOP_IF_DOWNLOAD_UNCHANGED`. This means that users could add an additional input of `STOP_IF_DOWNLOAD_UNCHANGED`=`True` in their child recipes or overrides in order to stop processing after `URLDownloader` if the download is unchanged. The default behaviour is of course not altered.

Together, these two steps give AutoPkg users powerful additional flexibility to stop processes at the optimal time (i.e. no code reverification, repackaging or upload to repositories when not required), without changing all existing Download recipes to add a `StopProcessingIf` processor.