### PR TITLE
Failing to verify trust due to NOT FOUND will now exit 1

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1726,6 +1726,7 @@ def verify_trust_info(argv):
                              make_suggestions=True, search_github=False)
         if not recipe:
             log_err('%s: NOT FOUND' % recipe_name)
+            return_code = 1
             continue
         try:
             verify_parent_trust(


### PR DESCRIPTION
Autopkg should return non-zero (specifically, exit 1) if it can't verify trust because the recipe is not found.

Solves #458.