### PR TITLE
generate_processor_docs sorts the sidebar alphabetically

### DIFF
--- a/Scripts/generate_processor_docs.py
+++ b/Scripts/generate_processor_docs.py
@@ -40,7 +40,7 @@ imp.load_source("autopkg", os.path.join(CODE_DIR, "autopkg"))
 
 
 def writefile(stringdata, path):
-    '''Writes string data to path.'''
+    """Writes string data to path."""
     try:
         fileobject = open(path, mode='w', buffering=1)
         print(stringdata.encode('UTF-8'), file=fileobject)
@@ -50,8 +50,8 @@ def writefile(stringdata, path):
 
 
 def escape(thing):
-    '''Returns string with underscores and asterisks escaped
-    for use with Markdown'''
+    """Returns string with underscores and asterisks escaped
+    for use with Markdown"""
     string = str(thing)
     string = string.replace("_", r"\_")
     string = string.replace("*", r"\*")
@@ -59,7 +59,7 @@ def escape(thing):
 
 
 def generate_markdown(dict_data, indent=0):
-    '''Returns a string with Markup-style formatting of dict_data'''
+    """Returns a string with Markup-style formatting of dict_data"""
     string = ""
     for key, value in dict_data.items():
         if isinstance(value, dict):
@@ -72,9 +72,9 @@ def generate_markdown(dict_data, indent=0):
 
 
 def clone_wiki_dir(clone_dir=None):
