### PR TITLE
MunkiImporter - Adding metadata_additions

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -84,6 +84,13 @@ class MunkiImporter(Processor):
                 "Extension for output pkginfo files. Default is 'plist'.",
             "required": False
         },
+        "metadata_additions": {
+            "description": (
+                "A dictionary that will be added directly into the _metadata "
+                "of the pkginfo"
+            ),
+            "required": False
+        },
     }
     output_variables = {
         "pkginfo_repo_path": {
@@ -479,6 +486,10 @@ class MunkiImporter(Processor):
         if "pkginfo" in self.env:
             for key in self.env["pkginfo"]:
                 pkginfo[key] = self.env["pkginfo"][key]
+
+        # copy any keys from metadata_additions
+        if "metadata_additions" in self.env:
+            pkginfo["_metadata"].update(self.env["metadata_additions"])
 
         # set an alternate version_comparison_key
         # if pkginfo has an installs item

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -86,8 +86,9 @@ class MunkiImporter(Processor):
         },
         "metadata_additions": {
             "description": (
-                "A dictionary that will be added directly into the _metadata "
-                "of the pkginfo"
+                "A dictionary that will be merged with the pkginfo _metadata.  "
+                "Unique keys will be added, but overlapping keys will replace "
+                "existing values."
             ),
             "required": False
         },


### PR DESCRIPTION
Adding a metadata_additions key to the input variables for MunkiImporter.

This allows passing a dictionary of keys/values that will be directly added into the _metadata key of the pkginfo that is generated.

I tested this using Firefox.munki. This is what my override's input variables look like, where I added the `metadata_additions` dictionary:
```
cat /Library/AutoPkg/RecipeOverrides/Firefox.munki.recipe
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>Identifier</key>
        <string>local.munki.Firefox</string>
        <key>Input</key>
        <dict>
                <key>metadata_additions</key>
                <dict>
                        <key>autopkg_build</key>
                        <string>%AUTOPKG_VERSION%</string>
                </dict>
                <key>LOCALE</key>
                <string>en_US</string>
                <key>MUNKI_REPO_SUBDIR</key>
                <string>apps/firefox</string>
                <key>NAME</key>
                <string>Firefox</string>
                <key>RELEASE</key>
                <string>latest</string>
                <key>pkginfo</key>
                <dict>
                        <key>catalogs</key>
                        <array>
                                <string>testing</string>
                        </array>
                        <key>category</key>
                        <string>Web Browsers</string>
                        <key>description</key>
                        <string>Mozilla Firefox is a free and open source web browser.</string>
                        <key>developer</key>
                        <string>Mozilla</string>
                        <key>display_name</key>
                        <string>Mozilla Firefox</string>
                        <key>items_to_copy</key>
                        <array>
                                <dict>
                                        <key>destination_path</key>
                                        <string>/Applications</string>
                                        <key>mode</key>
                                        <string>g+rw</string>
                                        <key>source_item</key>
                                        <string>Firefox.app</string>
                                </dict>
                        </array>
                        <key>name</key>
                        <string>%NAME%</string>
                        <key>unattended_install</key>
                        <true/>
                </dict>
        </dict>
        <key>ParentRecipe</key>
        <string>com.github.autopkg.munki.firefox-rc-en_US</string>
```

Then, `autopkg run -vvv Firefox.munki`. I've edited out the results for relevant portions:
```
Processing Firefox.munki...
{'AUTOPKG_VERSION': u'1.0.5',
...
 u'metadata_additions': {
    "autopkg_build" = "1.0.5";
},
 ...
MunkiImporter
{'Input': {'MUNKI_REPO': u'/Volumes/Repo/it-bin/shelves/cpe_munki/munki_repo',
           'metadata_additions': {
    "autopkg_build" = "1.0.5";
},
           'pkg_path': u'/Volumes/Repo/Cache/local.munki.Firefox/downloads/Firefox.dmg',
           'pkginfo': {
    catalogs =     (
        testing
    );
    category = "Web Browsers";
    description = "Mozilla Firefox is a free and open source web browser.";
    developer = Mozilla;
    "display_name" = "Mozilla Firefox";
    "items_to_copy" =     (
                {
            "destination_path" = "/Applications";
            mode = "g+rw";
            "source_item" = "Firefox.app";
        }
    );
    name = Firefox;
    "unattended_install" = 1;
},
           'repo_subdirectory': u'apps/firefox'}}
MunkiImporter: Copied pkginfo to /Volumes/Repo/it-bin/shelves/cpe_munki/munki_repo/pkgsinfo/apps/firefox/Firefox-66.0.5.plist
MunkiImporter: Copied pkg to /Volumes/Repo/it-bin/shelves/cpe_munki/munki_repo/pkgs/apps/firefox/Firefox-66.0.5.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': u'testing',
                                                       'name': u'Firefox',
                                                       'pkg_repo_path': u'apps/firefox/Firefox-66.0.5.dmg',
                                                       'pkginfo_path': u'apps/firefox/Firefox-66.0.5.plist',
                                                       'version': u'66.0.5'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path'],
                                              'summary_text': 'The following new items were imported into Munki:'},
            'munki_info': {
    "_metadata" =     {
        "autopkg_build" = "1.0.5";
        "created_by" = nmcspadden;
        "creation_date" = "2019-05-09 05:14:45 +0000";
        "munki_version" = "3.6.2.3776";
        "os_version" = "10.14.4";
    };
...
The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                       Pkg Repo Path
    ----     -------  --------  ------------                       -------------
    Firefox  66.0.5   testing   apps/firefox/Firefox-66.0.5.plist  apps/firefox/Firefox-66.0.5.dmg
```

Looking at the contents of the plist, the new metadata items are present:
```
$ cat munki_repo/pkgsinfo/apps/firefox/Firefox-66.0.5.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>_metadata</key>
        <dict>
                <key>autopkg_build</key>
                <string>1.0.5</string>
                <key>created_by</key>
                <string>nmcspadden</string>
                <key>creation_date</key>
                <date>2019-05-09T05:14:45Z</date>
                <key>munki_version</key>
                <string>3.6.2.3776</string>
                <key>os_version</key>
                <string>10.14.4</string>
        </dict>
```