-    '''Clone the AutoPkg GitHub repo and return the path to where it was
+    """Clone the AutoPkg GitHub repo and return the path to where it was
     cloned. The path can be specified with 'clone_dir', otherwise a
-    temporary directory will be used.'''
+    temporary directory will be used."""
 
     if not clone_dir:
         outdir = mkdtemp()
@@ -85,7 +85,7 @@ def clone_wiki_dir(clone_dir=None):
 
 
 def indent_length(line_str):
-    '''Returns the indent length of a given string as an integer.'''
+    """Returns the indent length of a given string as an integer."""
     return len(line_str) - len(line_str.lstrip())
 
 

--- a/Scripts/generate_processor_docs.py
+++ b/Scripts/generate_processor_docs.py
@@ -16,24 +16,26 @@
 """A utility to export info from autopkg processors and upload it as processor
 documentation for the GitHub autopkg wiki"""
 
-import imp
-import os
-import optparse
-import sys
+from __future__ import print_function
 
+import imp
+import optparse
+import os
+import sys
 from tempfile import mkdtemp
+
+from autopkg import run_git
+from autopkglib import get_processor, processor_names
 
 #pylint: disable=import-error
 # Grabbing some functions from the Code directory
 CODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../Code"))
 sys.path.append(CODE_DIR)
-from autopkglib import get_processor, processor_names
 
 # Additional helper function(s) from the CLI tool
 # Don't make an "autopkgc" file
 sys.dont_write_bytecode = True
 imp.load_source("autopkg", os.path.join(CODE_DIR, "autopkg"))
-from autopkg import run_git
 #pylint: enable=import-error
 
 
@@ -41,10 +43,10 @@ def writefile(stringdata, path):
     '''Writes string data to path.'''
     try:
         fileobject = open(path, mode='w', buffering=1)
-        print >> fileobject, stringdata.encode('UTF-8')
+        print(stringdata.encode('UTF-8'), file=fileobject)
         fileobject.close()
     except (OSError, IOError):
-        print >> sys.stderr, "Couldn't write to %s" % path
+        print("Couldn't write to %s" % path, file=fileobject)
 
 
 def escape(thing):
@@ -109,18 +111,17 @@ def main(_):
     # Grab the version for the commit log.
     version = arguments[0]
 
-    print "Cloning AutoPkg wiki.."
-    print
+    print("Cloning AutoPkg wiki..")
+    print()
 
     if options.directory:
         output_dir = clone_wiki_dir(clone_dir=options.directory)
     else:
         output_dir = clone_wiki_dir()
 
-    print "Cloned to %s." % output_dir
-    print
-    print
-
+    print("Cloned to %s." % output_dir)
+    print()
+    print()
 
     # Generate markdown pages for each processor attributes
     for processor_name in processor_names():
@@ -164,7 +165,6 @@ def main(_):
         page_name.replace(" ", "-")
         toc_string += "      * [[%s|%s]]\n" % (processor_name, page_name)
 
-
     # Merge in the new stuff!
     # - Scrape through the current _Sidebar.md, look for where the existing
     # processors block starts and ends
@@ -184,8 +184,10 @@ def main(_):
         if line == processor_heading:
             past_processors_section = True
             processors_start = index
-        if (indent_length(line) <= section_indent) and \
-        past_processors_section:
+        if (
+            (indent_length(line) <= section_indent)
+            and past_processors_section
+        ):
             processors_end = index
 
     # Build the new sidebar
@@ -203,12 +205,12 @@ def main(_):
     run_git(["commit", "-m", "Updating Wiki docs for release %s" % version])
 
     # Show the full diff
-    print run_git(["log", "-p", "--color", "-1"])
+    print(run_git(["log", "-p", "--color", "-1"]))
 
     # Do we accept?
-    print "-------------------------------------------------------------------"
-    print
-    print (
+    print("-------------------------------------------------------------------")
+    print()
+    print(
         "Shown above is the commit log for the changes to the wiki markdown. \n"
         "Type 'push' to accept and push the changes to GitHub. The wiki repo \n"
         "local clone can be also inspected at:\n"
@@ -217,6 +219,7 @@ def main(_):
     push_commit = raw_input()
     if push_commit == "push":
         run_git(["push", "origin", "master"])
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/Scripts/generate_processor_docs.py
+++ b/Scripts/generate_processor_docs.py
@@ -23,6 +23,7 @@ import optparse
 import os
 import sys
 from tempfile import mkdtemp
+from textwrap import dedent
 
 #pylint: disable=import-error
 # Grabbing some functions from the Code directory
@@ -98,18 +99,22 @@ def indent_length(line_str):
 
 def main(_):
     """Do it all"""
-    usage = """%prog VERSION
+    usage = dedent("""%prog VERSION
 
-..where VERSION is the release version for which docs are being generated."""
+    ..where VERSION is the release version for which docs are being generated.""")
     parser = optparse.OptionParser(usage=usage)
     parser.description = (
         "Generate GitHub Wiki documentation from the core processors present "
         "in autopkglib. The autopkg.wiki repo is cloned locally, changes are "
         "committed, a diff shown and the user is interactively given the "
         "option to push to the remote.")
-    parser.add_option("-d", "--directory", metavar="CLONEDIRECTORY",
-                      help=("Directory path in which to clone the repo. If not "
-                            "specified, a temporary directory will be used."))
+    parser.add_option(
+        "-d", "--directory", metavar="CLONEDIRECTORY",
+        help=(
+            "Directory path in which to clone the repo. If not "
+            "specified, a temporary directory will be used."
+        )
+    )
     options, arguments = parser.parse_args()
     if len(arguments) < 1:
         parser.print_usage()
@@ -167,7 +172,7 @@ def main(_):
     processor_heading = "  * **Processor Reference**"
     toc_string = ""
     toc_string += processor_heading + "\n"
-    for processor_name in processor_names():
+    for processor_name in sorted(processor_names()):
         page_name = "Processor-%s" % processor_name
         page_name.replace(" ", "-")
         toc_string += "      * [[%s|%s]]\n" % (processor_name, page_name)

--- a/Scripts/generate_processor_docs.py
+++ b/Scripts/generate_processor_docs.py
@@ -24,18 +24,25 @@ import os
 import sys
 from tempfile import mkdtemp
 
-from autopkg import run_git
-from autopkglib import get_processor, processor_names
-
 #pylint: disable=import-error
 # Grabbing some functions from the Code directory
-CODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../Code"))
-sys.path.append(CODE_DIR)
+try:
+    CODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../Code"))
+    sys.path.append(CODE_DIR)
+    from autopkglib import get_processor, processor_names
+except ImportError:
+    print("Unable to import code from autopkglib!", file=sys.stderr)
+    sys.exit(1)
 
 # Additional helper function(s) from the CLI tool
 # Don't make an "autopkgc" file
-sys.dont_write_bytecode = True
-imp.load_source("autopkg", os.path.join(CODE_DIR, "autopkg"))
+try:
+    sys.dont_write_bytecode = True
+    imp.load_source("autopkg", os.path.join(CODE_DIR, "autopkg"))
+    from autopkg import run_git
+except ImportError:
+    print("Unable to import code from autopkg!", file=sys.stderr)
+    sys.exit(1)
 #pylint: enable=import-error
 
 


### PR DESCRIPTION
This fixes generate_processor_docs.py to ensure the sidebar always ends up being sorted alphabetically.

Running this:
```
$ generate_processor_docs.py 1.0.5
```
produces (processor-based results are truncated):
```
diff --git a/_Sidebar.md b/_Sidebar.md
index 1715e7b..75b75c6 100644
--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -29,10 +29,10 @@
       * [[AppDmgVersioner|Processor-AppDmgVersioner]]
       * [[AppPkgCreator|Processor-AppPkgCreator]]
       * [[BrewCaskInfoProvider|Processor-BrewCaskInfoProvider]]
-      * [[CodeSignatureVerifier|Processor-CodeSignatureVerifier]]
-      * [[Copier|Processor-Copier]]
       * [[CURLDownloader|Processor-CURLDownloader]]
       * [[CURLTextSearcher|Processor-CURLTextSearcher]]
+      * [[CodeSignatureVerifier|Processor-CodeSignatureVerifier]]
+      * [[Copier|Processor-Copier]]
       * [[DmgCreator|Processor-DmgCreator]]
       * [[DmgMounter|Processor-DmgMounter]]
       * [[EndOfCheckPhase|Processor-EndOfCheckPhase]]
@@ -42,8 +42,8 @@
       * [[FlatPkgPacker|Processor-FlatPkgPacker]]
       * [[FlatPkgUnpacker|Processor-FlatPkgUnpacker]]
       * [[GitHubReleasesInfoProvider|Processor-GitHubReleasesInfoProvider]]
-      * [[Installer|Processor-Installer]]
       * [[InstallFromDMG|Processor-InstallFromDMG]]
+      * [[Installer|Processor-Installer]]
       * [[MunkiCatalogBuilder|Processor-MunkiCatalogBuilder]]
       * [[MunkiImporter|Processor-MunkiImporter]]
       * [[MunkiInfoCreator|Processor-MunkiInfoCreator]]
@@ -63,9 +63,9 @@
       * [[SparkleUpdateInfoProvider|Processor-SparkleUpdateInfoProvider]]
       * [[StopProcessingIf|Processor-StopProcessingIf]]
       * [[Symlinker|Processor-Symlinker]]
-      * [[Unarchiver|Processor-Unarchiver]]
       * [[URLDownloader|Processor-URLDownloader]]
       * [[URLTextSearcher|Processor-URLTextSearcher]]
+      * [[Unarchiver|Processor-Unarchiver]]
       * [[Versioner|Processor-Versioner]]
   * **Development**
-      * [[Packaging releases on GitHub|Packaging-AutoPkg-For-Release-on-GitHub]]
\ No newline at end of file
+      * [[Packaging releases on GitHub|Packaging-AutoPkg-For-Release-on-GitHub]]

-------------------------------------------------------------------

Shown above is the commit log for the changes to the wiki markdown.
Type 'push' to accept and push the changes to GitHub. The wiki repo
local clone can be also inspected at:
/var/folders/th/3tqg05g54f73x0k_mstm5wy1_0g_xw/T/tmpxm0OqN.
```