### PR TITLE
Blackening all Python code

### DIFF
--- a/Code/FoundationPlist/FoundationPlist.py
+++ b/Code/FoundationPlist/FoundationPlist.py
@@ -43,43 +43,55 @@ and writePlistToString().
 
 import os
 
-from Foundation import (NSData, NSPropertyListMutableContainersAndLeaves,
-                        NSPropertyListSerialization,
-                        NSPropertyListXMLFormat_v1_0)
+from Foundation import (
+    NSData,
+    NSPropertyListMutableContainersAndLeaves,
+    NSPropertyListSerialization,
+    NSPropertyListXMLFormat_v1_0,
+)
 
 
 class FoundationPlistException(Exception):
-    '''Base error for this module'''
+    """Base error for this module"""
+
     pass
 
 
 class NSPropertyListSerializationException(FoundationPlistException):
-    '''Read error for this module'''
+    """Read error for this module"""
+
     pass
 
 
 class NSPropertyListWriteException(FoundationPlistException):
-    '''Write error for this module'''
+    """Write error for this module"""
+
     pass
 
 
 # private functions
 def _dataToPlist(data):
-    '''low-level function that parses a data object into a propertyList object'''
-    darwin_vers = int(os.uname()[2].split('.')[0])
+    """low-level function that parses a data object into a propertyList object"""
+    darwin_vers = int(os.uname()[2].split(".")[0])
     if darwin_vers > 10:
-        (plistObject, plistFormat, error) = (
-            NSPropertyListSerialization.propertyListWithData_options_format_error_(
-                data, NSPropertyListMutableContainersAndLeaves, None, None))
+        (
+            plistObject,
+            plistFormat,
+            error,
+        ) = NSPropertyListSerialization.propertyListWithData_options_format_error_(
+            data, NSPropertyListMutableContainersAndLeaves, None, None
+        )
     else:
         # 10.5 doesn't support propertyListWithData:options:format:error:
         # 10.6's PyObjC wrapper for propertyListWithData:options:format:error:
         #        is broken
         # so use the older NSPropertyListSerialization function
-        (plistObject, plistFormat, error) = (
-            NSPropertyListSerialization.propertyListFromData_mutabilityOption_format_errorDescription_(
-                data, NSPropertyListMutableContainersAndLeaves, None, None
-            )
+        (
+            plistObject,
+            plistFormat,
+            error,
+        ) = NSPropertyListSerialization.propertyListFromData_mutabilityOption_format_errorDescription_(
+            data, NSPropertyListMutableContainersAndLeaves, None, None
         )
     if plistObject is None:
         if error is None:
@@ -90,17 +102,23 @@ def _dataToPlist(data):
 
 
 def _plistToData(plistObject):
-    '''low-level function that creates NSData from a plist object'''
-    darwin_vers = int(os.uname()[2].split('.')[0])
+    """low-level function that creates NSData from a plist object"""
+    darwin_vers = int(os.uname()[2].split(".")[0])
     if darwin_vers > 10:
-        (data, error) = (
-            NSPropertyListSerialization.dataWithPropertyList_format_options_error_(
-                plistObject, NSPropertyListXMLFormat_v1_0, 0, None))
+        (
+            data,
+            error,
+        ) = NSPropertyListSerialization.dataWithPropertyList_format_options_error_(
+            plistObject, NSPropertyListXMLFormat_v1_0, 0, None
+        )
     else:
         # use the older NSPropertyListSerialization function on 10.6 and 10.5
-        (data, error) = (
-            NSPropertyListSerialization.dataFromPropertyList_format_errorDescription_(
-                plistObject, NSPropertyListXMLFormat_v1_0, None))
+        (
+            data,
+            error,
+        ) = NSPropertyListSerialization.dataFromPropertyList_format_errorDescription_(
+            plistObject, NSPropertyListXMLFormat_v1_0, None
+        )
     if data is None:
         if error is None:
             error = "Property list invalid for format."
@@ -110,33 +128,34 @@ def _plistToData(plistObject):
 
 # public functions
 def readPlist(filepath):
-    '''Read a .plist file from filepath.  Return the unpacked root object
-    (which is usually a dictionary).'''
+    """Read a .plist file from filepath.  Return the unpacked root object
+    (which is usually a dictionary)."""
     try:
         data = NSData.dataWithContentsOfFile_(filepath)
     except NSPropertyListSerializationException as error:
         # insert filepath info into error message
-        errmsg = (u'%s in %s' % (error, filepath))
+        errmsg = u"%s in %s" % (error, filepath)
         raise NSPropertyListSerializationException(errmsg)
     return _dataToPlist(data)
 
 
 def readPlistFromString(aString):
-    '''Read a plist data from a string. Return the root object.'''
+    """Read a plist data from a string. Return the root object."""
     data = buffer(aString)
     return _dataToPlist(data)
 
 
 def writePlist(plistObject, filepath):
-    '''Write 'plistObject' as a plist to filepath.'''
+    """Write 'plistObject' as a plist to filepath."""
     plistData = _plistToData(plistObject)
     if plistData.writeToFile_atomically_(filepath, True):
         return
     else:
         raise NSPropertyListWriteException(
-            u"Failed to write plist data to %s" % filepath)
+            u"Failed to write plist data to %s" % filepath
+        )
 
 
 def writePlistToString(plistObject):
-    '''Create a plist-formatted string from plistObject.'''
+    """Create a plist-formatted string from plistObject."""
     return str(_plistToData(plistObject))

--- a/Code/FoundationPlist/__init__.py
+++ b/Code/FoundationPlist/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+
 # We're effectively using this package as module
 try:
     from FoundationPlist import *
@@ -9,4 +10,3 @@ except:
         "FoundationPlist import *' in " + __name__
     )
     from plistlib import *
-

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -35,26 +35,38 @@ from urllib import quote
 from urlparse import urlparse
 
 import autopkglib.github
-from autopkglib import (AutoPackager, AutoPackagerError, PreferenceError,
-                        core_processor_names,
-                        extract_processor_name_with_recipe_identifier,
-                        find_recipe_by_identifier, get_all_prefs,
-                        get_autopkg_version, get_identifier, get_pref,
-                        get_processor, processor_names, set_pref,
-                        version_equal_or_greater)
+from autopkglib import (
+    AutoPackager,
+    AutoPackagerError,
+    PreferenceError,
+    core_processor_names,
+    extract_processor_name_with_recipe_identifier,
+    find_recipe_by_identifier,
+    get_all_prefs,
+    get_autopkg_version,
+    get_identifier,
+    get_pref,
+    get_processor,
+    processor_names,
+    set_pref,
+    version_equal_or_greater,
+)
 
-if sys.platform != 'darwin':
-    print("""
+
+if sys.platform != "darwin":
+    print(
+        """
 --------------------------------------------------------------------------------
 -- WARNING: AutoPkg is not completely functional on platforms other than OS X --
 --------------------------------------------------------------------------------
-""")
+"""
+    )
 
 try:
     import FoundationPlist
 except:
-    print('WARNING: importing plistlib as FoundationPlist;')
-    print('WARNING: some plist formats will be unsupported')
+    print("WARNING: importing plistlib as FoundationPlist;")
+    print("WARNING: some plist formats will be unsupported")
     import plistlib as FoundationPlist
 
 # If any recipe fails during 'autopkg run', return this exit code
@@ -62,28 +74,28 @@ RECIPE_FAILED_CODE = 70
 
 
 def log(msg, error=False):
-    '''Message logger, prints to stdout/stderr.'''
+    """Message logger, prints to stdout/stderr."""
     if error:
-        print(unicode(msg).encode('UTF-8'), file=sys.stderr)
+        print(unicode(msg).encode("UTF-8"), file=sys.stderr)
     else:
-        print(unicode(msg).encode('UTF-8'), file=sys.stderr)
+        print(unicode(msg).encode("UTF-8"), file=sys.stderr)
 
 
 def log_err(msg):
-    '''Message logger for errors.'''
+    """Message logger for errors."""
     log(msg, error=True)
 
 
 def print_version(argv):
-    '''Prints autopkg version'''
+    """Prints autopkg version"""
     # make PyLint happy here since all our verb functions are passed argv
     _ = argv[1]
     print(get_autopkg_version())
 
 
 def recipe_has_step_processor(recipe, processor):
-    '''Does the recipe object contain at least one step with the
-    named Processor?'''
+    """Does the recipe object contain at least one step with the
+    named Processor?"""
     if "Process" in recipe:
         processors = [step.get("Processor") for step in recipe["Process"]]
         if processor in processors:
@@ -92,36 +104,35 @@ def recipe_has_step_processor(recipe, processor):
 
 
 def has_munkiimporter_step(recipe):
-    '''Does the recipe have a MunkiImporter step?'''
+    """Does the recipe have a MunkiImporter step?"""
     return recipe_has_step_processor(recipe, "MunkiImporter")
 
 
 def has_check_phase(recipe):
-    '''Does the recipe have a "check" phase?'''
+    """Does the recipe have a "check" phase?"""
     return recipe_has_step_processor(recipe, "EndOfCheckPhase")
 
 
 def builds_a_package(recipe):
-    '''Does this recipe build any packages?'''
+    """Does this recipe build any packages?"""
     return recipe_has_step_processor(recipe, "PkgCreator")
 
 
 def recipe_plist_from_file(filename):
-    '''Create a recipe plist from a file. Handle exceptions and log'''
+    """Create a recipe plist from a file. Handle exceptions and log"""
     if os.path.isfile(filename):
         try:
             # make sure we can read it
             recipe_plist = FoundationPlist.readPlist(filename)
         except FoundationPlist.FoundationPlistException as err:
-            log_err(
-                "WARNING: plist error for %s: %s" % (filename, unicode(err)))
+            log_err("WARNING: plist error for %s: %s" % (filename, unicode(err)))
             return
         return recipe_plist
 
 
 def valid_recipe_plist_with_keys(recipe_plist, keys_to_verify):
-    '''Attempts to read a plist and ensures the keys in
-    keys_to_verify exist. Returns False on any failure, True otherwise.'''
+    """Attempts to read a plist and ensures the keys in
+    keys_to_verify exist. Returns False on any failure, True otherwise."""
     if recipe_plist:
         for key in keys_to_verify:
             if key not in recipe_plist:
@@ -132,15 +143,15 @@ def valid_recipe_plist_with_keys(recipe_plist, keys_to_verify):
 
 
 def valid_plist_with_keys(filename, keys_to_verify):
-    '''Attempts to read a plist file and ensures the keys in
-    keys_to_verify exist. Returns False on any failure, True otherwise.'''
+    """Attempts to read a plist file and ensures the keys in
+    keys_to_verify exist. Returns False on any failure, True otherwise."""
     recipe_plist = recipe_plist_from_file(filename)
     return valid_plist_with_keys(recipe_plist, keys_to_verify)
 
 
 def valid_recipe_plist(recipe_plist):
-    '''Returns True if recipe plist is a valid recipe,
-    otherwise returns False'''
+    """Returns True if recipe plist is a valid recipe,
+    otherwise returns False"""
     return (
         valid_recipe_plist_with_keys(recipe_plist, ["Input", "Process"])
         or valid_recipe_plist_with_keys(recipe_plist, ["Input", "Recipe"])
@@ -149,29 +160,29 @@ def valid_recipe_plist(recipe_plist):
 
 
 def valid_recipe_file(filename):
-    '''Returns True if filename contains a valid recipe,
-    otherwise returns False'''
+    """Returns True if filename contains a valid recipe,
+    otherwise returns False"""
     recipe_plist = recipe_plist_from_file(filename)
     return valid_recipe_plist(recipe_plist)
 
 
 def valid_override_plist(recipe_plist):
-    '''Returns True if the recipe is a valid override,
-    otherwise returns False'''
-    return (
-        valid_recipe_plist_with_keys(recipe_plist, ["Input", "ParentRecipe"])
-        or valid_recipe_plist_with_keys(recipe_plist, ["Input", "Recipe"]))
+    """Returns True if the recipe is a valid override,
+    otherwise returns False"""
+    return valid_recipe_plist_with_keys(
+        recipe_plist, ["Input", "ParentRecipe"]
+    ) or valid_recipe_plist_with_keys(recipe_plist, ["Input", "Recipe"])
 
 
 def valid_override_file(filename):
-    '''Returns True if filename contains a valid override,
-    otherwise returns False'''
+    """Returns True if filename contains a valid override,
+    otherwise returns False"""
     override_plist = recipe_plist_from_file(filename)
     return valid_override_plist(override_plist)
 
 
 def find_recipe_by_name(name, search_dirs):
-    '''Search search_dirs for a recipe by file/directory naming rules'''
+    """Search search_dirs for a recipe by file/directory naming rules"""
     if name.endswith(".recipe"):
         # drop ".recipe" from the end of the name because we're
         # going to add it back on...
@@ -181,7 +192,7 @@ def find_recipe_by_name(name, search_dirs):
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         patterns = [
             os.path.join(normalized_dir, "%s.recipe" % name),
-            os.path.join(normalized_dir, "*/%s.recipe" % name)
+            os.path.join(normalized_dir, "*/%s.recipe" % name),
         ]
         for pattern in patterns:
             matches = glob.glob(pattern)
@@ -193,42 +204,46 @@ def find_recipe_by_name(name, search_dirs):
 
 
 def find_recipe(id_or_name, search_dirs):
-    '''find a recipe based on a string that might be an identifier
-    or a name'''
-    return (find_recipe_by_identifier(id_or_name, search_dirs) or
-            find_recipe_by_name(id_or_name, search_dirs))
+    """find a recipe based on a string that might be an identifier
+    or a name"""
+    return find_recipe_by_identifier(id_or_name, search_dirs) or find_recipe_by_name(
+        id_or_name, search_dirs
+    )
 
 
 def get_identifier_from_override(override):
-    '''Return the identifier from an override, falling back with a
-    warning to just the 'name' of the recipe.'''
+    """Return the identifier from an override, falling back with a
+    warning to just the 'name' of the recipe."""
     # prefer ParentRecipe
-    identifier = override.get('ParentRecipe')
+    identifier = override.get("ParentRecipe")
     if identifier:
         return identifier
-    identifier = override['Recipe'].get("identifier")
+    identifier = override["Recipe"].get("identifier")
     if identifier:
         return identifier
     else:
-        name = override['Recipe'].get("name")
-        log_err("WARNING: Override contains no identifier. Will fall "
-                "back to matching it by name using search rules. It's "
-                "recommended to give the original recipe identifier "
-                "in the override's 'Recipes' dict to ensure the same "
-                "recipe is always used for this override.")
+        name = override["Recipe"].get("name")
+        log_err(
+            "WARNING: Override contains no identifier. Will fall "
+            "back to matching it by name using search rules. It's "
+            "recommended to give the original recipe identifier "
+            "in the override's 'Recipes' dict to ensure the same "
+            "recipe is always used for this override."
+        )
     return name
 
 
-def locate_recipe(name, override_dirs, recipe_dirs,
-                  make_suggestions=True, search_github=True):
-    '''Locates a recipe by name. If the name is the pathname to a file on disk,
+def locate_recipe(
+    name, override_dirs, recipe_dirs, make_suggestions=True, search_github=True
+):
+    """Locates a recipe by name. If the name is the pathname to a file on disk,
     we attempt to load that file and use it as recipe. If a parent recipe
     is required we first add the child recipe's directory to the search path
     so that the parent can be found, assuming it is in the same directory.
 
     Otherwise, we treat name as a recipe name or identifier and search first
     the override directories, then the recipe directories for a matching
-    recipe.'''
+    recipe."""
 
     recipe_file = None
     if os.path.isfile(name):
@@ -243,7 +258,7 @@ def locate_recipe(name, override_dirs, recipe_dirs,
         recipe_file = find_recipe(name, override_dirs + recipe_dirs)
 
     if not recipe_file and make_suggestions:
-        print(u"Didn't find a recipe for %s." % name.encode('UTF-8'))
+        print(u"Didn't find a recipe for %s." % name.encode("UTF-8"))
         make_suggestions_for(name)
 
     if not recipe_file and search_github:
@@ -252,15 +267,16 @@ def locate_recipe(name, override_dirs, recipe_dirs,
             indef_article = "an"
         answer = raw_input(
             "Search GitHub AutoPkg repos for %s %s recipe? [y/n]: "
-            % (indef_article, name))
-        if answer.lower().startswith('y'):
+            % (indef_article, name)
+        )
+        if answer.lower().startswith("y"):
             results_limit = 100
             query = "q=%s+extension:recipe+user:autopkg+in:file,path" % name
             query += "&per_page=%s" % results_limit
 
             results = do_gh_code_search(query, use_token=False)
 
-            if not results or not results.get('total_count'):
+            if not results or not results.get("total_count"):
                 print("Nothing found.")
                 return None
 
@@ -272,14 +288,14 @@ def locate_recipe(name, override_dirs, recipe_dirs,
             #
             ## filter out any results that are in repos we already have added
             ## locally
-            #recipe_repo_urls = []
-            #recipe_repos = get_pref("RECIPE_REPOS") or {}
-            #for key in recipe_repos.keys():
+            # recipe_repo_urls = []
+            # recipe_repos = get_pref("RECIPE_REPOS") or {}
+            # for key in recipe_repos.keys():
             #    recipe_repo_urls.append(recipe_repos[key]['URL'])
-            #results_items = [
+            # results_items = [
             #    item for item in results_items
             #    if item['repository']['html_url'] not in recipe_repo_urls]
-            #if len(results_items) > 1:
+            # if len(results_items) > 1:
             #    # filter results items by matching filenames.
             #    # this works around the fact that we can't do a
             #    # case-insensitive filename search with the GitHub API
@@ -295,7 +311,7 @@ def locate_recipe(name, override_dirs, recipe_dirs,
             # make a list of unique repo names
             repo_names = []
             for item in results_items:
-                repo_name = item["repository"]['name']
+                repo_name = item["repository"]["name"]
                 if repo_name not in repo_names:
                     repo_names.append(repo_name)
 
@@ -303,44 +319,56 @@ def locate_recipe(name, override_dirs, recipe_dirs,
                 # we found results in a single repo, so offer to add it
                 repo = results_items[0]["repository"]
                 print()
-                answer = raw_input(
-                    "Add recipe repo '%s'? [y/n]: " % repo['name'])
-                if answer.lower().startswith('y'):
-                    repo_add([None, 'repo-add', repo['name']])
+                answer = raw_input("Add recipe repo '%s'? [y/n]: " % repo["name"])
+                if answer.lower().startswith("y"):
+                    repo_add([None, "repo-add", repo["name"]])
                     # try once again to locate the recipe, but don't
                     # search GitHub again!
                     print
                     recipe_dirs = get_search_dirs()
                     recipe_file = locate_recipe(
-                        name, override_dirs, recipe_dirs,
-                        make_suggestions=True, search_github=False)
+                        name,
+                        override_dirs,
+                        recipe_dirs,
+                        make_suggestions=True,
+                        search_github=False,
+                    )
             elif len(repo_names) > 1:
                 print()
-                print("To add a new recipe repo, use 'autopkg repo-add "
-                       "<repo name>'")
+                print("To add a new recipe repo, use 'autopkg repo-add " "<repo name>'")
                 return None
 
     return recipe_file
 
 
-def load_recipe(name, override_dirs, recipe_dirs,
-                preprocessors=None, postprocessors=None,
-                make_suggestions=True, search_github=True):
-    '''Loads a recipe, first locating it by name.
+def load_recipe(
+    name,
+    override_dirs,
+    recipe_dirs,
+    preprocessors=None,
+    postprocessors=None,
+    make_suggestions=True,
+    search_github=True,
+):
+    """Loads a recipe, first locating it by name.
     If we find one, we load it and return the plist object (which
     should be functionally equivelent to a dictionary). If an override file is
     used, it prefers finding the original recipe by identifier rather than
     name, so that if recipe names shift with updated recipe repos, the
-    override still applies to the recipe from which it was derived.'''
+    override still applies to the recipe from which it was derived."""
 
     if override_dirs is None:
         override_dirs = []
     if recipe_dirs is None:
         recipe_dirs = []
     recipe = None
-    recipe_file = locate_recipe(name, override_dirs, recipe_dirs,
-                                make_suggestions=make_suggestions,
-                                search_github=search_github)
+    recipe_file = locate_recipe(
+        name,
+        override_dirs,
+        recipe_dirs,
+        make_suggestions=make_suggestions,
+        search_github=search_github,
+    )
 
     if recipe_file:
         # read it
@@ -348,9 +376,8 @@ def load_recipe(name, override_dirs, recipe_dirs,
 
         # store parent trust info, but only if this is an override
         if recipe_in_override_dir(recipe_file, override_dirs):
-            parent_trust_info = recipe.get('ParentRecipeTrustInfo')
-            override_parent = (recipe.get("ParentRecipe")
-                               or recipe.get("Recipe"))
+            parent_trust_info = recipe.get("ParentRecipeTrustInfo")
+            override_parent = recipe.get("ParentRecipe") or recipe.get("Recipe")
         else:
             parent_trust_info = None
 
@@ -363,35 +390,42 @@ def load_recipe(name, override_dirs, recipe_dirs,
             # so that we'll be able to locate the parent
             recipe_dirs.append(os.path.dirname(recipe_file))
             # load its parent, this time not looking in override directories
-            recipe = load_recipe(parent_id, [], recipe_dirs,
-                                 make_suggestions=make_suggestions,
-                                 search_github=search_github)
+            recipe = load_recipe(
+                parent_id,
+                [],
+                recipe_dirs,
+                make_suggestions=make_suggestions,
+                search_github=search_github,
+            )
             if recipe:
                 # merge child_recipe
                 recipe["Identifier"] = get_identifier(child_recipe)
                 recipe["Description"] = child_recipe.get(
-                    "Description", recipe.get("Description", ""))
+                    "Description", recipe.get("Description", "")
+                )
                 for key in child_recipe["Input"].keys():
                     recipe["Input"][key] = child_recipe["Input"][key]
 
                 # take the highest of the two MinimumVersion keys, if they exist
                 for candidate_recipe in [recipe, child_recipe]:
-                    if 'MinimumVersion' not in candidate_recipe.keys():
-                        candidate_recipe['MinimumVersion'] = '0'
-                if version_equal_or_greater(child_recipe['MinimumVersion'],
-                                            recipe['MinimumVersion']):
-                    recipe['MinimumVersion'] = child_recipe['MinimumVersion']
+                    if "MinimumVersion" not in candidate_recipe.keys():
+                        candidate_recipe["MinimumVersion"] = "0"
+                if version_equal_or_greater(
+                    child_recipe["MinimumVersion"], recipe["MinimumVersion"]
+                ):
+                    recipe["MinimumVersion"] = child_recipe["MinimumVersion"]
 
                 recipe["Process"].extend(child_recipe.get("Process", []))
                 if recipe.get("RECIPE_PATH"):
                     if "PARENT_RECIPES" not in recipe:
                         recipe["PARENT_RECIPES"] = []
-                    recipe["PARENT_RECIPES"] = (
-                        [recipe["RECIPE_PATH"]] + recipe["PARENT_RECIPES"])
+                    recipe["PARENT_RECIPES"] = [recipe["RECIPE_PATH"]] + recipe[
+                        "PARENT_RECIPES"
+                    ]
                 recipe["RECIPE_PATH"] = recipe_file
             else:
                 # no parent recipe, so the current recipe is invalid
-                log_err('Could not find parent recipe for %s' % name)
+                log_err("Could not find parent recipe for %s" % name)
         else:
             recipe["RECIPE_PATH"] = recipe_file
 
@@ -399,17 +433,17 @@ def load_recipe(name, override_dirs, recipe_dirs,
         # up from a parent recipe
         if recipe:
             if parent_trust_info:
-                recipe['ParentRecipeTrustInfo'] = parent_trust_info
+                recipe["ParentRecipeTrustInfo"] = parent_trust_info
                 if override_parent:
-                    recipe['ParentRecipe'] = override_parent
+                    recipe["ParentRecipe"] = override_parent
                 else:
-                    log_err('No parent recipe specified for %s' % name)
-            elif 'ParentRecipeTrustInfo' in recipe:
-                del recipe['ParentRecipeTrustInfo']
+                    log_err("No parent recipe specified for %s" % name)
+            elif "ParentRecipeTrustInfo" in recipe:
+                del recipe["ParentRecipeTrustInfo"]
 
     if recipe:
         # store the name the user used to locate this recipe
-        recipe['name'] = name
+        recipe["name"] = name
 
     if recipe and preprocessors:
         steps = []
@@ -427,24 +461,32 @@ def load_recipe(name, override_dirs, recipe_dirs,
     return recipe
 
 
-def get_recipe_info(recipe_name, override_dirs, recipe_dirs,
-                    make_suggestions=True, search_github=True):
-    '''Loads a recipe, then prints some information about it. Override aware.'''
-    recipe = load_recipe(recipe_name, override_dirs, recipe_dirs,
-                         make_suggestions=make_suggestions,
-                         search_github=search_github)
+def get_recipe_info(
+    recipe_name, override_dirs, recipe_dirs, make_suggestions=True, search_github=True
+):
+    """Loads a recipe, then prints some information about it. Override aware."""
+    recipe = load_recipe(
+        recipe_name,
+        override_dirs,
+        recipe_dirs,
+        make_suggestions=make_suggestions,
+        search_github=search_github,
+    )
     if recipe:
-        log("Description:         %s" %
-            "\n                     "
-            .join(recipe.get("Description", "").splitlines()))
+        log(
+            "Description:         %s"
+            % "\n                     ".join(recipe.get("Description", "").splitlines())
+        )
         log("Identifier:          %s" % get_identifier(recipe))
         log("Munki import recipe: %s" % has_munkiimporter_step(recipe))
         log("Has check phase:     %s" % has_check_phase(recipe))
         log("Builds package:      %s" % builds_a_package(recipe))
         log("Recipe file path:    %s" % recipe["RECIPE_PATH"])
         if recipe.get("PARENT_RECIPES"):
-            log("Parent recipe(s):    %s"
-                % "\n                     ".join(recipe["PARENT_RECIPES"]))
+            log(
+                "Parent recipe(s):    %s"
+                % "\n                     ".join(recipe["PARENT_RECIPES"])
+            )
         log("Input values: ")
         output = pprint.pformat(recipe.get("Input", {}), indent=4)
         log(" " + output[1:-1])
@@ -463,7 +505,7 @@ def git_cmd():
     """
 
     def is_executable(exe_path):
-        '''Is exe_path executable?'''
+        """Is exe_path executable?"""
         return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
 
     git_path_pref = get_pref("GIT_PATH")
@@ -472,9 +514,11 @@ def git_cmd():
             # take a GIT_PATH pref
             return git_path_pref
         else:
-            log_err("WARNING: Git path given in the 'GIT_PATH' preference:'%s' "
-                    "either doesn't exist or is not executable! Falling back "
-                    "to one set in PATH, or /usr/bin/git." % git_path_pref)
+            log_err(
+                "WARNING: Git path given in the 'GIT_PATH' preference:'%s' "
+                "either doesn't exist or is not executable! Falling back "
+                "to one set in PATH, or /usr/bin/git." % git_path_pref
+            )
     for path_env in os.environ["PATH"].split(":"):
         gitbin = os.path.join(path_env, "git")
         if is_executable(gitbin):
@@ -487,13 +531,14 @@ def git_cmd():
 
 
 class GitError(Exception):
-    '''Exception to throw if git fails'''
+    """Exception to throw if git fails"""
+
     pass
 
 
 def run_git(git_options_and_arguments, git_directory=None):
-    '''Run a git command and return its output if successful;
-       raise GitError if unsuccessful.'''
+    """Run a git command and return its output if successful;
+       raise GitError if unsuccessful."""
     gitcmd = git_cmd()
     if not gitcmd:
         raise GitError("ERROR: git is not installed!")
@@ -501,16 +546,18 @@ def run_git(git_options_and_arguments, git_directory=None):
     cmd.extend(git_options_and_arguments)
     try:
         proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            cwd=git_directory)
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=git_directory
+        )
         (cmd_out, cmd_err) = proc.communicate()
     except OSError as err:
-        raise GitError("ERROR: git execution failed with error code %d: %s"
-                       % (err.errno, err.strerror))
+        raise GitError(
+            "ERROR: git execution failed with error code %d: %s"
+            % (err.errno, err.strerror)
+        )
     if proc.returncode != 0:
         raise GitError("ERROR: %s" % cmd_err)
     else:
-        return cmd_out.decode('UTF-8')
+        return cmd_out.decode("UTF-8")
 
 
 def get_recipe_repo(git_path):
@@ -520,13 +567,12 @@ def get_recipe_repo(git_path):
     parts = urlparse(git_path)
     domain_and_port = parts.netloc
     # discard port if any
-    domain = domain_and_port.split(':')[0]
-    reverse_domain = '.'.join(reversed(domain.split('.')))
+    domain = domain_and_port.split(":")[0]
+    reverse_domain = ".".join(reversed(domain.split(".")))
     # discard file extension if any
     url_path = os.path.splitext(parts.path)[0]
-    dest_name = reverse_domain + url_path.replace('/', '.')
-    recipe_repo_dir = (get_pref("RECIPE_REPO_DIR") or
-                       "~/Library/AutoPkg/RecipeRepos")
+    dest_name = reverse_domain + url_path.replace("/", ".")
+    recipe_repo_dir = get_pref("RECIPE_REPO_DIR") or "~/Library/AutoPkg/RecipeRepos"
     recipe_repo_dir = os.path.expanduser(recipe_repo_dir)
     dest_dir = os.path.join(recipe_repo_dir, dest_name)
     dest_dir = os.path.abspath(dest_dir)
@@ -538,12 +584,12 @@ def get_recipe_repo(git_path):
     if os.path.exists(dest_dir):
         # probably should attempt a git pull
         # check to see if this is really a git repo first
-        if not os.path.isdir(os.path.join(dest_dir, '.git')):
+        if not os.path.isdir(os.path.join(dest_dir, ".git")):
             log_err("%s exists and is not a git repo!" % dest_dir)
             return None
         log("Attempting git pull...")
         try:
-            log(run_git(['pull'], git_directory=dest_dir))
+            log(run_git(["pull"], git_directory=dest_dir))
             return dest_dir
         except GitError as err:
             log_err(err)
@@ -551,7 +597,7 @@ def get_recipe_repo(git_path):
     else:
         log("Attempting git clone...")
         try:
-            log(run_git(['clone', git_path, dest_dir]))
+            log(run_git(["clone", git_path, dest_dir]))
             return dest_dir
         except GitError as err:
             log_err(err)
@@ -560,8 +606,8 @@ def get_recipe_repo(git_path):
 
 
 def write_plist_exit_on_fail(plist_dict, path):
-    '''Writes a dict to a new plist at path, exits the program
-    if the write fails.'''
+    """Writes a dict to a new plist at path, exits the program
+    if the write fails."""
     try:
         FoundationPlist.writePlist(plist_dict, path)
     except FoundationPlist.NSPropertyListWriteException:
@@ -578,8 +624,8 @@ def print_tool_info(options):
 
 
 def get_repo_info(path_or_url):
-    '''Given a path or URL, find a locally installed repo and return
-    infomation in a dictionary about it'''
+    """Given a path or URL, find a locally installed repo and return
+    infomation in a dictionary about it"""
     repo_info = {}
     recipe_repos = get_pref("RECIPE_REPOS") or {}
 
@@ -591,20 +637,20 @@ def get_repo_info(path_or_url):
             test_url = recipe_repos[repo_path].get("URL")
             if repo_url == test_url:
                 # found it; copy the dict info
-                repo_info['path'] = repo_path
+                repo_info["path"] = repo_path
                 repo_info.update(recipe_repos[repo_path])
                 # get out now!
                 return repo_info
     else:
         repo_path = os.path.abspath(os.path.expanduser(path_or_url))
         if repo_path in recipe_repos:
-            repo_info['path'] = repo_path
+            repo_info["path"] = repo_path
             repo_info.update(recipe_repos[repo_path])
     return repo_info
 
 
 def save_pref_or_warn(key, value):
-    '''Saves a key and value to preferences, warning if there is an issue'''
+    """Saves a key and value to preferences, warning if there is an issue"""
     try:
         set_pref(key, value)
     except PreferenceError as err:
@@ -612,12 +658,8 @@ def save_pref_or_warn(key, value):
 
 
 def get_search_dirs():
-    '''Return search dirs from preferences or default list'''
-    default = [
-        ".",
-        "~/Library/AutoPkg/Recipes",
-        "/Library/AutoPkg/Recipes"
-    ]
+    """Return search dirs from preferences or default list"""
+    default = [".", "~/Library/AutoPkg/Recipes", "/Library/AutoPkg/Recipes"]
 
     dirs = get_pref("RECIPE_SEARCH_DIRS")
     if isinstance(dirs, basestring):
@@ -627,10 +669,8 @@ def get_search_dirs():
 
 
 def get_override_dirs():
-    '''Return override dirs from preferences or default list'''
-    default = [
-        "~/Library/AutoPkg/RecipeOverrides"
-    ]
+    """Return override dirs from preferences or default list"""
+    default = ["~/Library/AutoPkg/RecipeOverrides"]
 
     dirs = get_pref("RECIPE_OVERRIDE_DIRS")
     if isinstance(dirs, basestring):
@@ -640,32 +680,43 @@ def get_override_dirs():
 
 
 def add_search_and_override_dir_options(parser):
-    '''Several subcommands use these same options'''
+    """Several subcommands use these same options"""
     parser.add_option(
-        "-d", "--search-dir", metavar="DIRECTORY", dest="search_dirs",
-        action="append", default=[],
-        help=("Directory to search for recipes. Can be specified "
-              "multiple times."))
+        "-d",
+        "--search-dir",
+        metavar="DIRECTORY",
+        dest="search_dirs",
+        action="append",
+        default=[],
+        help=("Directory to search for recipes. Can be specified " "multiple times."),
+    )
     parser.add_option(
-        "--override-dir", metavar="DIRECTORY", dest="override_dirs",
-        action="append", default=[],
-        help=("Directory to search for recipe overrides. Can be "
-              "specified multiple times."))
+        "--override-dir",
+        metavar="DIRECTORY",
+        dest="override_dirs",
+        action="append",
+        default=[],
+        help=(
+            "Directory to search for recipe overrides. Can be "
+            "specified multiple times."
+        ),
+    )
 
 
 ########################
 # subcommand functions #
 ########################
 
+
 def expand_repo_url(url):
-    '''Given a GitHub repo URL-ish name, returns a full GitHub URL. Falls
+    """Given a GitHub repo URL-ish name, returns a full GitHub URL. Falls
     back to the 'autopkg' GitHub org, and full non-GitHub URLs return
     unmodified.
     Examples:
     'user/reciperepo'         -> 'https://github.com/user/reciperepo'
     'reciperepo'              -> 'https://github.com/autopkg/reciperepo'
     'http://some/repo/url     -> 'http://some/repo/url'
-    '''
+    """
     parsed_url = urlparse(url)
     # if no URL scheme was given in the URL, try GitHub URLs
     if not parsed_url.scheme:
@@ -681,10 +732,11 @@ def expand_repo_url(url):
 
 
 def repo_add(argv):
-    '''Add/update one or more repos of recipes'''
+    """Add/update one or more repos of recipes"""
     verb = argv[1]
     parser = optparse.OptionParser()
-    parser.set_usage("""Usage: %s %s recipe_repo_url
+    parser.set_usage(
+        """Usage: %s %s recipe_repo_url
 Download one or more new recipe repos and add it to the search path.
 The 'recipe_repo_url' argument can be of the following forms:
 - repo (implies 'https://github.com/autopkg/repo')
@@ -693,7 +745,8 @@ The 'recipe_repo_url' argument can be of the following forms:
 
 Example: '%s repo-add recipes'
 ..adds the autopkg/recipes repo from GitHub."""
-                     % ("%prog", verb, "%prog"))
+        % ("%prog", verb, "%prog")
+    )
 
     # Parse arguments
     arguments = parser.parse_args(argv[2:])[1]
@@ -723,13 +776,14 @@ Example: '%s repo-add recipes'
 
 
 def repo_delete(argv):
-    '''Delete a recipe repo'''
+    """Delete a recipe repo"""
     verb = argv[1]
     parser = optparse.OptionParser()
     parser.set_usage(
         "Usage: %s %s recipe_repo_path_or_url [...]\n"
         "Delete one or more recipe repo and remove it from the search "
-        "path." % ("%prog", verb))
+        "path." % ("%prog", verb)
+    )
 
     # Parse arguments
     arguments = parser.parse_args(argv[2:])[1]
@@ -742,7 +796,7 @@ def repo_delete(argv):
 
     for path_or_url in arguments:
         path_or_url = expand_repo_url(path_or_url)
-        repo_path = get_repo_info(path_or_url).get('path')
+        repo_path = get_repo_info(path_or_url).get("path")
         if not repo_path:
             log_err("ERROR: Can't find an installed repo for %s" % path_or_url)
             continue
@@ -765,17 +819,19 @@ def repo_delete(argv):
 
 
 def repo_list(argv):
-    '''List recipe repos'''
+    """List recipe repos"""
     verb = argv[1]
     parser = optparse.OptionParser()
-    parser.set_usage("Usage: %s %s\n"
-                     "List all installed recipe repos." % ("%prog", verb))
+    parser.set_usage(
+        "Usage: %s %s\n" "List all installed recipe repos." % ("%prog", verb)
+    )
 
     recipe_repos = get_pref("RECIPE_REPOS") or {}
     if recipe_repos:
         for key in sorted(recipe_repos.keys()):
-            print(u"%s (%s)" % (
-                key.encode('UTF-8'), recipe_repos[key]['URL'].encode('UTF-8'))
+            print(
+                u"%s (%s)"
+                % (key.encode("UTF-8"), recipe_repos[key]["URL"].encode("UTF-8"))
             )
         print()
     else:
@@ -783,13 +839,15 @@ def repo_list(argv):
 
 
 def repo_update(argv):
-    '''Update one or more recipe repos'''
+    """Update one or more recipe repos"""
     verb = argv[1]
     parser = optparse.OptionParser()
-    parser.set_usage("Usage: %s %s recipe_repo_path_or_url [...]\n"
-                     "Update one or more recipe repos.\n"
-                     "You may also use 'all' to update all installed recipe "
-                     "repos." % ("%prog", verb))
+    parser.set_usage(
+        "Usage: %s %s recipe_repo_path_or_url [...]\n"
+        "Update one or more recipe repos.\n"
+        "You may also use 'all' to update all installed recipe "
+        "repos." % ("%prog", verb)
+    )
 
     # Parse arguments
     arguments = parser.parse_args(argv[2:])[1]
@@ -797,7 +855,7 @@ def repo_update(argv):
         log_err("Need at least one recipe repo path or URL!")
         return -1
 
-    if 'all' in arguments:
+    if "all" in arguments:
         # just get all repos
         recipe_repos = get_pref("RECIPE_REPOS") or {}
         repo_dirs = [key for key in recipe_repos.keys()]
@@ -805,10 +863,9 @@ def repo_update(argv):
         repo_dirs = []
         for path_or_url in arguments:
             path_or_url = expand_repo_url(path_or_url)
-            repo_path = get_repo_info(path_or_url).get('path')
+            repo_path = get_repo_info(path_or_url).get("path")
             if not repo_path:
-                log_err("ERROR: Can't find an installed repo for %s"
-                        % path_or_url)
+                log_err("ERROR: Can't find an installed repo for %s" % path_or_url)
             else:
                 repo_dirs.append(repo_path)
 
@@ -817,26 +874,26 @@ def repo_update(argv):
         repo_dir = os.path.abspath(os.path.expanduser(repo_dir))
         log("Attempting git pull for %s..." % repo_dir)
         try:
-            log(run_git(['pull'], git_directory=repo_dir))
+            log(run_git(["pull"], git_directory=repo_dir))
         except GitError as err:
             log_err(err)
 
 
 def do_gh_code_search(query, use_token=False):
-    '''Search GitHub code repos'''
+    """Search GitHub code repos"""
     gh_session = autopkglib.github.GitHubSession()
     if use_token:
         gh_session.setup_token()
     # Do the search, including text match metadata
     (results, code) = gh_session.call_api(
-        "/search/code",
-        query=query,
-        accept="application/vnd.github.v3.text-match+json")
+        "/search/code", query=query, accept="application/vnd.github.v3.text-match+json"
+    )
 
     if code == 403:
         log_err(
             "You've probably hit the GitHub's search rate limit, officially 5 "
-            "requests per minute.\n")
+            "requests per minute.\n"
+        )
         if results:
             log_err("Server response follows:\n")
             log_err(results.get("message", None))
@@ -850,13 +907,12 @@ def do_gh_code_search(query, use_token=False):
 
 
 def print_gh_search_results(results_items):
-    '''Pretty print our GitHub search results'''
+    """Pretty print our GitHub search results"""
     column_spacer = 4
-    max_name_length = (
-        max([len(r["name"]) for r in results_items]) + column_spacer)
+    max_name_length = max([len(r["name"]) for r in results_items]) + column_spacer
     max_repo_length = (
-        max([len(r["repository"]["name"]) for r in results_items])
-        + column_spacer)
+        max([len(r["repository"]["name"]) for r in results_items]) + column_spacer
+    )
     spacers = (max_name_length, max_repo_length)
 
     print()
@@ -866,41 +922,62 @@ def print_gh_search_results(results_items):
     results_items.sort(key=operator.itemgetter("repository"))
     for result in results_items:
         repo = result["repository"]
-        name = result["name"].encode('UTF-8')
-        path = result["path"].encode('UTF-8')
+        name = result["name"].encode("UTF-8")
+        path = result["path"].encode("UTF-8")
         if repo["full_name"].startswith("autopkg"):
-            repo_name = repo["name"].encode('UTF-8')
+            repo_name = repo["name"].encode("UTF-8")
         else:
-            repo_name = repo["full_name"].encode('UTF-8')
+            repo_name = repo["full_name"].encode("UTF-8")
         print(format_str % (name, repo_name, path))
 
 
 def search_recipes(argv):
-    '''Search recipes on GitHub'''
+    """Search recipes on GitHub"""
     default_user = "autopkg"
     verb = argv[1]
     parser = optparse.OptionParser()
-    parser.set_usage("Usage: %s %s [options] search_term\n"
-                     "Search for recipes on GitHub. The AutoPkg organization "
-                     "at github.com/autopkg\n"
-                     "is the canonical 'repository' of recipe repos, "
-                     "which is what is searched by\n"
-                     "default."
-                     % ("%prog", verb))
-    parser.add_option("-u", "--user", default=default_user,
-                      help=("Alternate GitHub user whose repos to search. "
-                            "Defaults to '%s'." % default_user))
-    parser.add_option("-p", "--path-only", action="store_true", default=False,
-                      help=("Restrict search results to the recipe's path "
-                            "only. Note that the search API currently does not "
-                            "support fuzzy matches, so only exact directory or "
-                            "filenames (minus the extensions) will be "
-                            "returned."))
-    parser.add_option("-t", "--use-token", action="store_true", default=False,
-                      help=("Use a public-scope GitHub token for a higher "
-                            "rate limit. If a token doesn't exist, you'll "
-                            "be prompted for your account credentials to "
-                            "create one."))
+    parser.set_usage(
+        "Usage: %s %s [options] search_term\n"
+        "Search for recipes on GitHub. The AutoPkg organization "
+        "at github.com/autopkg\n"
+        "is the canonical 'repository' of recipe repos, "
+        "which is what is searched by\n"
+        "default." % ("%prog", verb)
+    )
+    parser.add_option(
+        "-u",
+        "--user",
+        default=default_user,
+        help=(
+            "Alternate GitHub user whose repos to search. "
+            "Defaults to '%s'." % default_user
+        ),
+    )
+    parser.add_option(
+        "-p",
+        "--path-only",
+        action="store_true",
+        default=False,
+        help=(
+            "Restrict search results to the recipe's path "
+            "only. Note that the search API currently does not "
+            "support fuzzy matches, so only exact directory or "
+            "filenames (minus the extensions) will be "
+            "returned."
+        ),
+    )
+    parser.add_option(
+        "-t",
+        "--use-token",
+        action="store_true",
+        default=False,
+        help=(
+            "Use a public-scope GitHub token for a higher "
+            "rate limit. If a token doesn't exist, you'll "
+            "be prompted for your account credentials to "
+            "create one."
+        ),
+    )
 
     # Parse arguments
     options, arguments = parser.parse_args(argv[2:])
@@ -933,37 +1010,44 @@ def search_recipes(argv):
 
     if count > results_limit:
         print()
-        print("Warning: Search yielded more than 100 results. Please try a "
-               "more specific search term.")
+        print(
+            "Warning: Search yielded more than 100 results. Please try a "
+            "more specific search term."
+        )
 
 
 def display_help(argv, subcommands):
-    '''Display top-level help'''
+    """Display top-level help"""
     main_command_name = os.path.basename(argv[0])
-    print("Usage: %s <verb> <options>, where <verb> is one of the following:"
-           % main_command_name)
+    print(
+        "Usage: %s <verb> <options>, where <verb> is one of the following:"
+        % main_command_name
+    )
     print()
     # find length of longest subcommand
     max_key_len = max([len(key) for key in subcommands.keys()])
     for key in sorted(subcommands.keys()):
         # pad name of subcommand to make pretty columns
         subcommand = key + (" " * (max_key_len - len(key)))
-        print("    %s  (%s)" % (subcommand, subcommands[key]['help']))
+        print("    %s  (%s)" % (subcommand, subcommands[key]["help"]))
     print()
     print("%s <verb> --help for more help for that verb" % main_command_name)
 
 
 def get_info(argv):
-    '''Display info about configuration or a recipe'''
+    """Display info about configuration or a recipe"""
     verb = argv[1]
     parser = optparse.OptionParser()
     parser.set_usage("Usage: %s %s [options] [recipe]" % ("%prog", verb))
 
     # Parse arguments
     add_search_and_override_dir_options(parser)
-    parser.add_option("-q", "--quiet", action="store_true",
-                      help=("Don't offer to search Github if a recipe can't "
-                            "be found."))
+    parser.add_option(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help=("Don't offer to search Github if a recipe can't " "be found."),
+    )
     options, arguments = parser.parse_args(argv[2:])
 
     override_dirs = options.override_dirs or get_override_dirs()
@@ -980,13 +1064,15 @@ def get_info(argv):
         return 0
     elif len(arguments) == 1:
         if get_recipe_info(
-            arguments[0], override_dirs, search_dirs,
+            arguments[0],
+            override_dirs,
+            search_dirs,
             make_suggestions=make_suggestions,
-            search_github=make_suggestions
+            search_github=make_suggestions,
         ):
             return 0
         else:
-            #log_err("Can't find recipe %s, or it is invalid." % arguments[0])
+            # log_err("Can't find recipe %s, or it is invalid." % arguments[0])
             return -1
     else:
         log_err("Too many recipes!")
@@ -994,7 +1080,7 @@ def get_info(argv):
 
 
 def processor_info(argv):
-    '''Display info about a processor'''
+    """Display info about a processor"""
 
     def print_vars(var_dict, indent=0):
         """Print a dict of dicts and strings"""
@@ -1003,16 +1089,14 @@ def processor_info(argv):
                 print(" " * indent, "%s:" % key)
                 print_vars(value, indent=indent + 2)
             else:
-                print(
-                    " " * indent,
-                    "%s: %s" % (key, unicode(value).encode('UTF-8'))
-                )
+                print(" " * indent, "%s: %s" % (key, unicode(value).encode("UTF-8")))
 
     verb = argv[1]
     parser = optparse.OptionParser()
     parser.set_usage("Usage: %s %s [options] processorname" % ("%prog", verb))
-    parser.add_option("-r", "--recipe", metavar="RECIPE",
-                      help="Name of recipe using the processor.")
+    parser.add_option(
+        "-r", "--recipe", metavar="RECIPE", help="Name of recipe using the processor."
+    )
 
     # Parse arguments
     add_search_and_override_dir_options(parser)
@@ -1061,56 +1145,68 @@ def processor_info(argv):
 
 
 def list_processors(argv):
-    '''List the processors in autopkglib'''
+    """List the processors in autopkglib"""
     verb = argv[1]
     parser = optparse.OptionParser()
-    parser.set_usage("Usage: %s %s [options]\n"
-                     "List the core Processors." % ("%prog", verb))
+    parser.set_usage(
+        "Usage: %s %s [options]\n" "List the core Processors." % ("%prog", verb)
+    )
 
     print("\n".join(sorted(processor_names())))
 
 
 def make_suggestions_for(search_name):
-    '''Suggest existing recipes with names similar to search name.'''
+    """Suggest existing recipes with names similar to search name."""
     # trim '.recipe' from the end if it exists
-    if os.path.splitext(search_name)[1].lower() == '.recipe':
+    if os.path.splitext(search_name)[1].lower() == ".recipe":
         search_name = os.path.splitext(search_name)[0]
     (search_name_base, search_name_ext) = os.path.splitext(search_name.lower())
-    recipe_names = [os.path.splitext(item['Name'])
-                    for item in get_recipe_list()]
+    recipe_names = [os.path.splitext(item["Name"]) for item in get_recipe_list()]
     recipe_names = list(set(recipe_names))
 
     matches = []
     if len(search_name_base) > 3:
-        matches = [''.join(item) for item in recipe_names
-                   if (search_name_base in item[0].lower()
-                       and search_name_ext in item[1].lower())]
+        matches = [
+            "".join(item)
+            for item in recipe_names
+            if (
+                search_name_base in item[0].lower()
+                and search_name_ext in item[1].lower()
+            )
+        ]
     if search_name_ext:
-        compare_names = [item[0].lower() for item in recipe_names
-                         if item[1].lower() == search_name_ext]
+        compare_names = [
+            item[0].lower()
+            for item in recipe_names
+            if item[1].lower() == search_name_ext
+        ]
     else:
         compare_names = [item[0].lower() for item in recipe_names]
 
-    close_matches = difflib.get_close_matches(
-        search_name_base, compare_names)
+    close_matches = difflib.get_close_matches(search_name_base, compare_names)
     if close_matches:
         matches.extend(
-            [''.join(item) for item in recipe_names
-             if (''.join(item) not in matches
-                 and item[0].lower() in close_matches)])
+            [
+                "".join(item)
+                for item in recipe_names
+                if ("".join(item) not in matches and item[0].lower() in close_matches)
+            ]
+        )
         if search_name_ext:
-            matches = [item for item in matches
-                       if os.path.splitext(item)[1] == search_name_ext]
+            matches = [
+                item for item in matches if os.path.splitext(item)[1] == search_name_ext
+            ]
 
     if len(matches) == 1:
         print("Maybe you meant %s?" % matches[0])
     elif len(matches):
-        print("Maybe you meant one of: %s?" % ', '.join(matches))
+        print("Maybe you meant one of: %s?" % ", ".join(matches))
 
 
-def get_recipe_list(override_dirs=None, search_dirs=None,
-                    augmented_list=False, show_all=False):
-    '''Factor out the core of list_recipes for use in other functions'''
+def get_recipe_list(
+    override_dirs=None, search_dirs=None, augmented_list=False, show_all=False
+):
+    """Factor out the core of list_recipes for use in other functions"""
     override_dirs = override_dirs or get_override_dirs()
     search_dirs = search_dirs or get_search_dirs()
 
@@ -1121,9 +1217,9 @@ def get_recipe_list(override_dirs=None, search_dirs=None,
             continue
 
         # find all top-level recipes and recipes one level down
-        matches = (
-            glob.glob(os.path.join(normalized_dir, "*.recipe")) +
-            glob.glob(os.path.join(normalized_dir, "*/*.recipe")))
+        matches = glob.glob(os.path.join(normalized_dir, "*.recipe")) + glob.glob(
+            os.path.join(normalized_dir, "*/*.recipe")
+        )
 
         for match in matches:
             recipe = recipe_plist_from_file(match)
@@ -1165,9 +1261,9 @@ def get_recipe_list(override_dirs=None, search_dirs=None,
                         # recipe's Identifier, remove the ParentRecipe from the
                         # listing.
                         for recipe in recipes:
-                            if recipe["Name"] == override["Name"] and \
-                               recipe.get("Identifier") == \
-                               override.get("ParentRecipe"):
+                            if recipe["Name"] == override["Name"] and recipe.get(
+                                "Identifier"
+                            ) == override.get("ParentRecipe"):
                                 recipes.remove(recipe)
 
                     recipes.append(override)
@@ -1175,51 +1271,75 @@ def get_recipe_list(override_dirs=None, search_dirs=None,
 
 
 def list_recipes(argv):
-    '''List all available recipes'''
+    """List all available recipes"""
     verb = argv[1]
     parser = optparse.OptionParser()
-    parser.set_usage("Usage: %s %s [options]\n"
-                     "List all the recipes this tool can find automatically.\n"
-                     % ("%prog", verb))
-    parser.add_option("-i", "--with-identifiers", action="store_true",
-                      help="Include recipe's identifier in the list.")
-    parser.add_option("-p", "--with-paths", action="store_true",
-                      help="Include recipe's path in the list.")
-    parser.add_option("--plist", action="store_true",
-                      help=("Print recipe list in plist format. This provides "
-                            "all available key/value pairs of recipes."))
-    parser.add_option("-a", "--show-all", action="store_true",
-                      help=("Include recipes with duplicate shortnames, "
-                            "including overrides. Use in conjunction with "
-                            "'--with-identifiers', '--with-paths', or "
-                            "'--plist'."))
+    parser.set_usage(
+        "Usage: %s %s [options]\n"
+        "List all the recipes this tool can find automatically.\n" % ("%prog", verb)
+    )
+    parser.add_option(
+        "-i",
+        "--with-identifiers",
+        action="store_true",
+        help="Include recipe's identifier in the list.",
+    )
+    parser.add_option(
+        "-p",
+        "--with-paths",
+        action="store_true",
+        help="Include recipe's path in the list.",
+    )
+    parser.add_option(
+        "--plist",
+        action="store_true",
+        help=(
+            "Print recipe list in plist format. This provides "
+            "all available key/value pairs of recipes."
+        ),
+    )
+    parser.add_option(
+        "-a",
+        "--show-all",
+        action="store_true",
+        help=(
+            "Include recipes with duplicate shortnames, "
+            "including overrides. Use in conjunction with "
+            "'--with-identifiers', '--with-paths', or "
+            "'--plist'."
+        ),
+    )
 
     # Parse options
     add_search_and_override_dir_options(parser)
     options = parser.parse_args(argv[1:])[0]
 
     augmented_list = False
-    if options.with_identifiers or \
-       options.with_paths or \
-       options.plist:
+    if options.with_identifiers or options.with_paths or options.plist:
         augmented_list = True
 
     if options.show_all and not augmented_list:
-        log_err("The '--show-all' option is only valid when used with "
-                "'--with-paths', '--with-identifiers', or '--plist' options.")
+        log_err(
+            "The '--show-all' option is only valid when used with "
+            "'--with-paths', '--with-identifiers', or '--plist' options."
+        )
         return -1
     elif options.plist and (options.with_identifiers or options.with_paths):
-        log_err("It is invalid to specify '--with-identifiers' or "
-                "'--with-paths' with '--plist'.")
+        log_err(
+            "It is invalid to specify '--with-identifiers' or "
+            "'--with-paths' with '--plist'."
+        )
         return -1
 
     override_dirs = options.override_dirs or get_override_dirs()
     search_dirs = options.search_dirs or get_search_dirs()
 
-    recipes = get_recipe_list(override_dirs=override_dirs,
-                              search_dirs=search_dirs,
-                              augmented_list=augmented_list,
-                              show_all=options.show_all)
+    recipes = get_recipe_list(
+        override_dirs=override_dirs,
+        search_dirs=search_dirs,
+        augmented_list=augmented_list,
+        show_all=options.show_all,
+    )
 
     lowercase_sorted = sorted(recipes, key=lambda s: s["Name"].lower())
 
@@ -1231,12 +1351,13 @@ def list_recipes(argv):
         max_identifier_length = 0
 
         if recipes and augmented_list:
-            max_name_length = (
-                max([len(r["Name"]) for r in recipes]) + column_spacer)
+            max_name_length = max([len(r["Name"]) for r in recipes]) + column_spacer
 
             max_identifier_length = (
-                max([len(r.get("Identifier", "")) for r in recipes])
-                + column_spacer) if options.with_identifiers else column_spacer
+                (max([len(r.get("Identifier", "")) for r in recipes]) + column_spacer)
+                if options.with_identifiers
+                else column_spacer
+            )
 
             spacers = (max_name_length, max_identifier_length)
             format_str = "%-{0}s %-{1}s %-20s".format(*spacers)
@@ -1261,7 +1382,7 @@ def list_recipes(argv):
                 if user_home:
                     recipe_path = recipe_path.replace(user_home, "~")
 
-            out_string = (format_str % (name, identifier, recipe_path))
+            out_string = format_str % (name, identifier, recipe_path)
 
             if out_string not in output:
                 output.append(out_string)
@@ -1270,11 +1391,11 @@ def list_recipes(argv):
 
 
 def get_git_commit_hash(filepath):
-    '''Get the current git commit hash if possible'''
+    """Get the current git commit hash if possible"""
     try:
         git_toplevel_dir = run_git(
-            ['rev-parse', '--show-toplevel'],
-            git_directory=os.path.dirname(filepath)).rstrip('\n')
+            ["rev-parse", "--show-toplevel"], git_directory=os.path.dirname(filepath)
+        ).rstrip("\n")
     except GitError:
         return None
     try:
@@ -1284,15 +1405,16 @@ def get_git_commit_hash(filepath):
         # file. Fine for later getting diff info but no good for finding the
         # the commits since the hash was recorded
         #
-        #git_hash = run_git(
+        # git_hash = run_git(
         #    ['rev-parse', ':' + relative_path],
         #    git_directory=git_toplevel_dir).rstrip('\n')
         #
         # instead, we need to use `rev-list` to find the most recent commit
         # hash for the file in question.
         git_hash = run_git(
-            ['rev-list', '-1', 'HEAD', '--', relative_path],
-            git_directory=git_toplevel_dir).rstrip('\n')
+            ["rev-list", "-1", "HEAD", "--", relative_path],
+            git_directory=git_toplevel_dir,
+        ).rstrip("\n")
     except GitError:
         return None
     # make sure the file hasn't been changed locally since the last git pull
@@ -1300,8 +1422,8 @@ def get_git_commit_hash(filepath):
     # the hash is pointless
     try:
         diff_output = run_git(
-            ['diff', git_hash, relative_path],
-            git_directory=git_toplevel_dir).rstrip('\n')
+            ["diff", git_hash, relative_path], git_directory=git_toplevel_dir
+        ).rstrip("\n")
     except GitError:
         return None
     if diff_output:
@@ -1310,13 +1432,13 @@ def get_git_commit_hash(filepath):
 
 
 def getsha256hash(filepath):
-    '''Generate a sha256 hash for the file at filepath'''
+    """Generate a sha256 hash for the file at filepath"""
     if not os.path.isfile(filepath):
-        return 'NOT A FILE'
+        return "NOT A FILE"
     hashfunction = hashlib.sha256()
-    fileref = open(filepath, 'rb')
+    fileref = open(filepath, "rb")
     while 1:
-        chunk = fileref.read(2**16)
+        chunk = fileref.read(2 ** 16)
         if not chunk:
             break
         hashfunction.update(chunk)
@@ -1325,38 +1447,41 @@ def getsha256hash(filepath):
 
 
 def find_processor_path(processor_name, recipe, env=None):
-    '''Returns the pathname to a procesor given a name and a recipe'''
+    """Returns the pathname to a procesor given a name and a recipe"""
     if env is None:
         env = {}
         env["RECIPE_SEARCH_DIRS"] = get_pref("RECIPE_SEARCH_DIRS") or []
     if recipe:
-        recipe_dir = os.path.dirname(recipe['RECIPE_PATH'])
+        recipe_dir = os.path.dirname(recipe["RECIPE_PATH"])
         processor_search_dirs = [recipe_dir]
 
         # check if our processor_name includes a recipe identifier that
         # should be used to locate the recipe.
         # if so, search for the recipe by identifier in order to add
         # its dirname to the processor search dirs
-        (processor_name, processor_recipe_id) = (
-            extract_processor_name_with_recipe_identifier(processor_name))
+        (
+            processor_name,
+            processor_recipe_id,
+        ) = extract_processor_name_with_recipe_identifier(processor_name)
         if processor_recipe_id:
-            shared_processor_recipe_path = (
-                find_recipe_by_identifier(processor_recipe_id,
-                                          env["RECIPE_SEARCH_DIRS"]))
+            shared_processor_recipe_path = find_recipe_by_identifier(
+                processor_recipe_id, env["RECIPE_SEARCH_DIRS"]
+            )
             if shared_processor_recipe_path:
                 processor_search_dirs.append(
-                    os.path.dirname(shared_processor_recipe_path))
+                    os.path.dirname(shared_processor_recipe_path)
+                )
 
         # search recipe dirs for processor
         if recipe.get("PARENT_RECIPES"):
             # also look in the directories containing the parent recipes
-            parent_recipe_dirs = list(set([
-                os.path.dirname(item)
-                for item in recipe["PARENT_RECIPES"]]))
+            parent_recipe_dirs = list(
+                set([os.path.dirname(item) for item in recipe["PARENT_RECIPES"]])
+            )
             processor_search_dirs.extend(parent_recipe_dirs)
 
         for directory in processor_search_dirs:
-            processor_filename = os.path.join(directory, processor_name + '.py')
+            processor_filename = os.path.join(directory, processor_name + ".py")
             if os.path.exists(processor_filename):
                 return processor_filename
 
@@ -1364,40 +1489,39 @@ def find_processor_path(processor_name, recipe, env=None):
 
 
 def os_path_compressuser(pathname):
-    '''Sort of the inverse of os.path.expanduser'''
-    home_dir = os.path.expanduser('~')
+    """Sort of the inverse of os.path.expanduser"""
+    home_dir = os.path.expanduser("~")
     if pathname == home_dir:
-        return '~'
+        return "~"
     elif pathname.startswith(home_dir):
-        return '~/' + os.path.relpath(pathname, home_dir)
+        return "~/" + os.path.relpath(pathname, home_dir)
     else:
         return pathname
 
 
 def get_trust_info(recipe, search_dirs=None):
-    '''Gets information from a recipe we use to ensure parent recipes and
-    non-core processors have not changed'''
+    """Gets information from a recipe we use to ensure parent recipes and
+    non-core processors have not changed"""
     # generate hashes for each parent recipe
-    parent_recipe_paths = recipe.get(
-        'PARENT_RECIPES', []) + [recipe["RECIPE_PATH"]]
+    parent_recipe_paths = recipe.get("PARENT_RECIPES", []) + [recipe["RECIPE_PATH"]]
     parent_recipe_hashes = {}
     for p_recipe_path in parent_recipe_paths:
         p_recipe_hash = getsha256hash(p_recipe_path)
         git_hash = get_git_commit_hash(p_recipe_path)
-        p_recipe = load_recipe(p_recipe_path, override_dirs=[],
-                               recipe_dirs=search_dirs)
+        p_recipe = load_recipe(p_recipe_path, override_dirs=[], recipe_dirs=search_dirs)
         identifier = get_identifier(p_recipe)
         parent_recipe_hashes[identifier] = {
-            'path': os_path_compressuser(p_recipe_path),
-            'sha256_hash': p_recipe_hash,
+            "path": os_path_compressuser(p_recipe_path),
+            "sha256_hash": p_recipe_hash,
         }
         if git_hash:
-            parent_recipe_hashes[identifier]['git_hash'] = git_hash
+            parent_recipe_hashes[identifier]["git_hash"] = git_hash
     # generate hashes for each non-core processor
     recipe_processors = [step["Processor"] for step in recipe["Process"]]
     core_processors = core_processor_names()
-    non_core_processors = [processor for processor in recipe_processors
-                           if processor not in core_processors]
+    non_core_processors = [
+        processor for processor in recipe_processors if processor not in core_processors
+    ]
     non_core_processor_hashes = {}
     for processor in non_core_processors:
         processor_path = find_processor_path(processor, recipe)
@@ -1406,76 +1530,78 @@ def get_trust_info(recipe, search_dirs=None):
             git_hash = get_git_commit_hash(processor_path)
         else:
             print(
-                'WARNING: processor path not found for %s' % processor,
-                file=sys.stderr
+                "WARNING: processor path not found for %s" % processor, file=sys.stderr
             )
             processor_path = ""
             processor_hash = "PROCESSOR FILEPATH NOT FOUND"
             git_hash = None
         non_core_processor_hashes[processor] = {
-            'path': os_path_compressuser(processor_path),
-            'sha256_hash': processor_hash,
+            "path": os_path_compressuser(processor_path),
+            "sha256_hash": processor_hash,
         }
         if git_hash:
-            non_core_processor_hashes[processor]['git_hash'] = git_hash
+            non_core_processor_hashes[processor]["git_hash"] = git_hash
 
     # return a dictionary containing the hashes we generated
     return {
-        'non_core_processors': non_core_processor_hashes,
-        'parent_recipes': parent_recipe_hashes
+        "non_core_processors": non_core_processor_hashes,
+        "parent_recipes": parent_recipe_hashes,
     }
 
 
 def get_git_diff(filepath, git_hash):
-    '''Get a git diff of filepath from git_hash'''
+    """Get a git diff of filepath from git_hash"""
     filepath = os.path.expanduser(filepath)
     try:
         git_toplevel_dir = run_git(
-            ['rev-parse', '--show-toplevel'],
-            git_directory=os.path.dirname(filepath)).rstrip('\n')
+            ["rev-parse", "--show-toplevel"], git_directory=os.path.dirname(filepath)
+        ).rstrip("\n")
     except GitError:
-        return ''
+        return ""
     relative_path = os.path.relpath(filepath, git_toplevel_dir)
     try:
         return run_git(
-            ['diff', '--color', git_hash, relative_path],
-            git_directory=git_toplevel_dir)
+            ["diff", "--color", git_hash, relative_path], git_directory=git_toplevel_dir
+        )
     except GitError:
-        return ''
+        return ""
 
 
 def get_git_log(filepath, git_hash):
-    '''Get log entries for commits for filepath since the commit referred to by
-    git_hash'''
+    """Get log entries for commits for filepath since the commit referred to by
+    git_hash"""
     filepath = os.path.expanduser(filepath)
     try:
         git_toplevel_dir = run_git(
-            ['rev-parse', '--show-toplevel'],
-            git_directory=os.path.dirname(filepath)).rstrip('\n')
+            ["rev-parse", "--show-toplevel"], git_directory=os.path.dirname(filepath)
+        ).rstrip("\n")
     except GitError:
-        return ''
+        return ""
     relative_path = os.path.relpath(filepath, git_toplevel_dir)
     try:
         return run_git(
-            ['log', git_hash + '..', '--', relative_path],
-            git_directory=git_toplevel_dir)
+            ["log", git_hash + "..", "--", relative_path],
+            git_directory=git_toplevel_dir,
+        )
     except GitError:
-        return ''
+        return ""
 
 
 class TrustVerificationWarning(AutoPackagerError):
-    '''Exception for trust verification warnings'''
+    """Exception for trust verification warnings"""
+
     pass
 
 
 class TrustVerificationError(AutoPackagerError):
-    '''Exception for trust verification errors'''
+    """Exception for trust verification errors"""
+
     pass
 
 
 def recipe_from_external_repo(recipe_path):
-    '''Returns True if the recipe_path is in a path in RECIPE_REPOS, which contains
-    recipes added via repo-add'''
+    """Returns True if the recipe_path is in a path in RECIPE_REPOS, which contains
+    recipes added via repo-add"""
     recipe_repos = get_pref("RECIPE_REPOS") or {}
     for repo in recipe_repos.keys():
         if recipe_path.startswith(repo):
@@ -1484,10 +1610,11 @@ def recipe_from_external_repo(recipe_path):
 
 
 def recipe_in_override_dir(recipe_path, override_dirs):
-    '''Returns True if the recipe is in a path in override_dirs'''
+    """Returns True if the recipe is in a path in override_dirs"""
     normalized_recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
-    normalized_override_dirs = [os.path.abspath(os.path.expanduser(directory))
-                                for directory in override_dirs]
+    normalized_override_dirs = [
+        os.path.abspath(os.path.expanduser(directory)) for directory in override_dirs
+    ]
     for override_dir in normalized_override_dirs:
         if normalized_recipe_path.startswith(override_dir):
             return True
@@ -1495,34 +1622,38 @@ def recipe_in_override_dir(recipe_path, override_dirs):
 
 
 def verify_parent_trust(recipe, override_dirs, search_dirs, verbosity=0):
-    '''Verify trust info for parent recipes'''
+    """Verify trust info for parent recipes"""
     # warn if trust info is in non-override
-    if (recipe.get('ParentRecipeTrustInfo') and
-            not recipe_in_override_dir(recipe["RECIPE_PATH"], override_dirs)):
+    if recipe.get("ParentRecipeTrustInfo") and not recipe_in_override_dir(
+        recipe["RECIPE_PATH"], override_dirs
+    ):
         warning = "Trust information in non-override recipe."
         if verbosity > 1:
             warning += (
-                '\nTrust info should only be stored in local recipe overrides.'
-                '\nTrust info found in %s' % recipe["RECIPE_PATH"])
+                "\nTrust info should only be stored in local recipe overrides."
+                "\nTrust info found in %s" % recipe["RECIPE_PATH"]
+            )
         raise TrustVerificationWarning(warning)
     # warn if no trust info
-    if not recipe.get('ParentRecipeTrustInfo'):
-        warning = 'No trust information present.'
-        if (recipe_in_override_dir(recipe["RECIPE_PATH"], override_dirs) and
-                recipe.get('PARENT_RECIPES')):
+    if not recipe.get("ParentRecipeTrustInfo"):
+        warning = "No trust information present."
+        if recipe_in_override_dir(recipe["RECIPE_PATH"], override_dirs) and recipe.get(
+            "PARENT_RECIPES"
+        ):
             if verbosity > 1:
                 warning += (
-                    '\nAudit the parent recipe, then run:\n'
-                    '\tautopkg update-trust-info %s' % recipe["name"])
+                    "\nAudit the parent recipe, then run:\n"
+                    "\tautopkg update-trust-info %s" % recipe["name"]
+                )
             raise TrustVerificationWarning(warning)
         else:
             if verbosity > 1:
                 warning += (
-                    '\nAudit the recipe, then store trust info by running:\n'
-                    '\tautopkg make-override %s' % recipe["name"])
+                    "\nAudit the recipe, then store trust info by running:\n"
+                    "\tautopkg make-override %s" % recipe["name"]
+                )
             raise TrustVerificationWarning(warning)
-    recipe_repo_dir = (get_pref("RECIPE_REPO_DIR") or
-                       "~/Library/AutoPkg/RecipeRepos")
+    recipe_repo_dir = get_pref("RECIPE_REPO_DIR") or "~/Library/AutoPkg/RecipeRepos"
     recipe_repo_dir = os.path.expanduser(recipe_repo_dir)
 
     # error if we can't use/trust the trust info (it was provided by another)
@@ -1530,120 +1661,129 @@ def verify_parent_trust(recipe, override_dirs, search_dirs, verbosity=0):
         # this recipe is in a cloned recipe repo; IE, not a local recipe
         # ignore any embedded trust info
         raise TrustVerificationError(
-            'Recipe from external repo: embedded trust info will be ignored. '
-            'Audit the recipe, then create an override to trust it.')
+            "Recipe from external repo: embedded trust info will be ignored. "
+            "Audit the recipe, then create an override to trust it."
+        )
 
     # verify trust of parent recipes
-    parent_recipe = load_recipe(recipe['ParentRecipe'],
-                                override_dirs, search_dirs,
-                                make_suggestions=False, search_github=False)
-    expected_trust_info = recipe['ParentRecipeTrustInfo']
+    parent_recipe = load_recipe(
+        recipe["ParentRecipe"],
+        override_dirs,
+        search_dirs,
+        make_suggestions=False,
+        search_github=False,
+    )
+    expected_trust_info = recipe["ParentRecipeTrustInfo"]
     actual_trust_info = get_trust_info(parent_recipe, search_dirs)
     if actual_trust_info == expected_trust_info:
         # shortcut if the two dictionaries match perfectly
         return
     # look for differences
-    trust_errors = u''
+    trust_errors = u""
     # get detail on non_core_processors
-    expected_processor_names = set(
-        expected_trust_info['non_core_processors'].keys())
-    actual_processor_names = set(
-        actual_trust_info['non_core_processors'].keys())
+    expected_processor_names = set(expected_trust_info["non_core_processors"].keys())
+    actual_processor_names = set(actual_trust_info["non_core_processors"].keys())
     for processor in expected_processor_names:
-        expected_hash = (
-            expected_trust_info['non_core_processors'][
-                processor]['sha256_hash'])
-        git_hash = expected_trust_info['non_core_processors'][
-            processor].get('git_hash')
+        expected_hash = expected_trust_info["non_core_processors"][processor][
+            "sha256_hash"
+        ]
+        git_hash = expected_trust_info["non_core_processors"][processor].get("git_hash")
         actual_hash = (
-            actual_trust_info['non_core_processors'].get(
-                processor, {}).get('sha256_hash'))
+            actual_trust_info["non_core_processors"]
+            .get(processor, {})
+            .get("sha256_hash")
+        )
         if expected_hash != actual_hash:
             processor_path = find_processor_path(processor, recipe)
             if processor_path:
                 trust_errors += (
-                    "Processor %s contents differ from expected.\n" % processor)
-                trust_errors += (
-                    '    Path: %s\n' % processor_path)
+                    "Processor %s contents differ from expected.\n" % processor
+                )
+                trust_errors += "    Path: %s\n" % processor_path
             else:
-                trust_errors += (
-                    'Expected processor %s can\'t be found.\n' % processor)
-                processor_path = expected_trust_info['non_core_processors'][
-                    processor].get('path')
+                trust_errors += "Expected processor %s can't be found.\n" % processor
+                processor_path = expected_trust_info["non_core_processors"][
+                    processor
+                ].get("path")
             if verbosity > 1 and processor_path and git_hash:
                 trust_errors += get_git_diff(processor_path, git_hash)
                 trust_errors += get_git_log(processor_path, git_hash)
-                trust_errors += '\n'
+                trust_errors += "\n"
     for processor in actual_processor_names:
         if processor not in expected_processor_names:
             trust_errors += "Unexpected processor found: %s\n" % processor
             processor_path = find_processor_path(processor, recipe)
             if processor_path:
-                trust_errors += (
-                    '    Path: %s\n' % processor_path)
+                trust_errors += "    Path: %s\n" % processor_path
 
     # get detail on parent_recipes
-    expected_parent_recipes = (
-        expected_trust_info['parent_recipes'].keys())
-    actual_parent_recipes = (
-        actual_trust_info['parent_recipes'].keys())
+    expected_parent_recipes = expected_trust_info["parent_recipes"].keys()
+    actual_parent_recipes = actual_trust_info["parent_recipes"].keys()
     if set(expected_parent_recipes) != set(actual_parent_recipes):
-        trust_errors += ("Expected parent recipe list: %s\n"
-                         % list(expected_parent_recipes))
-        trust_errors += ("Actual parent recipe list: %s\n"
-                         % list(actual_parent_recipes))
+        trust_errors += "Expected parent recipe list: %s\n" % list(
+            expected_parent_recipes
+        )
+        trust_errors += "Actual parent recipe list: %s\n" % list(actual_parent_recipes)
     for p_recipe_id in expected_parent_recipes:
-        expected_hash = (
-            expected_trust_info['parent_recipes'][
-                p_recipe_id]['sha256_hash'])
-        git_hash = expected_trust_info['parent_recipes'][
-            p_recipe_id].get('git_hash')
+        expected_hash = expected_trust_info["parent_recipes"][p_recipe_id][
+            "sha256_hash"
+        ]
+        git_hash = expected_trust_info["parent_recipes"][p_recipe_id].get("git_hash")
         actual_hash = (
-            actual_trust_info['parent_recipes'].get(
-                p_recipe_id, {}).get('sha256_hash'))
+            actual_trust_info["parent_recipes"].get(p_recipe_id, {}).get("sha256_hash")
+        )
         if expected_hash != actual_hash:
             p_recipe = load_recipe(
-                p_recipe_id, override_dirs, search_dirs,
-                make_suggestions=False, search_github=False)
+                p_recipe_id,
+                override_dirs,
+                search_dirs,
+                make_suggestions=False,
+                search_github=False,
+            )
             if p_recipe:
                 trust_errors += (
-                    "Parent recipe %s contents differ from expected.\n"
-                    % p_recipe_id)
-                trust_errors += (
-                    "    Path: %s\n" % p_recipe["RECIPE_PATH"])
+                    "Parent recipe %s contents differ from expected.\n" % p_recipe_id
+                )
+                trust_errors += "    Path: %s\n" % p_recipe["RECIPE_PATH"]
                 recipe_path = p_recipe["RECIPE_PATH"]
             else:
                 trust_errors += (
-                    'Expected parent recipe %s can\'t be found.\n'
-                    % p_recipe_id)
-                recipe_path = expected_trust_info['parent_recipes'][
-                    p_recipe_id].get('path')
+                    "Expected parent recipe %s can't be found.\n" % p_recipe_id
+                )
+                recipe_path = expected_trust_info["parent_recipes"][p_recipe_id].get(
+                    "path"
+                )
             if verbosity > 1 and recipe_path and git_hash:
                 trust_errors += get_git_log(recipe_path, git_hash)
                 trust_errors += get_git_diff(recipe_path, git_hash)
-                trust_errors += '\n'
+                trust_errors += "\n"
     for p_recipe_id in actual_parent_recipes:
         if p_recipe_id not in expected_parent_recipes:
             trust_errors += "Unexpected parent recipe found: %s\n" % p_recipe_id
             p_recipe = load_recipe(
-                p_recipe_id, override_dirs, search_dirs,
-                make_suggestions=False, search_github=False)
+                p_recipe_id,
+                override_dirs,
+                search_dirs,
+                make_suggestions=False,
+                search_github=False,
+            )
             if p_recipe:
-                trust_errors += (
-                    "    Path: %s\n" % p_recipe["RECIPE_PATH"])
+                trust_errors += "    Path: %s\n" % p_recipe["RECIPE_PATH"]
 
     if trust_errors:
         raise TrustVerificationError(trust_errors)
 
 
 def update_trust_info(argv):
-    '''Update the parent recipe trust information stored in a recipe override'''
+    """Update the parent recipe trust information stored in a recipe override"""
     verb = argv[1]
     parser = optparse.OptionParser()
 
-    parser.set_usage("Usage: %s %s [options] recipe_override_name [...]\n"
-                     "Update or add parent recipe trust information for a "
-                     "recipe override." % ("%prog", verb))
+    parser.set_usage(
+        "Usage: %s %s [options] recipe_override_name [...]\n"
+        "Update or add parent recipe trust information for a "
+        "recipe override." % ("%prog", verb)
+    )
 
     # Parse arguments
     add_search_and_override_dir_options(parser)
@@ -1653,26 +1793,33 @@ def update_trust_info(argv):
     search_dirs = options.search_dirs or get_search_dirs()
 
     if not recipe_names:
-        log_err('Need at least one recipe name or path!')
+        log_err("Need at least one recipe name or path!")
         log_err(parser.get_usage())
         return -1
 
     for recipe_name in recipe_names:
-        recipe_path = locate_recipe(recipe_name, override_dirs, search_dirs,
-                                    make_suggestions=True, search_github=False)
+        recipe_path = locate_recipe(
+            recipe_name,
+            override_dirs,
+            search_dirs,
+            make_suggestions=True,
+            search_github=False,
+        )
         if not recipe_path:
             log_err("Cannot find a recipe for %s." % recipe_name)
             continue
         # normalize recipe path
         recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
         recipe = FoundationPlist.readPlist(recipe_path)
-        if 'ParentRecipe' not in recipe:
-            log_err("%s is not a recipe override and has no parent recipe."
-                    % recipe_name)
+        if "ParentRecipe" not in recipe:
+            log_err(
+                "%s is not a recipe override and has no parent recipe." % recipe_name
+            )
             log_err("Path: %s" % recipe_path)
             continue
-        if ('ParentRecipeTrustInfo' not in recipe
-                and not recipe_in_override_dir(recipe_path, override_dirs)):
+        if "ParentRecipeTrustInfo" not in recipe and not recipe_in_override_dir(
+            recipe_path, override_dirs
+        ):
             print("%s does not appear to be a recipe override." % recipe_name)
             if recipe_from_external_repo(recipe_path):
                 # don't offer to add parent trust info to a recipe from
@@ -1681,34 +1828,46 @@ def update_trust_info(argv):
             else:
                 # must be a local recipe
                 answer = raw_input("Add parent trust info anyway? [y/n]: ")
-                if not answer.lower().startswith('y'):
+                if not answer.lower().startswith("y"):
                     continue
         # add trust info
-        parent_recipe = load_recipe(
-            recipe["ParentRecipe"], override_dirs, search_dirs)
+        parent_recipe = load_recipe(recipe["ParentRecipe"], override_dirs, search_dirs)
         if parent_recipe:
-            recipe['ParentRecipeTrustInfo'] = get_trust_info(
-                parent_recipe, search_dirs=search_dirs)
+            recipe["ParentRecipeTrustInfo"] = get_trust_info(
+                parent_recipe, search_dirs=search_dirs
+            )
             FoundationPlist.writePlist(recipe, recipe_path)
             log("Wrote updated %s" % recipe_path)
         else:
-            log_err("Could not find parent recipe %s for %s."
-                    % (recipe["ParentRecipe"], recipe_name))
+            log_err(
+                "Could not find parent recipe %s for %s."
+                % (recipe["ParentRecipe"], recipe_name)
+            )
 
 
 def verify_trust_info(argv):
-    '''Verify the parent recipe trust information stored in a recipe override'''
+    """Verify the parent recipe trust information stored in a recipe override"""
     verb = argv[1]
     parser = optparse.OptionParser()
 
-    parser.set_usage("Usage: %s %s [options] recipe_override_name [...]\n"
-                     "Verify parent recipe trust information for a "
-                     "recipe override." % ("%prog", verb))
-    parser.add_option("-l", "--recipe-list", metavar="TEXT_FILE",
-                      help=("Path to a text file with a list of recipes to "
-                            "verify."))
-    parser.add_option("-v", "--verbose", action="count", default=0,
-                      help="Verbose output. May be specified multiple times.")
+    parser.set_usage(
+        "Usage: %s %s [options] recipe_override_name [...]\n"
+        "Verify parent recipe trust information for a "
+        "recipe override." % ("%prog", verb)
+    )
+    parser.add_option(
+        "-l",
+        "--recipe-list",
+        metavar="TEXT_FILE",
+        help=("Path to a text file with a list of recipes to " "verify."),
+    )
+    parser.add_option(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Verbose output. May be specified multiple times.",
+    )
 
     # Parse arguments
     add_search_and_override_dir_options(parser)
@@ -1720,50 +1879,58 @@ def verify_trust_info(argv):
 
     if options.recipe_list:
         recipe_list = parse_recipe_list(options.recipe_list)
-        recipe_names.extend(recipe_list.get('recipes', []))
+        recipe_names.extend(recipe_list.get("recipes", []))
 
     if not recipe_names:
-        log_err('Need at least one recipe name or path!')
+        log_err("Need at least one recipe name or path!")
         log_err(parser.get_usage())
         return -1
 
     for recipe_name in recipe_names:
-        recipe = load_recipe(recipe_name, override_dirs, search_dirs,
-                             make_suggestions=True, search_github=False)
+        recipe = load_recipe(
+            recipe_name,
+            override_dirs,
+            search_dirs,
+            make_suggestions=True,
+            search_github=False,
+        )
         if not recipe:
-            log_err('%s: NOT FOUND' % recipe_name)
+            log_err("%s: NOT FOUND" % recipe_name)
             return_code = 1
             continue
         try:
-            verify_parent_trust(
-                recipe, override_dirs, search_dirs, options.verbose)
+            verify_parent_trust(recipe, override_dirs, search_dirs, options.verbose)
         except AutoPackagerError as err:
-            log_err('%s: FAILED' % recipe_name)
+            log_err("%s: FAILED" % recipe_name)
             if options.verbose > 0 and unicode(err):
                 for line in unicode(err).splitlines():
-                    log_err('    %s' % line)
+                    log_err("    %s" % line)
             return_code = 1
         else:
-            log('%s: OK' % recipe_name)
+            log("%s: OK" % recipe_name)
     return return_code
 
 
 def make_override(argv):
-    '''Make a recipe override skeleton.'''
+    """Make a recipe override skeleton."""
     verb = argv[1]
     parser = optparse.OptionParser()
 
-    parser.set_usage("Usage: %s %s [options] [recipe]\n"
-                     "Create a skeleton override file for a recipe. It will "
-                     "be stored in the first default override directory "
-                     "or that given by '--override-dir'" % ("%prog", verb))
+    parser.set_usage(
+        "Usage: %s %s [options] [recipe]\n"
+        "Create a skeleton override file for a recipe. It will "
+        "be stored in the first default override directory "
+        "or that given by '--override-dir'" % ("%prog", verb)
+    )
 
     # Parse arguments
     add_search_and_override_dir_options(parser)
-    parser.add_option("-n", "--name", metavar="FILENAME",
-                      help="Name for override file.")
-    parser.add_option("-f", "--force", action="store_true",
-                      help="Force overwrite an override file.")
+    parser.add_option(
+        "-n", "--name", metavar="FILENAME", help="Name for override file."
+    )
+    parser.add_option(
+        "-f", "--force", action="store_true", help="Force overwrite an override file."
+    )
     options, arguments = parser.parse_args(argv[2:])
 
     override_dirs = options.override_dirs or get_override_dirs()
@@ -1775,16 +1942,20 @@ def make_override(argv):
 
     recipe_name = arguments[0]
     if os.path.isfile(recipe_name):
-        log_err("%s doesn't work with absolute recipe paths, "
-                "as it may not be able to correctly determine the value "
-                "for 'name' that would be searched in recipe directories."
-                % verb)
+        log_err(
+            "%s doesn't work with absolute recipe paths, "
+            "as it may not be able to correctly determine the value "
+            "for 'name' that would be searched in recipe directories." % verb
+        )
         return -1
 
-    recipe = load_recipe(recipe_name,
-                         override_dirs=[],
-                         recipe_dirs=search_dirs,
-                         make_suggestions=True, search_github=False)
+    recipe = load_recipe(
+        recipe_name,
+        override_dirs=[],
+        recipe_dirs=search_dirs,
+        make_suggestions=True,
+        search_github=False,
+    )
     if not recipe:
         log_err("No valid recipe found for %s" % recipe_name)
         log_err("Dir(s) searched:\n\t%s" % "\n\t".join(search_dirs))
@@ -1793,24 +1964,29 @@ def make_override(argv):
     # make sure parent has an identifier
     parent_identifier = get_identifier(recipe)
     if not parent_identifier:
-        log_err("%s is missing an Identifier. Cannot make an override."
-                % recipe.get("RECIPE_PATH", recipe_name))
+        log_err(
+            "%s is missing an Identifier. Cannot make an override."
+            % recipe.get("RECIPE_PATH", recipe_name)
+        )
         return 1
 
     override_name = (
-        options.name
-        or os.path.splitext(os.path.basename(recipe["RECIPE_PATH"]))[0])
+        options.name or os.path.splitext(os.path.basename(recipe["RECIPE_PATH"]))[0]
+    )
 
-    reversed_name = '.'.join(reversed(override_name.split('.')))
+    reversed_name = ".".join(reversed(override_name.split(".")))
     override_identifier = "local." + reversed_name
 
-    override_plist = {"Identifier": override_identifier,
-                      "Input": recipe["Input"],
-                      "ParentRecipe": parent_identifier}
+    override_plist = {
+        "Identifier": override_identifier,
+        "Input": recipe["Input"],
+        "ParentRecipe": parent_identifier,
+    }
 
     # add trust info
-    override_plist['ParentRecipeTrustInfo'] = get_trust_info(
-        recipe, search_dirs=search_dirs)
+    override_plist["ParentRecipeTrustInfo"] = get_trust_info(
+        recipe, search_dirs=search_dirs
+    )
 
     if "IDENTIFIER" in override_plist["Input"]:
         del override_plist["Input"]["IDENTIFIER"]
@@ -1824,15 +2000,17 @@ def make_override(argv):
             return -1
 
     override_name = (
-        options.name
-        or os.path.splitext(os.path.basename(recipe["RECIPE_PATH"]))[0])
+        options.name or os.path.splitext(os.path.basename(recipe["RECIPE_PATH"]))[0]
+    )
 
     override_file = os.path.join(override_dir, "%s.recipe" % override_name)
     if os.path.exists(override_file):
         if not options.force:
-            log_err("An override plist already exists at %s, "
-                    "will not overwrite it. Use --force to overwrite "
-                    "anyway." % override_file)
+            log_err(
+                "An override plist already exists at %s, "
+                "will not overwrite it. Use --force to overwrite "
+                "anyway." % override_file
+            )
             return -1
         os.unlink(override_file)
     FoundationPlist.writePlist(override_plist, override_file)
@@ -1841,23 +2019,23 @@ def make_override(argv):
 
 
 def parse_recipe_list(filename):
-    '''Parses a recipe list. This can be either a simple list of recipes to run,
-    or a plist containing recipes and other key/value pairs'''
+    """Parses a recipe list. This can be either a simple list of recipes to run,
+    or a plist containing recipes and other key/value pairs"""
     recipe_list = {}
     try:
         plist = FoundationPlist.readPlist(filename)
-        if not plist.get('recipes'):
+        if not plist.get("recipes"):
             # try to trigger an AttributeError if the plist is not a dict
             pass
         return plist
-    except (FoundationPlist.NSPropertyListSerializationException,
-            AttributeError):
+    except (FoundationPlist.NSPropertyListSerializationException, AttributeError):
         # file does not appear to be a plist containing a dictionary;
         # read it as a plaintext list of recipes
         with open(filename, "r") as file_desc:
             data = file_desc.read()
-        recipe_list['recipes'] = [line for line in data.splitlines()
-                                  if line and not line.startswith("#")]
+        recipe_list["recipes"] = [
+            line for line in data.splitlines() if line and not line.startswith("#")
+        ]
     return recipe_list
 
 
@@ -1866,46 +2044,96 @@ def run_recipes(argv):
        recipe"""
     verb = argv[1]
     parser = optparse.OptionParser()
-    if verb == 'install':
-        parser.set_usage("Usage: %s %s [options] [itemname ...]\n"
-                         "Install one or more items." % ("%prog", verb))
+    if verb == "install":
+        parser.set_usage(
+            "Usage: %s %s [options] [itemname ...]\n"
+            "Install one or more items." % ("%prog", verb)
+        )
     else:
-        parser.set_usage("Usage: %s %s [options] [recipe ...]\n"
-                         "Run one or more recipes." % ("%prog", verb))
+        parser.set_usage(
+            "Usage: %s %s [options] [recipe ...]\n"
+            "Run one or more recipes." % ("%prog", verb)
+        )
 
     # Parse arguments.
-    parser.add_option('--pre', '--preprocessor', action='append',
-                      dest='preprocessors', default=[], metavar="PREPROCESSOR",
-                      help=("Name of a processor to run before each recipe. "
-                            "Can be repeated to run multiple preprocessors."))
-    parser.add_option('--post', '--postprocessor', action='append',
-                      dest='postprocessors', default=[],
-                      metavar="POSTPROCESSOR",
-                      help=("Name of a processor to run after each recipe. "
-                            "Can be repeated to run multiple postprocessors."))
-    parser.add_option("-c", "--check", action="store_true",
-                      help="Only check for new/changed downloads.")
-    parser.add_option("--ignore-parent-trust-verification-errors",
-                      action="store_true", default=False,
-                      help=("Run recipes even if they fail parent trust "
-                            "verification."))
-    parser.add_option("-k", "--key", action="append", dest="variables",
-                      default=[], metavar="KEY=VALUE",
-                      help=("Provide key/value pairs for recipe input. "
-                            "Caution: values specified here will be applied "
-                            "to all recipes."))
-    parser.add_option("-l", "--recipe-list", metavar="TEXT_FILE",
-                      help="Path to a text file with a list of recipes to run.")
-    parser.add_option("-p", "--pkg", metavar="PKG_OR_DMG",
-                      help=("Path to a pkg or dmg to provide to a recipe. "
-                            "Downloading will be skipped."))
-    parser.add_option("--report-plist", metavar="OUTPUT_PATH",
-                      help=("File path to save run report plist."))
-    parser.add_option("-v", "--verbose", action="count", default=0,
-                      help="Verbose output.")
-    parser.add_option("-q", "--quiet", action="store_true",
-                      help=("Don't offer to search Github if a recipe can't "
-                            "be found."))
+    parser.add_option(
+        "--pre",
+        "--preprocessor",
+        action="append",
+        dest="preprocessors",
+        default=[],
+        metavar="PREPROCESSOR",
+        help=(
+            "Name of a processor to run before each recipe. "
+            "Can be repeated to run multiple preprocessors."
+        ),
+    )
+    parser.add_option(
+        "--post",
+        "--postprocessor",
+        action="append",
+        dest="postprocessors",
+        default=[],
+        metavar="POSTPROCESSOR",
+        help=(
+            "Name of a processor to run after each recipe. "
+            "Can be repeated to run multiple postprocessors."
+        ),
+    )
+    parser.add_option(
+        "-c",
+        "--check",
+        action="store_true",
+        help="Only check for new/changed downloads.",
+    )
+    parser.add_option(
+        "--ignore-parent-trust-verification-errors",
+        action="store_true",
+        default=False,
+        help=("Run recipes even if they fail parent trust " "verification."),
+    )
+    parser.add_option(
+        "-k",
+        "--key",
+        action="append",
+        dest="variables",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Provide key/value pairs for recipe input. "
+            "Caution: values specified here will be applied "
+            "to all recipes."
+        ),
+    )
+    parser.add_option(
+        "-l",
+        "--recipe-list",
+        metavar="TEXT_FILE",
+        help="Path to a text file with a list of recipes to run.",
+    )
+    parser.add_option(
+        "-p",
+        "--pkg",
+        metavar="PKG_OR_DMG",
+        help=(
+            "Path to a pkg or dmg to provide to a recipe. "
+            "Downloading will be skipped."
+        ),
+    )
+    parser.add_option(
+        "--report-plist",
+        metavar="OUTPUT_PATH",
+        help=("File path to save run report plist."),
+    )
+    parser.add_option(
+        "-v", "--verbose", action="count", default=0, help="Verbose output."
+    )
+    parser.add_option(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help=("Don't offer to search Github if a recipe can't " "be found."),
+    )
     add_search_and_override_dir_options(parser)
     options, arguments = parser.parse_args(argv[2:])
 
@@ -1921,14 +2149,14 @@ def run_recipes(argv):
 
     # get our list of recipes
     recipe_paths = []
-    if verb == 'install':
+    if verb == "install":
         # hold on for syntactic sugar!
         for index, item in enumerate(arguments):
             # if recipe doesn't have an extension, append '.install'
             if not os.path.splitext(item)[1]:
                 # no extension!
-                arguments[index] = item + '.install'
-            elif os.path.splitext(item)[1] != '.install':
+                arguments[index] = item + ".install"
+            elif os.path.splitext(item)[1] != ".install":
                 log_err("Can't install with a non-install recipe: %s" % item)
                 del arguments[index]
 
@@ -1936,9 +2164,9 @@ def run_recipes(argv):
     recipe_list = {}
     if options.recipe_list:
         recipe_list = parse_recipe_list(options.recipe_list)
-        recipe_paths.extend(recipe_list.get('recipes', []))
-        preprocessors = recipe_list.get('preprocessors', [])
-        postprocessors = recipe_list.get('postprocessors', [])
+        recipe_paths.extend(recipe_list.get("recipes", []))
+        preprocessors = recipe_list.get("preprocessors", [])
+        postprocessors = recipe_list.get("postprocessors", [])
 
     if not recipe_paths:
         log_err(parser.get_usage())
@@ -1963,7 +2191,7 @@ def run_recipes(argv):
     # environment variables
     if recipe_list:
         for key, value in recipe_list.items():
-            if key not in ['recipes', 'preprocessors', 'postprocessors']:
+            if key not in ["recipes", "preprocessors", "postprocessors"]:
                 cli_values[key] = value
 
     # Add variables from commandline. These might override those from
@@ -1994,8 +2222,8 @@ def run_recipes(argv):
         FoundationPlist.writePlist(run_results, current_run_results_plist)
     except IOError as err:
         log_err(
-            "Can't write results to %s: %s"
-            % (current_run_results_plist, err.strerror))
+            "Can't write results to %s: %s" % (current_run_results_plist, err.strerror)
+        )
 
     if options.report_plist:
         results_report = dict()
@@ -2011,13 +2239,15 @@ def run_recipes(argv):
         # don't make suggestions or search Github if told to be quiet
         make_suggestions = False
     for recipe_path in recipe_paths:
-        recipe = load_recipe(recipe_path,
-                             override_dirs,
-                             search_dirs,
-                             preprocessors,
-                             postprocessors,
-                             make_suggestions=make_suggestions,
-                             search_github=make_suggestions)
+        recipe = load_recipe(
+            recipe_path,
+            override_dirs,
+            search_dirs,
+            preprocessors,
+            postprocessors,
+            make_suggestions=make_suggestions,
+            search_github=make_suggestions,
+        )
         if not recipe:
             if not make_suggestions:
                 log_err("No valid recipe found for %s" % recipe_path)
@@ -2027,12 +2257,16 @@ def run_recipes(argv):
         if options.check:
             # remove steps from the end of the recipe Process until we find a
             # EndOfCheckPhase step
-            while len(recipe["Process"]) >= 1 and \
-                    recipe["Process"][-1]["Processor"] != "EndOfCheckPhase":
+            while (
+                len(recipe["Process"]) >= 1
+                and recipe["Process"][-1]["Processor"] != "EndOfCheckPhase"
+            ):
                 del recipe["Process"][-1]
             if len(recipe["Process"]) == 0:
-                log_err("Recipe at %s is missing EndOfCheckPhase Processor, "
-                        "not possible to perform check." % recipe_path)
+                log_err(
+                    "Recipe at %s is missing EndOfCheckPhase Processor, "
+                    "not possible to perform check." % recipe_path
+                )
                 error_count += 1
                 continue
 
@@ -2054,36 +2288,40 @@ def run_recipes(argv):
 
         autopackager = AutoPackager(options, prefs)
 
-        fail_recipes_without_trust_info = bool(cli_values.get(
-            'FAIL_RECIPES_WITHOUT_TRUST_INFO', prefs.get(
-                'FAIL_RECIPES_WITHOUT_TRUST_INFO')))
+        fail_recipes_without_trust_info = bool(
+            cli_values.get(
+                "FAIL_RECIPES_WITHOUT_TRUST_INFO",
+                prefs.get("FAIL_RECIPES_WITHOUT_TRUST_INFO"),
+            )
+        )
 
-        if ('ParentRecipeTrustInfo' not in recipe and
-                not fail_recipes_without_trust_info):
-            log_err("WARNING: %s is missing trust info and "
-                    "FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. "
-                    "Proceeding..." % recipe_path)
+        if (
+            "ParentRecipeTrustInfo" not in recipe
+            and not fail_recipes_without_trust_info
+        ):
+            log_err(
+                "WARNING: %s is missing trust info and "
+                "FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. "
+                "Proceeding..." % recipe_path
+            )
 
         # we should also skip trust verification if we've been told to ignore
         # verification errors
-        skip_trust_verification = (
-            options.ignore_parent_trust_verification_errors or
-            ('ParentRecipeTrustInfo' not in recipe and
-             not fail_recipes_without_trust_info)
+        skip_trust_verification = options.ignore_parent_trust_verification_errors or (
+            "ParentRecipeTrustInfo" not in recipe
+            and not fail_recipes_without_trust_info
         )
 
         try:
             if not skip_trust_verification:
-                verify_parent_trust(
-                    recipe, override_dirs, search_dirs, options.verbose)
+                verify_parent_trust(recipe, override_dirs, search_dirs, options.verbose)
             autopackager.process_cli_overrides(recipe, cli_values)
             autopackager.verify(recipe)
             autopackager.process(recipe)
         except AutoPackagerError as err:
             error_count += 1
             failure = {}
-            if isinstance(err,
-                          (TrustVerificationWarning, TrustVerificationError)):
+            if isinstance(err, (TrustVerificationWarning, TrustVerificationError)):
                 log_err("Failed local trust verification.")
             else:
                 log_err("Failed.")
@@ -2091,7 +2329,7 @@ def run_recipes(argv):
             failure["message"] = unicode(err)
             failure["traceback"] = traceback.format_exc()
             failures.append(failure)
-            autopackager.results.append({'RecipeError': unicode(err).rstrip()})
+            autopackager.results.append({"RecipeError": unicode(err).rstrip()})
 
         run_results.append(autopackager.results)
         try:
@@ -2099,7 +2337,8 @@ def run_recipes(argv):
         except IOError as err:
             log_err(
                 "Can't write results to %s: %s"
-                % (current_run_results_plist, err.strerror))
+                % (current_run_results_plist, err.strerror)
+            )
 
         # build a pathname for a receipt
         recipe_basename = os.path.splitext(os.path.basename(recipe_path))[0]
@@ -2108,7 +2347,8 @@ def run_recipes(argv):
         # write a recipt. We should handle this better.
         # for now, just write the receipt to /tmp/receipts
         receipt_dir = os.path.join(
-            autopackager.env.get("RECIPE_CACHE_DIR", "/tmp"), "receipts")
+            autopackager.env.get("RECIPE_CACHE_DIR", "/tmp"), "receipts"
+        )
         timestamp = time.strftime("%Y%m%d-%H%M%S")
         receipt_name = "%s-receipt-%s.plist" % (recipe_basename, timestamp)
 
@@ -2124,20 +2364,22 @@ def run_recipes(argv):
             if item.get("Output"):
                 # record any summary results
                 output_keys = item["Output"].keys()
-                results_keys = [key for key in output_keys
-                                if key.endswith('_summary_result')]
+                results_keys = [
+                    key for key in output_keys if key.endswith("_summary_result")
+                ]
                 for key in results_keys:
                     result = item["Output"][key]
-                    summary_text = result.get('summary_text', '')
-                    data = result.get('data')
+                    summary_text = result.get("summary_text", "")
+                    data = result.get("data")
                     if key not in summary_results:
                         summary_results[key] = {}
-                        summary_results[key]['summary_text'] = summary_text
-                        if type(data).__name__ in ['dict', '__NSCFDictionary']:
-                            summary_results[key]['header'] = (
-                                result.get('report_fields') or data.keys())
-                        summary_results[key]['data_rows'] = []
-                    summary_results[key]['data_rows'].append(data)
+                        summary_results[key]["summary_text"] = summary_text
+                        if type(data).__name__ in ["dict", "__NSCFDictionary"]:
+                            summary_results[key]["header"] = (
+                                result.get("report_fields") or data.keys()
+                            )
+                        summary_results[key]["data_rows"] = []
+                    summary_results[key]["data_rows"].append(data)
 
         # save receipt
         if os.path.exists(receipt_dir):
@@ -2147,8 +2389,7 @@ def run_recipes(argv):
                 if options.verbose:
                     log("Receipt written to %s" % receipt_path)
             except IOError as err:
-                log_err("Can't write receipt to %s: %s"
-                        % (receipt_path, err.strerror))
+                log_err("Can't write receipt to %s: %s" % (receipt_path, err.strerror))
 
     # done running recipes, print a summary
     if failures:
@@ -2160,28 +2401,29 @@ def run_recipes(argv):
 
     if summary_results:
         for key, value in summary_results.items():
-            log("\n%s" % value['summary_text'])
+            log("\n%s" % value["summary_text"])
 
             # make our table header
-            display_header = [item.replace('_', ' ').title()
-                              for item in value['header']]
-            underlines = ['-' * len(item) for item in value['header']]
+            display_header = [
+                item.replace("_", " ").title() for item in value["header"]
+            ]
+            underlines = ["-" * len(item) for item in value["header"]]
             rows = [display_header, underlines]
-            for row in value['data_rows']:
+            for row in value["data_rows"]:
                 this_row = []
-                for field in value['header']:
+                for field in value["header"]:
                     this_row.append(row[field])
                 rows.append(this_row)
 
             # calculate the widths of each column
             widths = []
-            for column in range(len(value['header'])):
+            for column in range(len(value["header"])):
                 this_column = [len(row[column]) for row in rows]
                 widths.append(max(this_column) + 2)
 
             # build a format string for each row based on our
             # column widths
-            format_str = '    '
+            format_str = "    "
             for count, width in enumerate(widths):
                 # adding format strings with 'count' for 2.6 compatibility
                 format_str += "{" + str(count) + ":<" + str(width) + "}"
@@ -2195,8 +2437,8 @@ def run_recipes(argv):
 
     # save report plist with the summary data
     if options.report_plist:
-        results_report['failures'] = failures
-        results_report['summary_results'] = summary_results
+        results_report["failures"] = failures
+        results_report["summary_results"] = summary_results
         write_plist_exit_on_fail(results_report, options.report_plist)
         log("\nReport plist saved to %s." % options.report_plist)
 
@@ -2206,24 +2448,24 @@ def run_recipes(argv):
 
 def printplistitem(label, value, indent=0):
     """Prints a plist item in an 'attractive' way"""
-    indentspace = '    '
+    indentspace = "    "
     if value is None:
-        log(indentspace * indent + '%s: !NONE!' % label)
-    elif type(value) == list or type(value).__name__ == 'NSCFArray':
+        log(indentspace * indent + "%s: !NONE!" % label)
+    elif type(value) == list or type(value).__name__ == "NSCFArray":
         if label:
-            log(indentspace * indent + '%s:' % label)
+            log(indentspace * indent + "%s:" % label)
         for item in value:
-            printplistitem('', item, indent + 1)
-    elif type(value) == dict or type(value).__name__ == 'NSCFDictionary':
+            printplistitem("", item, indent + 1)
+    elif type(value) == dict or type(value).__name__ == "NSCFDictionary":
         if label:
-            log(indentspace * indent + '%s:' % label)
+            log(indentspace * indent + "%s:" % label)
         for subkey in value.keys():
             printplistitem(subkey, value[subkey], indent + 1)
     else:
         if label:
-            log(indentspace * indent + '%s: %s' % (label, value))
+            log(indentspace * indent + "%s: %s" % (label, value))
         else:
-            log(indentspace * indent + '%s' % value)
+            log(indentspace * indent + "%s" % value)
 
 
 def printplist(plistdict):
@@ -2235,42 +2477,52 @@ def printplist(plistdict):
 
 
 def find_http_urls_in_recipe(recipe):
-    '''Looks in the Input and Process sections of a recipe for any http URLs.
-    Returns a dict.'''
+    """Looks in the Input and Process sections of a recipe for any http URLs.
+    Returns a dict."""
     recipe_urls = {}
-    for key, value in recipe.get('Input', {}).items():
-        if isinstance(value, basestring) and value.startswith('http:'):
-            if 'Input' not in recipe_urls:
-                recipe_urls['Input'] = {}
-            recipe_urls['Input'][key] = value
-    for step in recipe.get('Process', []):
-        processor = step['Processor']
-        arguments = step.get('Arguments', {})
+    for key, value in recipe.get("Input", {}).items():
+        if isinstance(value, basestring) and value.startswith("http:"):
+            if "Input" not in recipe_urls:
+                recipe_urls["Input"] = {}
+            recipe_urls["Input"][key] = value
+    for step in recipe.get("Process", []):
+        processor = step["Processor"]
+        arguments = step.get("Arguments", {})
         for key, value in arguments.items():
-            if isinstance(value, basestring) and value.startswith('http:'):
-                if 'Process' not in recipe_urls:
-                    recipe_urls['Process'] = {}
-                if processor not in recipe_urls['Process']:
-                    recipe_urls['Process'][processor] = {}
-                recipe_urls['Process'][processor][key] = value
+            if isinstance(value, basestring) and value.startswith("http:"):
+                if "Process" not in recipe_urls:
+                    recipe_urls["Process"] = {}
+                if processor not in recipe_urls["Process"]:
+                    recipe_urls["Process"][processor] = {}
+                recipe_urls["Process"][processor][key] = value
     return recipe_urls
 
 
 def audit(argv):
-    '''Audit one or more recipes.'''
+    """Audit one or more recipes."""
     verb = argv[1]
     parser = optparse.OptionParser()
 
-    parser.set_usage("Usage: %s %s [options] recipe [..]\n"
-                     "Audit one or more recipes." % ("%prog", verb))
+    parser.set_usage(
+        "Usage: %s %s [options] recipe [..]\n"
+        "Audit one or more recipes." % ("%prog", verb)
+    )
 
     # Parse arguments
     add_search_and_override_dir_options(parser)
-    parser.add_option("-l", "--recipe-list", metavar="TEXT_FILE",
-                      help="Path to a text file with a list of recipes to "
-                           "audit.")
-    parser.add_option("-p", "--plist", action="store_true", default=False,
-                      help="Output in plist format.")
+    parser.add_option(
+        "-l",
+        "--recipe-list",
+        metavar="TEXT_FILE",
+        help="Path to a text file with a list of recipes to " "audit.",
+    )
+    parser.add_option(
+        "-p",
+        "--plist",
+        action="store_true",
+        default=False,
+        help="Output in plist format.",
+    )
 
     options, arguments = parser.parse_args(argv[2:])
 
@@ -2278,28 +2530,28 @@ def audit(argv):
     search_dirs = options.search_dirs or get_search_dirs()
 
     # these processors download items
-    DOWNLOAD_PROCESSORS = {'CURLDownloader', 'URLDownloader'}
+    DOWNLOAD_PROCESSORS = {"CURLDownloader", "URLDownloader"}
 
     # these processors build packages or dmgs
-    CREATOR_PROCESSORS = {'DmgCreator', 'FlatPkgPacker', 'PkgCreator'}
+    CREATOR_PROCESSORS = {"DmgCreator", "FlatPkgPacker", "PkgCreator"}
 
     # these processors could be used to modify the contents of a vendor
     # distribution (pkg, dmg, etc)
     MODIFICATION_PROCESSORS = [
-        'Copier',
-        'FileCreator',
-        'FileMover',
-        'PathDeleter',
-        'PkgInfoCreator',
-        'PlistEditor',
-        'Symlinker',
+        "Copier",
+        "FileCreator",
+        "FileMover",
+        "PathDeleter",
+        "PkgInfoCreator",
+        "PlistEditor",
+        "Symlinker",
     ]
 
     recipe_paths = []
     recipe_paths.extend(arguments)
     if options.recipe_list:
         recipe_list = parse_recipe_list(options.recipe_list)
-        recipe_paths.extend(recipe_list.get('recipes', []))
+        recipe_paths.extend(recipe_list.get("recipes", []))
 
     override_dirs = options.override_dirs or get_override_dirs()
     search_dirs = options.search_dirs or get_search_dirs()
@@ -2312,13 +2564,15 @@ def audit(argv):
     recipe_issue_count = 0
     recipe_no_issue_count = 0
     for recipe_path in recipe_paths:
-        recipe = load_recipe(recipe_path,
-                             override_dirs,
-                             search_dirs,
-                             None,
-                             None,
-                             make_suggestions=False,
-                             search_github=False)
+        recipe = load_recipe(
+            recipe_path,
+            override_dirs,
+            search_dirs,
+            None,
+            None,
+            make_suggestions=False,
+            search_github=False,
+        )
         if not recipe:
             log_err("No valid recipe found for %s" % recipe_path)
             continue
@@ -2326,35 +2580,39 @@ def audit(argv):
         audit_results[recipe_path] = {}
         http_urls = find_http_urls_in_recipe(recipe)
         if http_urls:
-            audit_results[recipe_path]['http_urls'] = http_urls
+            audit_results[recipe_path]["http_urls"] = http_urls
         recipe_processors = [step["Processor"] for step in recipe["Process"]]
-        if (set(recipe_processors).intersection(DOWNLOAD_PROCESSORS)
-                and 'CodeSignatureVerifier' not in recipe_processors):
-            audit_results[recipe_path]['MissingCodeSignatureVerifier'] = True
-        creator_processors = set(recipe_processors).intersection(
-            CREATOR_PROCESSORS)
+        if (
+            set(recipe_processors).intersection(DOWNLOAD_PROCESSORS)
+            and "CodeSignatureVerifier" not in recipe_processors
+        ):
+            audit_results[recipe_path]["MissingCodeSignatureVerifier"] = True
+        creator_processors = set(recipe_processors).intersection(CREATOR_PROCESSORS)
         core_processors = core_processor_names()
-        non_core_processors = [processor for processor in recipe_processors
-                               if processor not in core_processors]
+        non_core_processors = [
+            processor
+            for processor in recipe_processors
+            if processor not in core_processors
+        ]
         modification_processors = set()
         # only flag modification processors if there is a creator or non-core
         # processor afterwards
         for index in range(len(recipe_processors)):
             if recipe_processors[index] in MODIFICATION_PROCESSORS:
                 # are there any creator processors after this one?
-                if set(recipe_processors[index + 1:]).intersection(
-                        CREATOR_PROCESSORS):
+                if set(recipe_processors[index + 1 :]).intersection(CREATOR_PROCESSORS):
                     modification_processors.add(recipe_processors[index])
                 # are there any non-core processors after this one?
-                elif set(recipe_processors[index + 1:]).intersection(
-                        set(non_core_processors)):
+                elif set(recipe_processors[index + 1 :]).intersection(
+                    set(non_core_processors)
+                ):
                     modification_processors.add(recipe_processors[index])
         if creator_processors or non_core_processors:
-            audit_results[recipe_path]['audit_processors'] = (
-                list(creator_processors) + list(modification_processors))
+            audit_results[recipe_path]["audit_processors"] = list(
+                creator_processors
+            ) + list(modification_processors)
         if non_core_processors:
-            audit_results[recipe_path]['non_core_processors'] = (
-                non_core_processors)
+            audit_results[recipe_path]["non_core_processors"] = non_core_processors
         if options.plist:
             # skip all the printing; we'll print plist output later.
             continue
@@ -2363,39 +2621,44 @@ def audit(argv):
             log(recipe_path)
             log("    File path:        %s" % recipe["RECIPE_PATH"])
             if recipe.get("PARENT_RECIPES"):
-                log("    Parent recipe(s): %s"
-                    % "\n                      ".join(
-                        recipe["PARENT_RECIPES"]))
-            if audit_results[recipe_path].get('MissingCodeSignatureVerifier'):
-                log('    Missing CodeSignatureVerifier')
-            if audit_results[recipe_path].get('http_urls'):
-                log('    The following http URLs were found in the recipe:')
-                printplist(audit_results[recipe_path]['http_urls'])
-            if audit_results[recipe_path].get('non_core_processors'):
-                log('    The following processors are non-core and can execute '
-                    'arbitrary code, performing any action.')
-                log('    Be sure you understand what the processor does and/or '
-                    'you trust its source:')
-                for processor in audit_results[recipe_path].get(
-                        'non_core_processors'):
-                    log('        %s' % processor)
-            if audit_results[recipe_path].get('audit_processors'):
-                log('    The following processors make modifications and their '
-                    'use in this recipe should be more closely inspected:')
-                for processor in audit_results[recipe_path].get(
-                        'audit_processors'):
-                    log('        %s' % processor)
-            log('')
+                log(
+                    "    Parent recipe(s): %s"
+                    % "\n                      ".join(recipe["PARENT_RECIPES"])
+                )
+            if audit_results[recipe_path].get("MissingCodeSignatureVerifier"):
+                log("    Missing CodeSignatureVerifier")
+            if audit_results[recipe_path].get("http_urls"):
+                log("    The following http URLs were found in the recipe:")
+                printplist(audit_results[recipe_path]["http_urls"])
+            if audit_results[recipe_path].get("non_core_processors"):
+                log(
+                    "    The following processors are non-core and can execute "
+                    "arbitrary code, performing any action."
+                )
+                log(
+                    "    Be sure you understand what the processor does and/or "
+                    "you trust its source:"
+                )
+                for processor in audit_results[recipe_path].get("non_core_processors"):
+                    log("        %s" % processor)
+            if audit_results[recipe_path].get("audit_processors"):
+                log(
+                    "    The following processors make modifications and their "
+                    "use in this recipe should be more closely inspected:"
+                )
+                for processor in audit_results[recipe_path].get("audit_processors"):
+                    log("        %s" % processor)
+            log("")
         else:
             recipe_no_issue_count += 1
-            log('%s: no audit flags triggered.' % recipe_path)
+            log("%s: no audit flags triggered." % recipe_path)
     if options.plist:
         print(FoundationPlist.writePlistToString(audit_results))
     elif len(recipe_paths) > 1:
-        log('\nSummary:')
-        log('    %s recipes audited' % len(audit_results.keys()))
-        log('    %s recipes with audit issues' % recipe_issue_count)
-        log('    %s recipes triggered no audit flags' % recipe_no_issue_count)
+        log("\nSummary:")
+        log("    %s recipes audited" % len(audit_results.keys()))
+        log("    %s recipes with audit issues" % recipe_issue_count)
+        log("    %s recipes triggered no audit flags" % recipe_no_issue_count)
 
 
 def new_recipe(argv):
@@ -2403,14 +2666,16 @@ def new_recipe(argv):
     verb = argv[1]
     parser = optparse.OptionParser()
 
-    parser.set_usage("Usage: %s %s [options] recipe_pathname\n"
-                     "Make a new template recipe." % ("%prog", verb))
+    parser.set_usage(
+        "Usage: %s %s [options] recipe_pathname\n"
+        "Make a new template recipe." % ("%prog", verb)
+    )
 
     # Parse arguments
-    parser.add_option("-i", "--identifier",
-                      help="Recipe identifier")
-    parser.add_option("-p", "--parent-identifier",
-                      help="Parent recipe identifier for this recipe.")
+    parser.add_option("-i", "--identifier", help="Recipe identifier")
+    parser.add_option(
+        "-p", "--parent-identifier", help="Parent recipe identifier for this recipe."
+    )
 
     options, arguments = parser.parse_args(argv[2:])
 
@@ -2420,24 +2685,19 @@ def new_recipe(argv):
         return -1
 
     filename = arguments[0]
-    name = os.path.basename(filename).split('.')[0]
+    name = os.path.basename(filename).split(".")[0]
     identifier = options.identifier or "local." + name
 
     recipe = {
         "Description": "Recipe description",
         "Identifier": identifier,
-        "Input": {
-            "NAME": name,
-        },
+        "Input": {"NAME": name},
         "MiniumumVersion": "1.0",
         "Process": [
             {
-                "Arguments": {
-                    "Argument1": "Value1",
-                    "Argument2": "Value2",
-                },
-                "Processor": "ProcessorName"
-            },
+                "Arguments": {"Argument1": "Value1", "Argument2": "Value2"},
+                "Processor": "ProcessorName",
+            }
         ],
     }
     if options.parent_identifier:
@@ -2454,63 +2714,60 @@ def main(argv):
     """Main routine"""
     # define our subcommands ('verbs')
     subcommands = {
-        "help": {
-            "function": display_help,
-            "help": "Display this help"},
-        "audit": {
-            "function": audit,
-            "help": "Audit one or more recipes."},
+        "help": {"function": display_help, "help": "Display this help"},
+        "audit": {"function": audit, "help": "Audit one or more recipes."},
         "info": {
             "function": get_info,
-            "help": "Get info about configuration or a recipe"},
+            "help": "Get info about configuration or a recipe",
+        },
         "install": {
             "function": run_recipes,
-            "help": ("Run one or more install recipes. "
-                     "Example: autopkg install Firefox -- "
-                     "equivalent to: autopkg run Firefox.install")},
+            "help": (
+                "Run one or more install recipes. "
+                "Example: autopkg install Firefox -- "
+                "equivalent to: autopkg run Firefox.install"
+            ),
+        },
         "list-recipes": {
             "function": list_recipes,
-            "help": "List recipes available locally"},
+            "help": "List recipes available locally",
+        },
         "list-processors": {
             "function": list_processors,
-            "help": "List available core Processors"},
-        "make-override": {
-            "function": make_override,
-            "help": "Make a recipe override"},
-        "new-recipe": {
-            "function": new_recipe,
-            "help": "Make a new template recipe"},
+            "help": "List available core Processors",
+        },
+        "make-override": {"function": make_override, "help": "Make a recipe override"},
+        "new-recipe": {"function": new_recipe, "help": "Make a new template recipe"},
         "processor-info": {
             "function": processor_info,
-            "help": "Get information about a specific processor"},
+            "help": "Get information about a specific processor",
+        },
         "repo-add": {
             "function": repo_add,
-            "help": "Add one or more recipe repo from a URL"},
-        "repo-delete": {
-            "function": repo_delete,
-            "help": "Delete a recipe repo"},
-        "repo-list": {
-            "function": repo_list,
-            "help": "List installed recipe repos"},
+            "help": "Add one or more recipe repo from a URL",
+        },
+        "repo-delete": {"function": repo_delete, "help": "Delete a recipe repo"},
+        "repo-list": {"function": repo_list, "help": "List installed recipe repos"},
         "repo-update": {
             "function": repo_update,
-            "help": "Update one or more recipe repos"},
-        "run": {
-            "function": run_recipes,
-            "help": "Run one or more recipes"},
-        "search": {
-            "function": search_recipes,
-            "help": "Search for recipes on GitHub."},
+            "help": "Update one or more recipe repos",
+        },
+        "run": {"function": run_recipes, "help": "Run one or more recipes"},
+        "search": {"function": search_recipes, "help": "Search for recipes on GitHub."},
         "update-trust-info": {
             "function": update_trust_info,
-            "help": ("Update or add parent recipe trust info for a recipe "
-                     "override.")},
+            "help": (
+                "Update or add parent recipe trust info for a recipe " "override."
+            ),
+        },
         "verify-trust-info": {
             "function": verify_trust_info,
-            "help": ("Verify parent recipe trust info for a recipe override.")},
+            "help": ("Verify parent recipe trust info for a recipe override."),
+        },
         "version": {
             "function": print_version,
-            "help": "Print the current version of autopkg"}
+            "help": "Print the current version of autopkg",
+        },
     }
 
     # Warn against running as root
@@ -2522,23 +2779,24 @@ def main(argv):
             "    important system files.\n"
             "    Please run autopkg as an unprivileged user.\n"
             "    A future release of autopkg may fail with an error if run as\n"
-            "    root.\n")
+            "    root.\n"
+        )
         log_err("WARNING! " * 8 + "\n")
 
     try:
         verb = argv[1]
     except IndexError:
-        verb = 'help'
+        verb = "help"
     if verb.startswith("-"):
         # option instead of a verb
-        verb = 'help'
-    if verb == 'help' or verb not in subcommands.keys():
+        verb = "help"
+    if verb == "help" or verb not in subcommands.keys():
         display_help(argv, subcommands)
     else:
         # call the function and pass it the argument list
         # we leave the verb in the list in case one function can handle
         # multiple verbs
-        exit(subcommands[verb]['function'](argv))
+        exit(subcommands[verb]["function"](argv))
 
     exit()
 

--- a/Code/autopkglib/AppDmgVersioner.py
+++ b/Code/autopkglib/AppDmgVersioner.py
@@ -23,7 +23,8 @@ import os.path
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 
-#pylint: disable=no-name-in-module
+
+# pylint: disable=no-name-in-module
 try:
     from Foundation import NSData, NSPropertyListSerialization
     from Foundation import NSPropertyListMutableContainers
@@ -36,38 +37,32 @@ except:
         "WARNING: Failed 'from Foundation import "
         "NSPropertyListMutableContainers' in " + __name__
     )
-#pylint: enable=no-name-in-module
+# pylint: enable=no-name-in-module
 
 __all__ = ["AppDmgVersioner"]
 
 
 class AppDmgVersioner(DmgMounter):
     # we dynamically set the docstring from the description (DRY), so:
-    #pylint: disable=missing-docstring
+    # pylint: disable=missing-docstring
     description = "Extracts bundle ID and version of app inside dmg."
     input_variables = {
         "dmg_path": {
             "required": True,
             "description": "Path to a dmg containing an app.",
-        },
+        }
     }
     output_variables = {
-        "app_name": {
-            "description": "Name of app found on the disk image."
-        },
-        "bundleid": {
-            "description": "Bundle identifier of the app.",
-        },
-        "version": {
-            "description": "Version of the app.",
-        },
+        "app_name": {"description": "Name of app found on the disk image."},
+        "bundleid": {"description": "Bundle identifier of the app."},
+        "version": {"description": "Version of the app."},
     }
 
     __doc__ = description
 
     def find_app(self, path):
         """Find app bundle at path."""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
         apps = glob.glob(os.path.join(path, "*.app"))
         if len(apps) == 0:
             raise ProcessorError("No app found in dmg")
@@ -75,17 +70,17 @@ class AppDmgVersioner(DmgMounter):
 
     def read_bundle_info(self, path):
         """Read Contents/Info.plist inside a bundle."""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
 
         plistpath = os.path.join(path, "Contents", "Info.plist")
-        #pylint: disable=line-too-long
-        info, _, error = (
-            NSPropertyListSerialization.propertyListFromData_mutabilityOption_format_errorDescription_(
-                NSData.dataWithContentsOfFile_(plistpath),
-                NSPropertyListMutableContainers,
-                None,
-                None))
-        #pylint: enable=line-too-long
+        # pylint: disable=line-too-long
+        info, _, error = NSPropertyListSerialization.propertyListFromData_mutabilityOption_format_errorDescription_(
+            NSData.dataWithContentsOfFile_(plistpath),
+            NSPropertyListMutableContainers,
+            None,
+            None,
+        )
+        # pylint: enable=line-too-long
 
         if error:
             raise ProcessorError("Can't read %s: %s" % (plistpath, error))
@@ -112,6 +107,6 @@ class AppDmgVersioner(DmgMounter):
             self.unmount(self.env["dmg_path"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = AppDmgVersioner()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/AppPkgCreator.py
+++ b/Code/autopkglib/AppPkgCreator.py
@@ -24,11 +24,13 @@ from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 from autopkglib.PkgCreator import PkgCreator
 
+
 __all__ = ["AppPkgCreator"]
 
 
 class AppPkgCreator(DmgMounter, PkgCreator):
     """Calls autopkgserver to create a package from an application."""
+
     description = __doc__
     input_variables = {
         "app_path": {
@@ -37,53 +39,49 @@ class AppPkgCreator(DmgMounter, PkgCreator):
                 "Path to an application to be packaged. Can be on a disk "
                 "image and globbed. If not set, defaults to %pathname%/*.app. "
                 "Typically %pathname% points to a disk image downloaded in a "
-                "prior recipe step.")
+                "prior recipe step."
+            ),
         },
         "pkg_path": {
             "required": False,
-            "description":
-                "The pathname for the pkg to be created. If not set, defaults "
-                "to %RECIPE_CACHE_DIR%/%app_name%-%version%.pkg",
+            "description": "The pathname for the pkg to be created. If not set, defaults "
+            "to %RECIPE_CACHE_DIR%/%app_name%-%version%.pkg",
         },
         "bundleid": {
             "required": False,
-            "description":
-                "Bundle identifier of the app. If not set, will be extracted "
-                "from the CFBundleIdentifier in the app's Info.plist.",
+            "description": "Bundle identifier of the app. If not set, will be extracted "
+            "from the CFBundleIdentifier in the app's Info.plist.",
         },
         "version": {
             "required": False,
-            "description":
-                "Version of the app. If not set, will be extracted from the "
-                "CFBundleShortVersionString in the app's Info.plist.",
+            "description": "Version of the app. If not set, will be extracted from the "
+            "CFBundleShortVersionString in the app's Info.plist.",
         },
         "force_pkg_build": {
             "required": False,
             "description": (
                 "When set, this forces building a new package even if "
                 "a package already exists in the output directory with "
-                "the same identifier and version number. Defaults to False"),
+                "the same identifier and version number. Defaults to False"
+            ),
         },
     }
     output_variables = {
         "new_package_request": {
-            "description":
-                "True if a new package was actually requested to be built. "
-                "False if a package with the same filename, identifier and "
-                "version already exists and thus no package was built (see "
-                "'force_pkg_build' input variable.)"
+            "description": "True if a new package was actually requested to be built. "
+            "False if a package with the same filename, identifier and "
+            "version already exists and thus no package was built (see "
+            "'force_pkg_build' input variable.)"
         },
-        "version": {
-            "description": "Version of the app.",
-        },
+        "version": {"description": "Version of the app."},
         "app_pkg_creator_summary_result": {
             "description": "Description of interesting results."
-        }
+        },
     }
 
     def read_info_plist(self, app_path):
         """Read Contents/Info.plist from the app."""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
         plistpath = os.path.join(app_path, "Contents", "Info.plist")
         try:
             plist = FoundationPlist.readPlist(plistpath)
@@ -92,22 +90,22 @@ class AppPkgCreator(DmgMounter, PkgCreator):
         return plist
 
     def package_app(self, app_path):
-        '''Build a packaging request, send it to the autopkgserver and get the
-        constructed package.'''
+        """Build a packaging request, send it to the autopkgserver and get the
+        constructed package."""
 
         # clear any pre-exising summary result
-        if 'app_pkg_creator_summary_result' in self.env:
-            del self.env['app_pkg_creator_summary_result']
+        if "app_pkg_creator_summary_result" in self.env:
+            del self.env["app_pkg_creator_summary_result"]
 
         # get version and bundleid
         infoplist = self.read_info_plist(app_path)
-        if not self.env.get('version'):
+        if not self.env.get("version"):
             try:
                 self.env["version"] = infoplist["CFBundleShortVersionString"]
                 self.output("Version: %s" % self.env["version"])
             except BaseException as err:
                 raise ProcessorError(err)
-        if not self.env.get('bundleid'):
+        if not self.env.get("bundleid"):
             try:
                 self.env["bundleid"] = infoplist["CFBundleIdentifier"]
                 self.output("BundleID: %s" % self.env["bundleid"])
@@ -120,24 +118,25 @@ class AppPkgCreator(DmgMounter, PkgCreator):
             pkgdir = os.path.dirname(pkg_path)
             pkgname = os.path.splitext(os.path.basename(pkg_path))[0]
         else:
-            pkgdir = self.env['RECIPE_CACHE_DIR']
+            pkgdir = self.env["RECIPE_CACHE_DIR"]
             pkgname = "%s-%s" % (
                 os.path.splitext(os.path.basename(app_path))[0],
-                self.env["version"])
-            pkg_path = os.path.join(pkgdir, pkgname + '.pkg')
+                self.env["version"],
+            )
+            pkg_path = os.path.join(pkgdir, pkgname + ".pkg")
 
         # Check for an existing flat package in the output dir and compare
         # its identifier and version to the one we're going to build.
-        if self.pkg_already_exists(
-                pkg_path, self.env["bundleid"], self.env["version"]):
-            self.output("Existing package matches version and identifier, "
-                        "not building.")
+        if self.pkg_already_exists(pkg_path, self.env["bundleid"], self.env["version"]):
+            self.output(
+                "Existing package matches version and identifier, " "not building."
+            )
             self.env["pkg_path"] = pkg_path
             self.env["new_package_request"] = False
             return
 
         # create pkgroot and copy application into it
-        pkgroot = os.path.join(self.env['RECIPE_CACHE_DIR'], 'payload')
+        pkgroot = os.path.join(self.env["RECIPE_CACHE_DIR"], "payload")
         if os.path.exists(pkgroot):
             # remove it if it already exists
             try:
@@ -146,16 +145,15 @@ class AppPkgCreator(DmgMounter, PkgCreator):
                 else:
                     os.unlink(pkgroot)
             except OSError as err:
-                raise ProcessorError(
-                    "Can't remove %s: %s" % (pkgroot, err.strerror))
+                raise ProcessorError("Can't remove %s: %s" % (pkgroot, err.strerror))
         try:
-            os.makedirs(os.path.join(pkgroot, 'Applications'), 0o775)
+            os.makedirs(os.path.join(pkgroot, "Applications"), 0o775)
         except OSError as err:
-            raise ProcessorError('Could not create pkgroot: %s' % err.strerror)
+            raise ProcessorError("Could not create pkgroot: %s" % err.strerror)
 
         app_name = os.path.basename(app_path)
         source_item = app_path
-        dest_item = os.path.join(pkgroot, 'Applications', app_name)
+        dest_item = os.path.join(pkgroot, "Applications", app_name)
         try:
             if os.path.isdir(source_item):
                 shutil.copytree(source_item, dest_item, symlinks=True)
@@ -166,8 +164,8 @@ class AppPkgCreator(DmgMounter, PkgCreator):
             self.output("Copied %s to %s" % (source_item, dest_item))
         except OSError as err:
             raise ProcessorError(
-                "Can't copy %s to %s: %s"
-                % (source_item, dest_item, err.strerror))
+                "Can't copy %s to %s: %s" % (source_item, dest_item, err.strerror)
+            )
 
         # build a package request
         request = {
@@ -179,12 +177,8 @@ class AppPkgCreator(DmgMounter, PkgCreator):
             "version": self.env["version"],
             "infofile": "",
             "resources": "",
-            "chown": [
-                {"path": "Applications",
-                 "user": "root",
-                 "group": "admin"}
-            ],
-            "scripts": ""
+            "chown": [{"path": "Applications", "user": "root", "group": "admin"}],
+            "scripts": "",
         }
 
         # Send packaging request.
@@ -201,21 +195,21 @@ class AppPkgCreator(DmgMounter, PkgCreator):
         # Return path to pkg.
         self.env["pkg_path"] = pkg_path
         self.env["app_pkg_creator_summary_result"] = {
-            'summary_text': 'The following packages were built:',
-            'report_fields': ['identifier', 'version', 'pkg_path'],
-            'data': {
-                'identifier': request['id'],
-                'version': request['version'],
-                'pkg_path': pkg_path
-            }
+            "summary_text": "The following packages were built:",
+            "report_fields": ["identifier", "version", "pkg_path"],
+            "data": {
+                "identifier": request["id"],
+                "version": request["version"],
+                "pkg_path": pkg_path,
+            },
         }
 
     def main(self):
-        '''Find an app, package it up'''
-        if self.env.get('app_path'):
-            app_path = self.env['app_path']
-        elif self.env.get('pathname'):
-            app_path = self.env['pathname'] + "/*.app"
+        """Find an app, package it up"""
+        if self.env.get("app_path"):
+            app_path = self.env["app_path"]
+        elif self.env.get("pathname"):
+            app_path = self.env["pathname"] + "/*.app"
         else:
             raise ProcessorError("No app_path or pathname specified.")
         # Check if we're trying to package something inside a dmg.
@@ -229,18 +223,21 @@ class AppPkgCreator(DmgMounter, PkgCreator):
             matches = glob(app_path)
             if len(matches) == 0:
                 raise ProcessorError(
-                    "Error processing path '%s' with glob. " % app_path)
+                    "Error processing path '%s' with glob. " % app_path
+                )
             matched_app_path = matches[0]
             if len(matches) > 1:
                 self.output(
-                    "WARNING: Multiple paths match 'app_path' glob '%s':"
-                    % app_path)
+                    "WARNING: Multiple paths match 'app_path' glob '%s':" % app_path
+                )
                 for match in matches:
                     self.output("  - %s" % match)
 
-            if [c for c in '*?[]!' if c in app_path]:
-                self.output("Using path '%s' matched from globbed '%s'."
-                            % (matched_app_path, app_path))
+            if [c for c in "*?[]!" if c in app_path]:
+                self.output(
+                    "Using path '%s' matched from globbed '%s'."
+                    % (matched_app_path, app_path)
+                )
 
             # do the copy
             self.package_app(matched_app_path)
@@ -250,6 +247,6 @@ class AppPkgCreator(DmgMounter, PkgCreator):
                 self.unmount(dmg_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = AppPkgCreator()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/BrewCaskInfoProvider.py
+++ b/Code/autopkglib/BrewCaskInfoProvider.py
@@ -20,38 +20,43 @@ import urllib2
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["BrewCaskInfoProvider"]
 
 
 class BrewCaskInfoProvider(Processor):
     # we dynamically set the docstring from the description (DRY), so:
-    #pylint: disable=missing-docstring
+    # pylint: disable=missing-docstring
 
-    description = ("ATTENTION: This processor is deprecated, may not work "
-                   "as expected with all known Casks, and may be removed "
-                   "in a future release of AutoPkg. Description follows: "
-                   "Provides crowd-sourced URL and version info from thousands "
-                   "of applications listed in brew-cask: "
-                   "https://github.com/caskroom/homebrew-cask. See available "
-                   "apps: https://github.com/caskroom/homebrew-cask/tree/"
-                   "master/Casks")
+    description = (
+        "ATTENTION: This processor is deprecated, may not work "
+        "as expected with all known Casks, and may be removed "
+        "in a future release of AutoPkg. Description follows: "
+        "Provides crowd-sourced URL and version info from thousands "
+        "of applications listed in brew-cask: "
+        "https://github.com/caskroom/homebrew-cask. See available "
+        "apps: https://github.com/caskroom/homebrew-cask/tree/"
+        "master/Casks"
+    )
     input_variables = {
         "cask_name": {
             "required": True,
-            "description": ("Name of cask to fetch, as would be given to the "
-                            "'brew' command. Example: 'audacity'")
+            "description": (
+                "Name of cask to fetch, as would be given to the "
+                "'brew' command. Example: 'audacity'"
+            ),
         }
     }
     output_variables = {
-        "url": {
-            "description": "URL for the Cask's download.",
-        },
+        "url": {"description": "URL for the Cask's download."},
         "version": {
-            "description": ("Version info from formula. Depending on the "
-                            "nature of the formula and stability of the URL, "
-                            "this might be simply 'latest'. It's provided "
-                            "here for convenience in the recipe.")
-        }
+            "description": (
+                "Version info from formula. Depending on the "
+                "nature of the formula and stability of the URL, "
+                "this might be simply 'latest'. It's provided "
+                "here for convenience in the recipe."
+            )
+        },
     }
 
     __doc__ = description
@@ -59,7 +64,7 @@ class BrewCaskInfoProvider(Processor):
     def parse_formula(self, formula):
         """Return a dict containing attributes of the formula, ie. 'url',
         'version', etc. parsed from the formula .rb file."""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
         attrs = {}
         regex = r"^\s+(?P<attr>.+) [\'\"](?P<value>.+)[\'\"].*$"
         for line in formula.splitlines():
@@ -80,19 +85,22 @@ class BrewCaskInfoProvider(Processor):
             match = re.search("#{(.+?)}", value)
             if match:
                 subbed_key = match.groups()[0]
-                self.output("Substituting value '%s' in %s: '%s'" % (
-                    subbed_key, key, value))
-                newattrs[key] = re.sub("#{%s}" % subbed_key,
-                                       newattrs[subbed_key],
-                                       newattrs[key])
+                self.output(
+                    "Substituting value '%s' in %s: '%s'" % (subbed_key, key, value)
+                )
+                newattrs[key] = re.sub(
+                    "#{%s}" % subbed_key, newattrs[subbed_key], newattrs[key]
+                )
         return newattrs
 
     def main(self):
-        self.output("WARNING: BrewCaskInfoProvider is deprecated and may be "
-                    "removed in a future AutoPkg release.")
+        self.output(
+            "WARNING: BrewCaskInfoProvider is deprecated and may be "
+            "removed in a future AutoPkg release."
+        )
         github_raw_baseurl = (
-            "https://raw.githubusercontent.com/caskroom/homebrew-cask/master/"
-            "Casks")
+            "https://raw.githubusercontent.com/caskroom/homebrew-cask/master/" "Casks"
+        )
         cask_url = "%s/%s.rb" % (github_raw_baseurl, self.env["cask_name"])
         try:
             urlobj = urllib2.urlopen(cask_url)
@@ -112,8 +120,9 @@ class BrewCaskInfoProvider(Processor):
         else:
             self.env["version"] = ""
 
-        self.output("Got URL %s from for cask '%s':"
-                    % (self.env["url"], self.env["cask_name"]))
+        self.output(
+            "Got URL %s from for cask '%s':" % (self.env["url"], self.env["cask_name"])
+        )
 
 
 if __name__ == "__main__":

--- a/Code/autopkglib/CURLDownloader.py
+++ b/Code/autopkglib/CURLDownloader.py
@@ -18,6 +18,7 @@ deprecation period."""
 
 from autopkglib.URLDownloader import URLDownloader
 
+
 __all__ = ["CURLDownloader"]
 
 CURLDownloader = URLDownloader

--- a/Code/autopkglib/CURLTextSearcher.py
+++ b/Code/autopkglib/CURLTextSearcher.py
@@ -18,6 +18,7 @@ the deprecation period."""
 
 from autopkglib.URLTextSearcher import URLTextSearcher
 
+
 __all__ = ["CURLTextSearcher"]
 
 CURLTextSearcher = URLTextSearcher

--- a/Code/autopkglib/Copier.py
+++ b/Code/autopkglib/Copier.py
@@ -22,11 +22,13 @@ from glob import glob
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 
+
 __all__ = ["Copier"]
 
 
 class Copier(DmgMounter):
     """Copies source_path to destination_path."""
+
     description = __doc__
     input_variables = {
         "source_path": {
@@ -36,26 +38,24 @@ class Copier(DmgMounter):
                 "Can point to a path inside a .dmg which will be mounted. "
                 "This path may also contain basic globbing characters such as "
                 "the wildcard '*', but only the first result will be "
-                "returned."),
+                "returned."
+            ),
         },
-        "destination_path": {
-            "required": True,
-            "description": "Path to destination.",
-        },
+        "destination_path": {"required": True, "description": "Path to destination."},
         "overwrite": {
             "required": False,
             "description": (
                 "Whether the destination will be overwritten if necessary. "
-                "Uses a boolean value."),
+                "Uses a boolean value."
+            ),
         },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     __doc__ = description
 
     def copy(self, source_item, dest_item, overwrite=False):
-        '''Copies source_item to dest_item, overwriting if allowed'''
+        """Copies source_item to dest_item, overwriting if allowed"""
         # Remove destination if needed.
         if os.path.exists(dest_item) and overwrite:
             try:
@@ -64,8 +64,7 @@ class Copier(DmgMounter):
                 else:
                     os.unlink(dest_item)
             except OSError as err:
-                raise ProcessorError(
-                    "Can't remove %s: %s" % (dest_item, err.strerror))
+                raise ProcessorError("Can't remove %s: %s" % (dest_item, err.strerror))
 
         # Copy file or directory.
         try:
@@ -78,10 +77,11 @@ class Copier(DmgMounter):
             self.output("Copied %s to %s" % (source_item, dest_item))
         except BaseException as err:
             raise ProcessorError(
-                "Can't copy %s to %s: %s" % (source_item, dest_item, err))
+                "Can't copy %s to %s: %s" % (source_item, dest_item, err)
+            )
 
     def main(self):
-        source_path = self.env['source_path']
+        source_path = self.env["source_path"]
         # Check if we're trying to copy something inside a dmg.
         (dmg_path, dmg, dmg_source_path) = self.parsePathForDMG(source_path)
         try:
@@ -93,27 +93,34 @@ class Copier(DmgMounter):
             matches = glob(source_path)
             if len(matches) == 0:
                 raise ProcessorError(
-                    "Error processing path '%s' with glob. " % source_path)
+                    "Error processing path '%s' with glob. " % source_path
+                )
             matched_source_path = matches[0]
             if len(matches) > 1:
                 self.output(
                     "WARNING: Multiple paths match 'source_path' glob '%s':"
-                    % source_path)
+                    % source_path
+                )
                 for match in matches:
                     self.output("  - %s" % match)
 
-            if [c for c in '*?[]!' if c in source_path]:
-                self.output("Using path '%s' matched from globbed '%s'."
-                            % (matched_source_path, source_path))
+            if [c for c in "*?[]!" if c in source_path]:
+                self.output(
+                    "Using path '%s' matched from globbed '%s'."
+                    % (matched_source_path, source_path)
+                )
 
             # do the copy
-            self.copy(matched_source_path, self.env['destination_path'],
-                      overwrite=self.env.get("overwrite"))
+            self.copy(
+                matched_source_path,
+                self.env["destination_path"],
+                overwrite=self.env.get("overwrite"),
+            )
         finally:
             if dmg:
                 self.unmount(dmg_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = Copier()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/DmgMounter.py
+++ b/Code/autopkglib/DmgMounter.py
@@ -23,78 +23,83 @@ import sys
 import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["DmgMounter"]
 
 
 class DmgMounter(Processor):
     """Base class for Processors that need to mount disk images."""
 
-    DMG_EXTENSIONS = ['.dmg', '.iso', '.DMG', '.ISO']
+    DMG_EXTENSIONS = [".dmg", ".iso", ".DMG", ".ISO"]
 
     def __init__(self, data=None, infile=None, outfile=None):
         super(DmgMounter, self).__init__(data, infile, outfile)
         self.mounts = dict()
 
-    #pylint: disable=invalid-name
+    # pylint: disable=invalid-name
     def parsePathForDMG(self, pathname):
         """Helper method for working with paths that reference something
         inside a disk image"""
         for extension in self.DMG_EXTENSIONS:
-            (dmg_path, dmg, dmg_source_path) = (
-                pathname.partition(extension + "/"))
+            (dmg_path, dmg, dmg_source_path) = pathname.partition(extension + "/")
             if dmg:
                 dmg_path += extension
                 return dmg_path, dmg, dmg_source_path
         # no disk image in path
-        return pathname, '', ''
-    #pylint: enable=invalid-name
+        return pathname, "", ""
+
+    # pylint: enable=invalid-name
 
     def get_first_plist(self, text_string):
         """Gets the first plist from a text string that may contain one or
         more text-style plists.
         Returns a tuple - the first plist (if any) and the remaining
         string after the plist"""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
 
-        plist_header = '<?xml version'
-        plist_footer = '</plist>'
+        plist_header = "<?xml version"
+        plist_footer = "</plist>"
         plist_start_index = text_string.find(plist_header)
         if plist_start_index == -1:
             # not found
             return ("", text_string)
         plist_end_index = text_string.find(
-            plist_footer, plist_start_index + len(plist_header))
+            plist_footer, plist_start_index + len(plist_header)
+        )
         if plist_end_index == -1:
             # not found
             return ("", text_string)
         # adjust end value
         plist_end_index = plist_end_index + len(plist_footer)
-        return (text_string[plist_start_index:plist_end_index],
-                text_string[plist_end_index:])
+        return (
+            text_string[plist_start_index:plist_end_index],
+            text_string[plist_end_index:],
+        )
 
     def dmg_has_sla(self, dmgpath):
-        '''Returns true if dmg has a Software License Agreement.
-        These dmgs normally cannot be attached without user intervention'''
+        """Returns true if dmg has a Software License Agreement.
+        These dmgs normally cannot be attached without user intervention"""
         has_sla = False
         proc = subprocess.Popen(
-            ['/usr/bin/hdiutil', 'imageinfo', dmgpath, '-plist'],
-            bufsize=-1, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            ["/usr/bin/hdiutil", "imageinfo", dmgpath, "-plist"],
+            bufsize=-1,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         (stdout, stderr) = proc.communicate()
         if stderr:
             # some error with hdiutil.
             # Output but return False so we can attempt to continue
-            self.output('hdiutil imageinfo error %s with image %s.'
-                        % (stderr, dmgpath))
+            self.output("hdiutil imageinfo error %s with image %s." % (stderr, dmgpath))
             return False
 
         (pliststr, stdout) = self.get_first_plist(stdout)
         if pliststr:
             try:
                 plist = FoundationPlist.readPlistFromString(pliststr)
-                properties = plist.get('Properties')
+                properties = plist.get("Properties")
                 if properties:
-                    has_sla = properties.get(
-                        'Software License Agreement', False)
+                    has_sla = properties.get("Software License Agreement", False)
             except FoundationPlist.NSPropertyListSerializationException:
                 pass
 
@@ -106,26 +111,32 @@ class DmgMounter(Processor):
         if pathname in self.mounts:
             raise ProcessorError("%s is already mounted" % pathname)
 
-        stdin = ''
+        stdin = ""
         if self.dmg_has_sla(pathname):
-            stdin = 'Y\n'
+            stdin = "Y\n"
 
         # Call hdiutil.
         try:
-            proc = subprocess.Popen(("/usr/bin/hdiutil",
-                                     "attach",
-                                     "-plist",
-                                     "-mountrandom", "/private/tmp",
-                                     "-nobrowse",
-                                     pathname),
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE,
-                                    stdin=subprocess.PIPE)
+            proc = subprocess.Popen(
+                (
+                    "/usr/bin/hdiutil",
+                    "attach",
+                    "-plist",
+                    "-mountrandom",
+                    "/private/tmp",
+                    "-nobrowse",
+                    pathname,
+                ),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+            )
             (stdout, stderr) = proc.communicate(stdin)
         except OSError as err:
             raise ProcessorError(
                 "hdiutil execution failed with error code %d: %s"
-                % (err.errno, err.strerror))
+                % (err.errno, err.strerror)
+            )
         if proc.returncode != 0:
             raise ProcessorError("mounting %s failed: %s" % (pathname, stderr))
 
@@ -135,7 +146,8 @@ class DmgMounter(Processor):
             output = FoundationPlist.readPlistFromString(pliststr)
         except FoundationPlist.NSPropertyListSerializationException:
             raise ProcessorError(
-                "mounting %s failed: unexpected output from hdiutil" % pathname)
+                "mounting %s failed: unexpected output from hdiutil" % pathname
+            )
 
         # Find mount point.
         for part in output.get("system-entities", []):
@@ -145,7 +157,8 @@ class DmgMounter(Processor):
                 self.output("Mounted disk image %s" % pathname)
                 return self.mounts[pathname]
         raise ProcessorError(
-            "mounting %s failed: unexpected output from hdiutil" % pathname)
+            "mounting %s failed: unexpected output from hdiutil" % pathname
+        )
 
     def unmount(self, pathname):
         """Unmount previously mounted image."""
@@ -156,25 +169,25 @@ class DmgMounter(Processor):
 
         # Call hdiutil.
         try:
-            proc = subprocess.Popen(("/usr/bin/hdiutil",
-                                     "detach",
-                                     self.mounts[pathname]),
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+            proc = subprocess.Popen(
+                ("/usr/bin/hdiutil", "detach", self.mounts[pathname]),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
             stderr = proc.communicate()[1]
         except OSError as err:
             raise ProcessorError(
                 "hdiutil execution failed with error code %d: %s"
-                % (err.errno, err.strerror))
+                % (err.errno, err.strerror)
+            )
         if proc.returncode != 0:
-            raise ProcessorError(
-                "unmounting %s failed: %s" % (pathname, stderr))
+            raise ProcessorError("unmounting %s failed: %s" % (pathname, stderr))
 
         # Delete mount from mount list.
         del self.mounts[pathname]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         DMGMOUNTER = DmgMounter()
         MOUNTPOINT = DMGMOUNTER.mount("Download/Firefox-sv-SE.dmg")

--- a/Code/autopkglib/EndOfCheckPhase.py
+++ b/Code/autopkglib/EndOfCheckPhase.py
@@ -18,21 +18,21 @@ phase"""
 
 from autopkglib import Processor
 
+
 __all__ = ["EndOfCheckPhase"]
 
 
 class EndOfCheckPhase(Processor):
     """This processor does nothing at all."""
-    input_variables = {
-    }
-    output_variables = {
-    }
+
+    input_variables = {}
+    output_variables = {}
     description = __doc__
 
     def main(self):
         return
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = EndOfCheckPhase()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/FileCreator.py
+++ b/Code/autopkglib/FileCreator.py
@@ -19,46 +19,43 @@ import os
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["FileCreator"]
 
 
 class FileCreator(Processor):
     """Create a file."""
+
     description = __doc__
     input_variables = {
-        "file_path": {
-            "required": True,
-            "description": "Path to a file to create.",
-        },
-        "file_content": {
-            "required": True,
-            "description": "Contents to put in file.",
-        },
+        "file_path": {"required": True, "description": "Path to a file to create."},
+        "file_content": {"required": True, "description": "Contents to put in file."},
         "file_mode": {
             "required": False,
-            "description": "String. Numeric mode for file in octal format."
-        }
+            "description": "String. Numeric mode for file in octal format.",
+        },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     def main(self):
         try:
-            with open(self.env['file_path'], "w") as fileref:
-                fileref.write(self.env['file_content'])
-            self.output("Created file at %s" % self.env['file_path'])
+            with open(self.env["file_path"], "w") as fileref:
+                fileref.write(self.env["file_content"])
+            self.output("Created file at %s" % self.env["file_path"])
         except BaseException as err:
-            raise ProcessorError("Can't create file at %s: %s"
-                                 % (self.env['file_path'], err))
-        if 'file_mode' in self.env:
+            raise ProcessorError(
+                "Can't create file at %s: %s" % (self.env["file_path"], err)
+            )
+        if "file_mode" in self.env:
             try:
-                os.chmod(self.env['file_path'], int(self.env['file_mode'], 8))
+                os.chmod(self.env["file_path"], int(self.env["file_mode"], 8))
             except BaseException as err:
                 raise ProcessorError(
                     "Can't set mode of %s to %s: %s"
-                    % (self.env['file_path'], self.env['file_mode'], err))
+                    % (self.env["file_path"], self.env["file_mode"], err)
+                )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = FileCreator()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/FileFinder.py
+++ b/Code/autopkglib/FileFinder.py
@@ -22,61 +22,60 @@ from glob import glob
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 
+
 __all__ = ["FileFinder"]
 
 
 class FileFinder(DmgMounter):
-    '''Finds a filename for use in other Processors.
+    """Finds a filename for use in other Processors.
 
     Currently only supports glob filename patterns.
 
     Requires version 0.2.3.
-    '''
+    """
 
     input_variables = {
-        'pattern': {
-            'description': 'Shell glob pattern to match files by',
-            'required': True,
+        "pattern": {
+            "description": "Shell glob pattern to match files by",
+            "required": True,
         },
-        'find_method': {
-            'description': ('Type of pattern to match. Currently only '
-                            'supported type is "glob" (also the default)'),
-            'default': 'glob',
-            'required': False,
+        "find_method": {
+            "description": (
+                "Type of pattern to match. Currently only "
+                'supported type is "glob" (also the default)'
+            ),
+            "default": "glob",
+            "required": False,
         },
     }
     output_variables = {
-        'found_filename': {
-            'description': 'Full path of found filename',
-        },
-        'dmg_found_filename': {
-            'description': 'DMG-relative path of found filename',
-        }
+        "found_filename": {"description": "Full path of found filename"},
+        "dmg_found_filename": {"description": "DMG-relative path of found filename"},
     }
 
     description = __doc__
 
     def globfind(self, pattern):
-        '''If multiple files are found the last alphanumerically sorted found
-        file is returned'''
-        #pylint: disable=no-self-use
+        """If multiple files are found the last alphanumerically sorted found
+        file is returned"""
+        # pylint: disable=no-self-use
 
         glob_matches = glob(pattern)
 
         if len(glob_matches) < 1:
-            raise ProcessorError('No matching filename found')
+            raise ProcessorError("No matching filename found")
 
         glob_matches.sort()
 
         return glob_matches[-1]
 
     def main(self):
-        pattern = self.env.get('pattern')
+        pattern = self.env.get("pattern")
 
-        method = self.env.get('find_method')
+        method = self.env.get("find_method")
 
-        if method != 'glob':
-            raise ProcessorError('Unsupported find_method: %s' % method)
+        if method != "glob":
+            raise ProcessorError("Unsupported find_method: %s" % method)
 
         source_path = pattern
 
@@ -89,17 +88,22 @@ class FileFinder(DmgMounter):
                 source_path = os.path.join(mount_point, dmg_source_path)
             # process path with globbing
             match = self.globfind(source_path)
-            self.env['found_filename'] = match
-            self.output("Found file match: '%s' from globbed '%s'" % (self.env['found_filename'], source_path))
+            self.env["found_filename"] = match
+            self.output(
+                "Found file match: '%s' from globbed '%s'"
+                % (self.env["found_filename"], source_path)
+            )
 
             if dmg and match.startswith(mount_point):
-                self.env['dmg_found_filename'] = match[len(mount_point):].lstrip('/')
-                self.output("DMG-relative file match: '%s'" % self.env['dmg_found_filename'])
+                self.env["dmg_found_filename"] = match[len(mount_point) :].lstrip("/")
+                self.output(
+                    "DMG-relative file match: '%s'" % self.env["dmg_found_filename"]
+                )
         finally:
             if dmg:
                 self.unmount(dmg_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = FileFinder()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/FileMover.py
+++ b/Code/autopkglib/FileMover.py
@@ -19,35 +19,28 @@ from os import rename
 
 from autopkglib import Processor
 
+
 __all__ = ["FileMover"]
 
 
 class FileMover(Processor):
-    '''Moves/renames a file.
+    """Moves/renames a file.
 
-    Requires version 0.2.9.'''
+    Requires version 0.2.9."""
 
     input_variables = {
-        'source': {
-            'description': 'Source file',
-            'required': True,
-        },
-        'target': {
-            'description': 'Target file',
-            'required': True,
-        },
+        "source": {"description": "Source file", "required": True},
+        "target": {"description": "Target file", "required": True},
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     description = __doc__
 
     def main(self):
-        rename(self.env['source'], self.env['target'])
-        self.output(
-            'File %s moved to %s' % (self.env['source'], self.env['target']))
+        rename(self.env["source"], self.env["target"])
+        self.output("File %s moved to %s" % (self.env["source"], self.env["target"]))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = FileMover()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/FlatPkgPacker.py
+++ b/Code/autopkglib/FlatPkgPacker.py
@@ -19,25 +19,26 @@ import subprocess
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["FlatPkgPacker"]
 
 
 class FlatPkgPacker(Processor):
-    '''Flatten an expanded package using pkgutil.
+    """Flatten an expanded package using pkgutil.
 
     Requires version 0.2.4.
-    '''
+    """
 
     description = __doc__
 
     input_variables = {
-        'source_flatpkg_dir': {
-            'description': 'Path to an extracted flat package',
-            'required': True,
+        "source_flatpkg_dir": {
+            "description": "Path to an extracted flat package",
+            "required": True,
         },
-        'destination_pkg': {
-            'description': 'Name of destination pkg to be flattened',
-            'required': True,
+        "destination_pkg": {
+            "description": "Name of destination pkg to be flattened",
+            "required": True,
         },
     }
 
@@ -45,23 +46,23 @@ class FlatPkgPacker(Processor):
 
     def flatten(self, source_dir, dest_pkg):
         """Flattens a previously expanded flat package"""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
         try:
-            subprocess.check_call(['/usr/sbin/pkgutil',
-                                   '--flatten', source_dir, dest_pkg])
+            subprocess.check_call(
+                ["/usr/sbin/pkgutil", "--flatten", source_dir, dest_pkg]
+            )
         except subprocess.CalledProcessError as err:
             raise ProcessorError("%s flattening %s" % (err, source_dir))
 
     def main(self):
-        source_dir = self.env.get('source_flatpkg_dir')
-        dest_pkg = self.env.get('destination_pkg')
+        source_dir = self.env.get("source_flatpkg_dir")
+        dest_pkg = self.env.get("destination_pkg")
 
         self.flatten(source_dir, dest_pkg)
 
-        self.output("Flattened %s to %s"
-                    % (source_dir, dest_pkg))
+        self.output("Flattened %s to %s" % (source_dir, dest_pkg))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = FlatPkgPacker()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/FlatPkgUnpacker.py
+++ b/Code/autopkglib/FlatPkgUnpacker.py
@@ -25,6 +25,7 @@ from glob import glob
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 
+
 __all__ = ["FlatPkgUnpacker"]
 
 
@@ -36,9 +37,11 @@ class FlatPkgUnpacker(DmgMounter):
     input_variables = {
         "flat_pkg_path": {
             "required": True,
-            "description": ("Path to a flat package. "
-                            "Can point to a globbed path inside a .dmg which "
-                            "will be mounted."),
+            "description": (
+                "Path to a flat package. "
+                "Can point to a globbed path inside a .dmg which "
+                "will be mounted."
+            ),
         },
         "skip_payload": {
             "required": False,
@@ -47,12 +50,14 @@ class FlatPkgUnpacker(DmgMounter):
                 "Defaults to False. Note if this option is used then the "
                 "files are extracted using xar(1) instead of pkgutil(1). "
                 "This means components of the package will not be "
-                "extracted such as scripts."),
+                "extracted such as scripts."
+            ),
         },
         "destination_path": {
             "required": True,
-            "description": ("Directory where archive will be unpacked, created "
-                            "if necessary."),
+            "description": (
+                "Directory where archive will be unpacked, created " "if necessary."
+            ),
         },
         "purge_destination": {
             "required": False,
@@ -60,37 +65,36 @@ class FlatPkgUnpacker(DmgMounter):
                 "Whether the contents of the destination directory "
                 "will be removed before unpacking. Note that unless "
                 "skip_payload argument is used the destination directory "
-                "will be removed as pkgutil requires an empty destination."),
+                "will be removed as pkgutil requires an empty destination."
+            ),
         },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     source_path = None
 
     def unpack_flat_pkg(self):
         """Unpacks a flat package using either xar or pkgutil"""
         # Create the directory if needed.
-        if not os.path.exists(self.env['destination_path']):
+        if not os.path.exists(self.env["destination_path"]):
             try:
-                os.makedirs(self.env['destination_path'])
+                os.makedirs(self.env["destination_path"])
             except OSError as err:
                 raise ProcessorError(
-                    "Can't create %s: %s"
-                    % (self.env['destination_path'], err.strerror))
-        elif self.env.get('purge_destination'):
-            for entry in os.listdir(self.env['destination_path']):
-                path = os.path.join(self.env['destination_path'], entry)
+                    "Can't create %s: %s" % (self.env["destination_path"], err.strerror)
+                )
+        elif self.env.get("purge_destination"):
+            for entry in os.listdir(self.env["destination_path"]):
+                path = os.path.join(self.env["destination_path"], entry)
                 try:
                     if os.path.isdir(path) and not os.path.islink(path):
                         shutil.rmtree(path)
                     else:
                         os.unlink(path)
                 except OSError as err:
-                    raise ProcessorError(
-                        "Can't remove %s: %s" % (path, err.strerror))
+                    raise ProcessorError("Can't remove %s: %s" % (path, err.strerror))
 
-        if self.env.get('skip_payload'):
+        if self.env.get("skip_payload"):
             self.xar_expand()
         else:
             self.pkgutil_expand()
@@ -98,82 +102,102 @@ class FlatPkgUnpacker(DmgMounter):
     def xar_expand(self):
         """Uses xar to expand an archive"""
         try:
-            xarcmd = ["/usr/bin/xar",
-                      "-x",
-                      "-C", self.env['destination_path'],
-                      "-f", self.source_path]
-            if self.env.get('skip_payload'):
+            xarcmd = [
+                "/usr/bin/xar",
+                "-x",
+                "-C",
+                self.env["destination_path"],
+                "-f",
+                self.source_path,
+            ]
+            if self.env.get("skip_payload"):
                 xarcmd.extend(["--exclude", "Payload"])
-            proc = subprocess.Popen(xarcmd,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+            proc = subprocess.Popen(
+                xarcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             (_, stderr) = proc.communicate()
         except OSError as err:
-            raise ProcessorError("xar execution failed with error code %d: %s"
-                                 % (err.errno, err.strerror))
+            raise ProcessorError(
+                "xar execution failed with error code %d: %s"
+                % (err.errno, err.strerror)
+            )
         if proc.returncode != 0:
-            raise ProcessorError("extraction of %s with xar failed: %s"
-                                 % (self.env['flat_pkg_path'], stderr))
+            raise ProcessorError(
+                "extraction of %s with xar failed: %s"
+                % (self.env["flat_pkg_path"], stderr)
+            )
 
     def pkgutil_expand(self):
         """Uses pkgutil to expand a flat package"""
         # pkgutil requires the dest. folder to be non-existant
-        if os.path.exists(self.env['destination_path']):
+        if os.path.exists(self.env["destination_path"]):
             try:
-                shutil.rmtree(self.env['destination_path'])
+                shutil.rmtree(self.env["destination_path"])
             except OSError as err:
                 raise ProcessorError(
-                    "Can't remove %s: %s"
-                    % (self.env['destination_path'], err.strerror))
+                    "Can't remove %s: %s" % (self.env["destination_path"], err.strerror)
+                )
 
         try:
-            pkgutilcmd = ["/usr/sbin/pkgutil",
-                          "--expand",
-                          self.source_path,
-                          self.env['destination_path']]
-            proc = subprocess.Popen(pkgutilcmd,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+            pkgutilcmd = [
+                "/usr/sbin/pkgutil",
+                "--expand",
+                self.source_path,
+                self.env["destination_path"],
+            ]
+            proc = subprocess.Popen(
+                pkgutilcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             (_, stderr) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 "pkgutil execution failed with error code %d: %s"
-                % (err.errno, err.strerror))
+                % (err.errno, err.strerror)
+            )
         if proc.returncode != 0:
-            raise ProcessorError("extraction of %s with pkgutil failed: %s"
-                                 % (self.env['flat_pkg_path'], stderr))
+            raise ProcessorError(
+                "extraction of %s with pkgutil failed: %s"
+                % (self.env["flat_pkg_path"], stderr)
+            )
 
     def main(self):
         # Check if we're trying to copy something inside a dmg.
-        (dmg_path, dmg, dmg_source_path) = (
-            self.parsePathForDMG(self.env['flat_pkg_path']))
+        (dmg_path, dmg, dmg_source_path) = self.parsePathForDMG(
+            self.env["flat_pkg_path"]
+        )
         try:
             if dmg:
                 # Mount dmg and copy path inside.
                 mount_point = self.mount(dmg_path)
-                self.source_path = (
-                    glob(os.path.join(mount_point, dmg_source_path)))
+                self.source_path = glob(os.path.join(mount_point, dmg_source_path))
                 if not self.source_path:
                     raise ProcessorError(
-                        ("No valid path found as given by 'flat_pkg_path': %s"
-                         % self.env['flat_pkg_path']))
+                        (
+                            "No valid path found as given by 'flat_pkg_path': %s"
+                            % self.env["flat_pkg_path"]
+                        )
+                    )
                 if len(self.source_path) > 1:
                     raise ProcessorError(
-                        ("Multiple source paths found in globbed path in "
-                         "'flat_pkg_path'. There must be only one. Found: %s"
-                         % ", ".join(self.source_path)))
+                        (
+                            "Multiple source paths found in globbed path in "
+                            "'flat_pkg_path'. There must be only one. Found: %s"
+                            % ", ".join(self.source_path)
+                        )
+                    )
                 self.source_path = self.source_path[0]
             else:
                 # Straight copy from file system.
-                self.source_path = self.env['flat_pkg_path']
+                self.source_path = self.env["flat_pkg_path"]
             self.unpack_flat_pkg()
-            self.output("Unpacked %s to %s"
-                        % (self.source_path, self.env['destination_path']))
+            self.output(
+                "Unpacked %s to %s" % (self.source_path, self.env["destination_path"])
+            )
         finally:
             if dmg:
                 self.unmount(dmg_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = FlatPkgUnpacker()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -17,58 +17,67 @@
 
 # Disabling warnings for env members and imports that only affect recipe-
 # specific processors.
-#pylint: disable=e1101,f0401
+# pylint: disable=e1101,f0401
 
 import re
 
 import autopkglib.github
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["GitHubReleasesInfoProvider"]
 
 
 class GitHubReleasesInfoProvider(Processor):
-    #pylint: disable=missing-docstring
-    description = ("Get metadata from the latest release from a GitHub project"
-                   " using the GitHub Releases API."
-                   "\nRequires version 0.5.0.")
+    # pylint: disable=missing-docstring
+    description = (
+        "Get metadata from the latest release from a GitHub project"
+        " using the GitHub Releases API."
+        "\nRequires version 0.5.0."
+    )
     input_variables = {
         "asset_regex": {
             "required": False,
-            "description": ("If set, return only a release asset that "
-                            "matches this regex.")
+            "description": (
+                "If set, return only a release asset that " "matches this regex."
+            ),
         },
         "github_repo": {
             "required": True,
-            "description": ("Name of a GitHub user and repo, ie. "
-                            "'MagerValp/AutoDMG'")
+            "description": (
+                "Name of a GitHub user and repo, ie. " "'MagerValp/AutoDMG'"
+            ),
         },
         "include_prereleases": {
             "required": False,
-            "description": ("If set to True or a non-empty value, include "
-                            "prereleases.")
+            "description": (
+                "If set to True or a non-empty value, include " "prereleases."
+            ),
         },
         "sort_by_highest_tag_names": {
             "required": False,
-            "description": ("Set this to have releases sorted by highest "
-                            "to lowest tag version. By default, releases "
-                            "are sorted descending by date posted. This "
-                            "changes this behavior for cases where an 'older' "
-                            "release may be posted later.")
+            "description": (
+                "Set this to have releases sorted by highest "
+                "to lowest tag version. By default, releases "
+                "are sorted descending by date posted. This "
+                "changes this behavior for cases where an 'older' "
+                "release may be posted later."
+            ),
         },
     }
     output_variables = {
         "release_notes": {
-            "description": ("Full release notes body text from the chosen "
-                            "release.")
+            "description": ("Full release notes body text from the chosen " "release.")
         },
         "url": {
-            "description": ("URL for the first asset found for the project's "
-                            "latest release.")
+            "description": (
+                "URL for the first asset found for the project's " "latest release."
+            )
         },
         "version": {
-            "description": ("Version info parsed, naively derived from the "
-                            "release's tag.")
+            "description": (
+                "Version info parsed, naively derived from the " "release's tag."
+            )
         },
     }
 
@@ -77,14 +86,13 @@ class GitHubReleasesInfoProvider(Processor):
     def get_releases(self, repo):
         """Return a list of releases dicts for a given GitHub repo. repo must
         be of the form 'user/repo'"""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
         releases = None
         github = autopkglib.github.GitHubSession()
         releases_uri = "/repos/%s/releases" % repo
         (releases, status) = github.call_api(releases_uri)
         if status != 200:
-            raise ProcessorError(
-                "Unexpected GitHub API status code %s." % status)
+            raise ProcessorError("Unexpected GitHub API status code %s." % status)
 
         if not releases:
             raise ProcessorError("No releases found for repo '%s'" % repo)
@@ -116,22 +124,25 @@ class GitHubReleasesInfoProvider(Processor):
                     break
                 else:
                     if re.match(regex, asset["name"]):
-                        self.output("Matched regex '%s' among asset(s): %s" % (
-                            regex,
-                            ", ".join([x["name"] for x in assets])))
+                        self.output(
+                            "Matched regex '%s' among asset(s): %s"
+                            % (regex, ", ".join([x["name"] for x in assets]))
+                        )
                         selected = (rel, asset)
                         break
         if not selected:
             raise ProcessorError(
-                "No release assets were found that satisfy the criteria.")
+                "No release assets were found that satisfy the criteria."
+            )
 
-        #pylint: disable=w0201
+        # pylint: disable=w0201
         # We set these in the class to avoid passing more objects around
         self.selected_release = selected[0]
         self.selected_asset = selected[1]
-        self.output("Selected asset '%s' from release '%s'" %
-                    (self.selected_asset["name"],
-                     self.selected_release["name"]))
+        self.output(
+            "Selected asset '%s' from release '%s'"
+            % (self.selected_asset["name"], self.selected_release["name"])
+        )
 
     def process_release_asset(self):
         """Extract what we need from the release and chosen asset, set env
@@ -156,14 +167,14 @@ class GitHubReleasesInfoProvider(Processor):
                 # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
                 # This will be refactored in Python 3.
                 from distutils.version import LooseVersion
+
                 this_comparison = LooseVersion(this) > LooseVersion(that)
                 that_comparison = LooseVersion(this) < LooseVersion(that)
                 return this_comparison - that_comparison
 
-            releases = sorted(releases,
-                              key=itemgetter("tag_name"),
-                              cmp=loose_compare,
-                              reverse=True)
+            releases = sorted(
+                releases, key=itemgetter("tag_name"), cmp=loose_compare, reverse=True
+            )
 
         # Store the first eligible asset
         self.select_asset(releases, self.env.get("asset_regex"))

--- a/Code/autopkglib/MunkiCatalogBuilder.py
+++ b/Code/autopkglib/MunkiCatalogBuilder.py
@@ -19,24 +19,23 @@ import subprocess
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["MunkiCatalogBuilder"]
 
 
 class MunkiCatalogBuilder(Processor):
     """Rebuilds Munki catalogs."""
+
     input_variables = {
-        "MUNKI_REPO": {
-            "required": True,
-            "description": "Path to the Munki repo.",
-        },
+        "MUNKI_REPO": {"required": True, "description": "Path to the Munki repo."},
         "munki_repo_changed": {
             "required": False,
-            "description": ("If not defined or False, causes running "
-                            "makecatalogs to be skipped."),
+            "description": (
+                "If not defined or False, causes running " "makecatalogs to be skipped."
+            ),
         },
     }
-    output_variables = {
-    }
+    output_variables = {}
     description = __doc__
 
     def main(self):
@@ -53,15 +52,16 @@ class MunkiCatalogBuilder(Processor):
         # Call makecatalogs.
         try:
             proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             (_, err_out) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 "makecatalog execution failed with error code %d: %s"
-                % (err.errno, err.strerror))
+                % (err.errno, err.strerror)
+            )
         if proc.returncode != 0:
-            raise ProcessorError(
-                "makecatalogs failed: %s" % err_out)
+            raise ProcessorError("makecatalogs failed: %s" % err_out)
         self.output("Munki catalogs rebuilt!")
 
 

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -22,15 +22,17 @@ import subprocess
 import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["MunkiImporter"]
 
 
 class MunkiImporter(Processor):
     """Imports a pkg or dmg to the Munki repo."""
+
     input_variables = {
         "MUNKI_REPO": {
             "description": "Path to a mounted Munki repo.",
-            "required": True
+            "required": True,
         },
         "pkg_path": {
             "required": True,
@@ -49,40 +51,47 @@ class MunkiImporter(Processor):
             "description": (
                 "The subdirectory under pkgs to which the item "
                 "will be copied, and under pkgsinfo where the pkginfo will "
-                "be created."),
+                "be created."
+            ),
         },
         "pkginfo": {
             "required": False,
-            "description": ("Dictionary of pkginfo keys to copy to "
-                            "generated pkginfo."),
+            "description": (
+                "Dictionary of pkginfo keys to copy to " "generated pkginfo."
+            ),
         },
         "force_munkiimport": {
             "required": False,
             "description": (
                 "If not False or Null, causes the pkg/dmg to be "
                 "imported even if there is a matching pkg already in the "
-                "repo."),
+                "repo."
+            ),
         },
         "additional_makepkginfo_options": {
             "required": False,
             "description": (
                 "Array of additional command-line options that will "
-                "be inserted when calling 'makepkginfo'.")
+                "be inserted when calling 'makepkginfo'."
+            ),
         },
         "version_comparison_key": {
             "required": False,
-            "description": ("String to set 'version_comparison_key' for "
-                            "any generated installs items."),
+            "description": (
+                "String to set 'version_comparison_key' for "
+                "any generated installs items."
+            ),
         },
         "uninstaller_pkg_path": {
             "required": False,
-            "description": ("Path to an uninstaller pkg, supported for Adobe "
-                            "installer_type items."),
+            "description": (
+                "Path to an uninstaller pkg, supported for Adobe "
+                "installer_type items."
+            ),
         },
         "MUNKI_PKGINFO_FILE_EXTENSION": {
-            "description":
-                "Extension for output pkginfo files. Default is 'plist'.",
-            "required": False
+            "description": "Extension for output pkginfo files. Default is 'plist'.",
+            "required": False,
         },
         "metadata_additions": {
             "description": (
@@ -90,25 +99,26 @@ class MunkiImporter(Processor):
                 "Unique keys will be added, but overlapping keys will replace "
                 "existing values."
             ),
-            "required": False
+            "required": False,
         },
     }
     output_variables = {
         "pkginfo_repo_path": {
-            "description": ("The repo path where the pkginfo was written. "
-                            "Empty if item not imported."),
+            "description": (
+                "The repo path where the pkginfo was written. "
+                "Empty if item not imported."
+            )
         },
         "pkg_repo_path": {
-            "description": ("The repo path where the pkg was written. "
-                            "Empty if item not imported."),
+            "description": (
+                "The repo path where the pkg was written. "
+                "Empty if item not imported."
+            )
         },
         "munki_info": {
-            "description":
-                "The pkginfo property list. Empty if item not imported.",
+            "description": "The pkginfo property list. Empty if item not imported."
         },
-        "munki_repo_changed": {
-            "description": "True if item was imported."
-        },
+        "munki_repo_changed": {"description": "True if item was imported."},
         "munki_importer_summary_result": {
             "description": "Description of interesting results."
         },
@@ -120,7 +130,7 @@ class MunkiImporter(Processor):
          database"""
 
         repo_path = self.env["MUNKI_REPO"]
-        all_items_path = os.path.join(repo_path, 'catalogs', 'all')
+        all_items_path = os.path.join(repo_path, "catalogs", "all")
         if not os.path.exists(all_items_path):
             # might be an error, or might be a brand-new empty repo
             catalogitems = []
@@ -129,7 +139,8 @@ class MunkiImporter(Processor):
                 catalogitems = FoundationPlist.readPlist(all_items_path)
             except OSError as err:
                 raise ProcessorError(
-                    "Error reading 'all' catalog from Munki repo: %s" % err)
+                    "Error reading 'all' catalog from Munki repo: %s" % err
+                )
 
         pkgid_table = {}
         app_table = {}
@@ -141,36 +152,34 @@ class MunkiImporter(Processor):
         itemindex = -1
         for item in catalogitems:
             itemindex = itemindex + 1
-            name = item.get('name', 'NO NAME')
-            vers = item.get('version', 'NO VERSION')
+            name = item.get("name", "NO NAME")
+            vers = item.get("version", "NO VERSION")
 
-            if name == 'NO NAME' or vers == 'NO VERSION':
+            if name == "NO NAME" or vers == "NO VERSION":
                 # skip this item
                 continue
 
             # add to hash table
-            if 'installer_item_hash' in item:
-                if not item['installer_item_hash'] in hash_table:
-                    hash_table[item['installer_item_hash']] = []
-                hash_table[item['installer_item_hash']].append(itemindex)
+            if "installer_item_hash" in item:
+                if not item["installer_item_hash"] in hash_table:
+                    hash_table[item["installer_item_hash"]] = []
+                hash_table[item["installer_item_hash"]].append(itemindex)
 
             # add to installer item table
-            if 'installer_item_location' in item:
-                installer_item_name = os.path.basename(
-                    item['installer_item_location'])
+            if "installer_item_location" in item:
+                installer_item_name = os.path.basename(item["installer_item_location"])
                 if installer_item_name not in installer_item_table:
                     installer_item_table[installer_item_name] = {}
                 if vers not in installer_item_table[installer_item_name]:
                     installer_item_table[installer_item_name][vers] = []
-                installer_item_table[
-                    installer_item_name][vers].append(itemindex)
+                installer_item_table[installer_item_name][vers].append(itemindex)
 
             # add to table of receipts
-            for receipt in item.get('receipts', []):
+            for receipt in item.get("receipts", []):
                 try:
-                    if 'packageid' in receipt and 'version' in receipt:
-                        pkgid = receipt['packageid']
-                        pkgvers = receipt['version']
+                    if "packageid" in receipt and "version" in receipt:
+                        pkgid = receipt["packageid"]
+                        pkgvers = receipt["version"]
                         if pkgid not in pkgid_table:
                             pkgid_table[pkgid] = {}
                         if pkgvers not in pkgid_table[pkgid]:
@@ -181,55 +190,52 @@ class MunkiImporter(Processor):
                     continue
 
             # add to table of installed applications
-            for install in item.get('installs', []):
+            for install in item.get("installs", []):
                 try:
-                    if install.get('type') in ('application', 'bundle'):
-                        if 'path' in install:
-                            if 'version_comparison_key' in install:
-                                app_version = (
-                                    install[install['version_comparison_key']])
+                    if install.get("type") in ("application", "bundle"):
+                        if "path" in install:
+                            if "version_comparison_key" in install:
+                                app_version = install[install["version_comparison_key"]]
                             else:
-                                app_version = (
-                                    install['CFBundleShortVersionString'])
-                            if install['path'] not in app_table:
-                                app_table[install['path']] = {}
-                            if vers not in app_table[install['path']]:
-                                app_table[install['path']][app_version] = []
-                            app_table[
-                                install['path']][app_version].append(itemindex)
-                    if install.get('type') == 'file':
-                        if 'path' in install:
-                            if 'md5checksum' in install:
-                                cksum = install['md5checksum']
+                                app_version = install["CFBundleShortVersionString"]
+                            if install["path"] not in app_table:
+                                app_table[install["path"]] = {}
+                            if vers not in app_table[install["path"]]:
+                                app_table[install["path"]][app_version] = []
+                            app_table[install["path"]][app_version].append(itemindex)
+                    if install.get("type") == "file":
+                        if "path" in install:
+                            if "md5checksum" in install:
+                                cksum = install["md5checksum"]
 
                                 if cksum not in checksum_table.keys():
                                     checksum_table[cksum] = []
 
                                 checksum_table[cksum].append(
-                                    {'path': install['path'],
-                                     'index': itemindex})
+                                    {"path": install["path"], "index": itemindex}
+                                )
                             else:
-                                path = install['path']
+                                path = install["path"]
 
                                 if path not in files_table.keys():
                                     files_table[path] = []
 
                                 files_table[path].append(
-                                    {'path': install['path'],
-                                     'index': itemindex})
+                                    {"path": install["path"], "index": itemindex}
+                                )
 
                 except (TypeError, KeyError):
                     # skip this item
                     continue
 
         pkgdb = {}
-        pkgdb['hashes'] = hash_table
-        pkgdb['receipts'] = pkgid_table
-        pkgdb['applications'] = app_table
-        pkgdb['installer_items'] = installer_item_table
-        pkgdb['checksums'] = checksum_table
-        pkgdb['files'] = files_table
-        pkgdb['items'] = catalogitems
+        pkgdb["hashes"] = hash_table
+        pkgdb["receipts"] = pkgid_table
+        pkgdb["applications"] = app_table
+        pkgdb["installer_items"] = installer_item_table
+        pkgdb["checksums"] = checksum_table
+        pkgdb["files"] = files_table
+        pkgdb["items"] = catalogitems
 
         return pkgdb
 
@@ -237,7 +243,7 @@ class MunkiImporter(Processor):
         """Looks through all catalog for items matching the one
         described by pkginfo. Returns a matching item if found."""
 
-        if not pkginfo.get('installer_item_hash'):
+        if not pkginfo.get("installer_item_hash"):
             return None
 
         if self.env.get("force_munkiimport"):
@@ -248,26 +254,28 @@ class MunkiImporter(Processor):
         pkgdb = self.make_catalog_db()
 
         # match hashes for the pkg or dmg
-        if 'installer_item_hash' in pkginfo:
+        if "installer_item_hash" in pkginfo:
             pkgdb = self.make_catalog_db()
-            matchingindexes = pkgdb['hashes'].get(
-                pkginfo['installer_item_hash'])
+            matchingindexes = pkgdb["hashes"].get(pkginfo["installer_item_hash"])
             if matchingindexes:
                 # we have an item with the exact same checksum hash in the repo
-                return pkgdb['items'][matchingindexes[0]]
+                return pkgdb["items"][matchingindexes[0]]
 
         # try to match against installed applications
-        applist = [item for item in pkginfo.get('installs', [])
-                   if item.get('type') in ('application', 'bundle') and 'path' in item]
+        applist = [
+            item
+            for item in pkginfo.get("installs", [])
+            if item.get("type") in ("application", "bundle") and "path" in item
+        ]
         if applist:
             matching_indexes = []
             for app in applist:
-                app_path = app['path']
-                if 'version_comparison_key' in app:
-                    app_version = app[app['version_comparison_key']]
+                app_path = app["path"]
+                if "version_comparison_key" in app:
+                    app_version = app[app["version_comparison_key"]]
                 else:
-                    app_version = app['CFBundleShortVersionString']
-                match = pkgdb['applications'].get(app_path, {}).get(app_version)
+                    app_version = app["CFBundleShortVersionString"]
+                match = pkgdb["applications"].get(app_path, {}).get(app_version)
                 if not match:
                     # no entry for app['path'] and app['version']
                     # no point in continuing
@@ -279,20 +287,19 @@ class MunkiImporter(Processor):
                     else:
                         # we're only interested in items that match
                         # all applications
-                        matching_indexes = (
-                            matching_indexes.intersection(set(match)))
+                        matching_indexes = matching_indexes.intersection(set(match))
 
             # did we find any matches?
             if matching_indexes:
-                return pkgdb['items'][list(matching_indexes)[0]]
+                return pkgdb["items"][list(matching_indexes)[0]]
 
         # fall back to matching against receipts
         matching_indexes = []
-        for item in pkginfo.get('receipts', []):
-            pkgid = item.get('packageid')
-            vers = item.get('version')
+        for item in pkginfo.get("receipts", []):
+            pkgid = item.get("packageid")
+            vers = item.get("version")
             if pkgid and vers:
-                match = pkgdb['receipts'].get(pkgid, {}).get(vers)
+                match = pkgdb["receipts"].get(pkgid, {}).get(vers)
                 if not match:
                     # no entry for pkgid and vers
                     # no point in continuing
@@ -304,25 +311,26 @@ class MunkiImporter(Processor):
                     else:
                         # we're only interested in items that match
                         # all receipts
-                        matching_indexes = (
-                            matching_indexes.intersection(set(match)))
+                        matching_indexes = matching_indexes.intersection(set(match))
 
         # did we find any matches?
         if matching_indexes:
-            return pkgdb['items'][list(matching_indexes)[0]]
+            return pkgdb["items"][list(matching_indexes)[0]]
 
         # try to match against install md5checksums
-        filelist = [item for item in pkginfo.get('installs', [])
-                    if item['type'] == 'file' and 'path' in item
-                    and 'md5checksum' in item]
+        filelist = [
+            item
+            for item in pkginfo.get("installs", [])
+            if item["type"] == "file" and "path" in item and "md5checksum" in item
+        ]
         if filelist:
             for fileitem in filelist:
-                cksum = fileitem['md5checksum']
-                if cksum in pkgdb['checksums']:
-                    cksum_matches = pkgdb['checksums'][cksum]
+                cksum = fileitem["md5checksum"]
+                if cksum in pkgdb["checksums"]:
+                    cksum_matches = pkgdb["checksums"][cksum]
                     for cksum_match in cksum_matches:
-                        if cksum_match['path'] == fileitem['path']:
-                            matching_pkg = pkgdb['items'][cksum_match['index']]
+                        if cksum_match["path"] == fileitem["path"]:
+                            matching_pkg = pkgdb["items"][cksum_match["index"]]
 
                             # TODO: maybe match pkg name, too?
                             # if matching_pkg['name'] == pkginfo['name']:
@@ -331,20 +339,24 @@ class MunkiImporter(Processor):
 
         # Try to match against a simple list of files and paths
         # where our pkginfo version also matches
-        path_only_filelist = [item for item in pkginfo.get('installs', [])
-                              if item.get('type') == 'file' and 'path' in item
-                              and 'md5checksum' not in item]
+        path_only_filelist = [
+            item
+            for item in pkginfo.get("installs", [])
+            if item.get("type") == "file"
+            and "path" in item
+            and "md5checksum" not in item
+        ]
         if path_only_filelist:
             for pathitem in path_only_filelist:
-                path = pathitem['path']
-                if path in pkgdb['files']:
-                    path_matches = pkgdb['files'][path]
+                path = pathitem["path"]
+                if path in pkgdb["files"]:
+                    path_matches = pkgdb["files"][path]
                     for path_match in path_matches:
-                        if path_match['path'] == pathitem['path']:
-                            matching_pkg = pkgdb['items'][path_match['index']]
+                        if path_match["path"] == pathitem["path"]:
+                            matching_pkg = pkgdb["items"][path_match["index"]]
                             # make sure we do this only for items that also
                             # match our pkginfo version
-                            if matching_pkg['version'] == pkginfo['version']:
+                            if matching_pkg["version"] == pkginfo["version"]:
                                 return matching_pkg
 
         # if we get here, we found no matches
@@ -373,8 +385,9 @@ class MunkiImporter(Processor):
             try:
                 os.makedirs(destination_path)
             except OSError as err:
-                raise ProcessorError("Could not create %s: %s"
-                                     % (destination_path, err.strerror))
+                raise ProcessorError(
+                    "Could not create %s: %s" % (destination_path, err.strerror)
+                )
 
         item_name = os.path.basename(itempath)
         destination_pathname = os.path.join(destination_path, item_name)
@@ -390,8 +403,7 @@ class MunkiImporter(Processor):
                 # add the version number to the end of
                 # the item name
                 item_name = "%s-%s%s" % (name, item_version, ext)
-                destination_pathname = os.path.join(
-                    destination_path, item_name)
+                destination_pathname = os.path.join(destination_path, item_name)
 
         index = 0
         name, ext = os.path.splitext(item_name)
@@ -406,7 +418,8 @@ class MunkiImporter(Processor):
         except OSError as err:
             raise ProcessorError(
                 "Can't copy %s to %s: %s"
-                % (self.env["pkg_path"], destination_pathname, err.strerror))
+                % (self.env["pkg_path"], destination_pathname, err.strerror)
+            )
 
         return os.path.join(subdirectory, item_name)
 
@@ -422,34 +435,42 @@ class MunkiImporter(Processor):
             try:
                 os.makedirs(destination_path)
             except OSError as err:
-                raise ProcessorError("Could not create %s: %s"
-                                     % (destination_path, err.strerror))
+                raise ProcessorError(
+                    "Could not create %s: %s" % (destination_path, err.strerror)
+                )
 
         extension = self.env.get("MUNKI_PKGINFO_FILE_EXTENSION", "plist")
         if len(extension) > 0:
-            extension = '.' + extension.strip(".")
-        pkginfo_name = "%s-%s%s" % (pkginfo["name"],
-                                     pkginfo["version"].strip(),
-                                     extension)
+            extension = "." + extension.strip(".")
+        pkginfo_name = "%s-%s%s" % (
+            pkginfo["name"],
+            pkginfo["version"].strip(),
+            extension,
+        )
         pkginfo_path = os.path.join(destination_path, pkginfo_name)
         index = 0
         while os.path.exists(pkginfo_path):
             index += 1
             pkginfo_name = "%s-%s__%s%s" % (
-                pkginfo["name"], pkginfo["version"], index, extension)
+                pkginfo["name"],
+                pkginfo["version"],
+                index,
+                extension,
+            )
             pkginfo_path = os.path.join(destination_path, pkginfo_name)
 
         try:
             FoundationPlist.writePlist(pkginfo, pkginfo_path)
         except OSError as err:
-            raise ProcessorError("Could not write pkginfo %s: %s"
-                                 % (pkginfo_path, err.strerror))
+            raise ProcessorError(
+                "Could not write pkginfo %s: %s" % (pkginfo_path, err.strerror)
+            )
         return pkginfo_path
 
     def main(self):
         # clear any pre-exising summary result
-        if 'munki_importer_summary_result' in self.env:
-            del self.env['munki_importer_summary_result']
+        if "munki_importer_summary_result" in self.env:
+            del self.env["munki_importer_summary_result"]
         # Generate arguments for makepkginfo.
         args = ["/usr/local/munki/makepkginfo", self.env["pkg_path"]]
         if self.env.get("munkiimport_pkgname"):
@@ -466,19 +487,21 @@ class MunkiImporter(Processor):
         # Call makepkginfo.
         try:
             proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             (out, err_out) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 "makepkginfo execution failed with error code %d: %s"
-                % (err.errno, err.strerror))
+                % (err.errno, err.strerror)
+            )
         if err_out:
             for err_line in err_out.splitlines():
                 self.output(err_line)
         if proc.returncode != 0:
             raise ProcessorError(
-                "creating pkginfo for %s failed: %s"
-                % (self.env["pkg_path"], err_out))
+                "creating pkginfo for %s failed: %s" % (self.env["pkg_path"], err_out)
+            )
 
         # Get pkginfo from output plist.
         pkginfo = FoundationPlist.readPlistFromString(out)
@@ -498,11 +521,13 @@ class MunkiImporter(Processor):
             for item in pkginfo["installs"]:
                 if not self.env["version_comparison_key"] in item:
                     raise ProcessorError(
-                        ("version_comparison_key '%s' could not be found in "
-                         "the installs item for path '%s'")
-                        % (self.env["version_comparison_key"], item["path"]))
-                item["version_comparison_key"] = (
-                    self.env["version_comparison_key"])
+                        (
+                            "version_comparison_key '%s' could not be found in "
+                            "the installs item for path '%s'"
+                        )
+                        % (self.env["version_comparison_key"], item["path"])
+                    )
+                item["version_comparison_key"] = self.env["version_comparison_key"]
 
         # check to see if this item is already in the repo
         matchingitem = self.find_matching_item_in_repo(pkginfo)
@@ -510,15 +535,19 @@ class MunkiImporter(Processor):
             self.env["pkginfo_repo_path"] = ""
             # set env["pkg_repo_path"] to the path of the matching item
             self.env["pkg_repo_path"] = os.path.join(
-                self.env["MUNKI_REPO"], "pkgs",
-                matchingitem['installer_item_location'])
+                self.env["MUNKI_REPO"], "pkgs", matchingitem["installer_item_location"]
+            )
             self.env["munki_info"] = {}
             if "munki_repo_changed" not in self.env:
                 self.env["munki_repo_changed"] = False
 
-            self.output("Item %s already exists in the munki repo as %s."
-                        % (os.path.basename(self.env["pkg_path"]),
-                           "pkgs/" + matchingitem['installer_item_location']))
+            self.output(
+                "Item %s already exists in the munki repo as %s."
+                % (
+                    os.path.basename(self.env["pkg_path"]),
+                    "pkgs/" + matchingitem["installer_item_location"],
+                )
+            )
             return
 
         # copy pkg/dmg to repo
@@ -529,14 +558,16 @@ class MunkiImporter(Processor):
 
         if self.env.get("uninstaller_pkg_path"):
             relative_uninstall_path = self.copy_item_to_repo(
-                pkginfo, uninstaller_pkg=True)
+                pkginfo, uninstaller_pkg=True
+            )
             pkginfo["uninstaller_item_location"] = relative_uninstall_path
             pkginfo["uninstallable"] = True
 
         # set output variables
         self.env["pkginfo_repo_path"] = self.copy_pkginfo_to_repo(pkginfo)
         self.env["pkg_repo_path"] = os.path.join(
-            self.env["MUNKI_REPO"], "pkgs", relative_path)
+            self.env["MUNKI_REPO"], "pkgs", relative_path
+        )
         # update env["pkg_path"] to match env["pkg_repo_path"]
         # this allows subsequent recipe steps to reuse the uploaded
         # pkg/dmg instead of re-uploading
@@ -546,18 +577,21 @@ class MunkiImporter(Processor):
         self.env["munki_info"] = pkginfo
         self.env["munki_repo_changed"] = True
         self.env["munki_importer_summary_result"] = {
-            'summary_text': 'The following new items were imported into Munki:',
-            'report_fields': ['name', 'version', 'catalogs',
-                              'pkginfo_path', 'pkg_repo_path'],
-            'data': {
-                'name': pkginfo['name'],
-                'version': pkginfo['version'],
-                'catalogs': ','. join(pkginfo['catalogs']),
-                'pkginfo_path':
-                    self.env['pkginfo_repo_path'].partition('pkgsinfo/')[2],
-                'pkg_repo_path':
-                    self.env['pkg_repo_path'].partition('pkgs/')[2]
-            }
+            "summary_text": "The following new items were imported into Munki:",
+            "report_fields": [
+                "name",
+                "version",
+                "catalogs",
+                "pkginfo_path",
+                "pkg_repo_path",
+            ],
+            "data": {
+                "name": pkginfo["name"],
+                "version": pkginfo["version"],
+                "catalogs": ",".join(pkginfo["catalogs"]),
+                "pkginfo_path": self.env["pkginfo_repo_path"].partition("pkgsinfo/")[2],
+                "pkg_repo_path": self.env["pkg_repo_path"].partition("pkgs/")[2],
+            },
         }
 
         self.output("Copied pkginfo to %s" % self.env["pkginfo_repo_path"])

--- a/Code/autopkglib/MunkiInfoCreator.py
+++ b/Code/autopkglib/MunkiInfoCreator.py
@@ -23,11 +23,13 @@ import tempfile
 import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["MunkiInfoCreator"]
 
 
 class MunkiInfoCreator(Processor):
     """Creates a pkginfo file for a munki package."""
+
     description = __doc__
     input_variables = {
         "pkg_path": {
@@ -38,20 +40,10 @@ class MunkiInfoCreator(Processor):
             "required": False,
             "description": "Version to override makepkginfo.",
         },
-        "name": {
-            "required": False,
-            "description": "Name to override makepkginfo.",
-        },
-        "info_path": {
-            "required": False,
-            "description": "Path to the pkgsinfo file.",
-        },
+        "name": {"required": False, "description": "Name to override makepkginfo."},
+        "info_path": {"required": False, "description": "Path to the pkgsinfo file."},
     }
-    output_variables = {
-        "munki_info": {
-            "description": "The pkginfo property list.",
-        },
-    }
+    output_variables = {"munki_info": {"description": "The pkginfo property list."}}
 
     def main(self):
         # Wrap in a try/finally so the temp_path is always removed.
@@ -69,12 +61,12 @@ class MunkiInfoCreator(Processor):
             # (which is called by makepkginfo) doesn't work on network drives.
             if self.env["pkg_path"].endswith("pkg"):
                 # Create temporary directory.
-                temp_path = tempfile.mkdtemp(
-                    prefix="autopkg", dir="/private/tmp")
+                temp_path = tempfile.mkdtemp(prefix="autopkg", dir="/private/tmp")
 
                 # Copy the pkg there
                 pkg_for_makepkginfo = os.path.join(
-                    temp_path, os.path.basename(self.env["pkg_path"]))
+                    temp_path, os.path.basename(self.env["pkg_path"])
+                )
                 shutil.copyfile(self.env["pkg_path"], pkg_for_makepkginfo)
             else:
                 pkg_for_makepkginfo = self.env["pkg_path"]
@@ -89,15 +81,19 @@ class MunkiInfoCreator(Processor):
             # Call makepkginfo.
             try:
                 proc = subprocess.Popen(
-                    args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
                 (stdout, stderr) = proc.communicate()
             except OSError as err:
                 raise ProcessorError(
                     "makepkginfo execution failed with error code %d: %s"
-                    % (err.errno, err.strerror))
+                    % (err.errno, err.strerror)
+                )
             if proc.returncode != 0:
-                raise ProcessorError("creating pkginfo for %s failed: %s"
-                                     % (self.env['pkg_path'], stderr))
+                raise ProcessorError(
+                    "creating pkginfo for %s failed: %s"
+                    % (self.env["pkg_path"], stderr)
+                )
 
         # makepkginfo cleanup.
         finally:
@@ -119,6 +115,6 @@ class MunkiInfoCreator(Processor):
             FoundationPlist.writePlist(output, self.env["info_path"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = MunkiInfoCreator()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -22,25 +22,24 @@ import subprocess
 import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
-#pylint: disable=no-name-in-module
+
+# pylint: disable=no-name-in-module
 try:
     from Foundation import NSDictionary
 except:
-    print(
-        "WARNING: Failed 'from Foundation import NSDictionary' in " + __name__
-    )
-#pylint: enable=no-name-in-module
+    print("WARNING: Failed 'from Foundation import NSDictionary' in " + __name__)
+# pylint: enable=no-name-in-module
 
 __all__ = ["MunkiInstallsItemsCreator"]
 
 
 class MunkiInstallsItemsCreator(Processor):
     """Generates an installs array for a pkginfo file."""
+
     input_variables = {
         "installs_item_paths": {
             "required": True,
-            "description":
-                "Array of paths to create installs items for.",
+            "description": "Array of paths to create installs items for.",
         },
         "faux_root": {
             "required": False,
@@ -57,14 +56,14 @@ class MunkiInstallsItemsCreator(Processor):
                 "version_comparison_key.\n"
                 "Example:\n"
                 "{'/Applications/Foo.app': 'CFBundleVersion',\n"
-                "'/Library/Bar.plugin': 'CFBundleShortVersionString'}"),
+                "'/Library/Bar.plugin': 'CFBundleShortVersionString'}"
+            ),
         },
-
     }
     output_variables = {
         "additional_pkginfo": {
-            "description": "Pkginfo dictionary containing installs array.",
-        },
+            "description": "Pkginfo dictionary containing installs array."
+        }
     }
     description = __doc__
 
@@ -81,15 +80,16 @@ class MunkiInstallsItemsCreator(Processor):
         # Call makepkginfo.
         try:
             proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             (out, err) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 "makepkginfo execution failed with error code %d: %s"
-                % (err.errno, err.strerror))
+                % (err.errno, err.strerror)
+            )
         if proc.returncode != 0:
-            raise ProcessorError(
-                "creating pkginfo failed: %s" % err)
+            raise ProcessorError("creating pkginfo failed: %s" % err)
 
         # Get pkginfo from output plist.
         pkginfo = FoundationPlist.readPlistFromString(out)
@@ -98,7 +98,7 @@ class MunkiInstallsItemsCreator(Processor):
         if faux_root:
             for item in installs_array:
                 if item["path"].startswith(faux_root):
-                    item["path"] = item["path"][len(faux_root):]
+                    item["path"] = item["path"][len(faux_root) :]
                 self.output("Created installs item for %s" % item["path"])
 
         if "version_comparison_key" in self.env:
@@ -108,8 +108,7 @@ class MunkiInstallsItemsCreator(Processor):
                 if isinstance(self.env["version_comparison_key"], basestring):
                     cmp_key = self.env["version_comparison_key"]
                 # It it's a dict, find if there's a key that matches a path
-                elif isinstance(
-                        self.env["version_comparison_key"], NSDictionary):
+                elif isinstance(self.env["version_comparison_key"], NSDictionary):
                     for path, key in self.env["version_comparison_key"].items():
                         if path == item["path"]:
                             cmp_key = key
@@ -121,8 +120,8 @@ class MunkiInstallsItemsCreator(Processor):
                     else:
                         raise ProcessorError(
                             "version_comparison_key '%s' could not be found in "
-                            "the installs item for path '%s'"
-                            % (cmp_key, item["path"]))
+                            "the installs item for path '%s'" % (cmp_key, item["path"])
+                        )
 
         if "additional_pkginfo" not in self.env:
             self.env["additional_pkginfo"] = {}

--- a/Code/autopkglib/MunkiPkginfoMerger.py
+++ b/Code/autopkglib/MunkiPkginfoMerger.py
@@ -17,29 +17,24 @@
 
 from autopkglib import Processor
 
+
 __all__ = ["MunkiPkginfoMerger"]
 
 
 class MunkiPkginfoMerger(Processor):
     """Merges two pkginfo dictionaries."""
+
     input_variables = {
-        "pkginfo": {
-            "required": False,
-            "description": "Dictionary of Munki pkginfo.",
-        },
+        "pkginfo": {"required": False, "description": "Dictionary of Munki pkginfo."},
         "additional_pkginfo": {
             "required": True,
             "description": (
                 "Dictionary containing additional Munki pkginfo. "
-                "This will be added to or replace keys in the pkginfo."),
-        },
-
-    }
-    output_variables = {
-        "pkginfo": {
-            "description": "Merged pkginfo.",
+                "This will be added to or replace keys in the pkginfo."
+            ),
         },
     }
+    output_variables = {"pkginfo": {"description": "Merged pkginfo."}}
     description = __doc__
 
     def main(self):

--- a/Code/autopkglib/MunkiSetDefaultCatalog.py
+++ b/Code/autopkglib/MunkiSetDefaultCatalog.py
@@ -18,7 +18,8 @@
 
 from autopkglib import Processor
 
-#pylint: disable=no-name-in-module
+
+# pylint: disable=no-name-in-module
 try:
     from Foundation import CFPreferencesCopyAppValue
 except:
@@ -26,7 +27,7 @@ except:
         "WARNING: Failed 'from Foundation import CFPreferencesCopyAppValue' "
         "in " + __name__
     )
-#pylint: enable=no-name-in-module
+# pylint: enable=no-name-in-module
 
 __all__ = ["MunkiSetDefaultCatalog"]
 
@@ -35,29 +36,24 @@ class MunkiSetDefaultCatalog(Processor):
     """Edit current munki pkginfo to set the 'catalog' key to the default
     catalog preference for munkiimport (com.googlecode.munki.munkiimport),
     if one has been set. Typically this would be run as a preprocessor."""
+
     input_variables = {
-        "pkginfo": {
-            "required": False,
-            "description": "Dictionary of Munki pkginfo.",
-        }
+        "pkginfo": {"required": False, "description": "Dictionary of Munki pkginfo."}
     }
-    output_variables = {
-        "pkginfo": {
-            "description": "Updated pkginfo.",
-        },
-    }
+    output_variables = {"pkginfo": {"description": "Updated pkginfo."}}
     description = __doc__
 
     def main(self):
         if "pkginfo" not in self.env:
             self.env["pkginfo"] = {}
         default_catalog = CFPreferencesCopyAppValue(
-            "default_catalog",
-            "com.googlecode.munki.munkiimport")
+            "default_catalog", "com.googlecode.munki.munkiimport"
+        )
         if default_catalog:
             self.env["pkginfo"]["catalogs"] = [default_catalog]
-            self.output("Updated target catalogs into pkginfo with %s"
-                        % default_catalog)
+            self.output(
+                "Updated target catalogs into pkginfo with %s" % default_catalog
+            )
         else:
             self.output("No default catalogs found, nothing changed")
 

--- a/Code/autopkglib/PackageRequired.py
+++ b/Code/autopkglib/PackageRequired.py
@@ -19,27 +19,30 @@ import os
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["PackageRequired"]
 
 
 class PackageRequired(Processor):
-    '''Raises a ProcessorError if the PKG variable doesn't exist.
+    """Raises a ProcessorError if the PKG variable doesn't exist.
 
-    Requires version 0.5.1.'''
+    Requires version 0.5.1."""
 
-    input_variables = {
-    }
-    output_variables = {
-    }
+    input_variables = {}
+    output_variables = {}
 
     def main(self):
-        pkg = self.env.get('PKG', None)
+        pkg = self.env.get("PKG", None)
 
         if not pkg:
-            raise ProcessorError('This recipe requires a package or disk '
+            raise ProcessorError(
+                "This recipe requires a package or disk "
                 'image to be pre-downloaded and supplied to autopkg ("-p" '
-                'command-line switch). This is likely due to required login '
-                'credentials to download the software.')
+                "command-line switch). This is likely due to required login "
+                "credentials to download the software."
+            )
 
         if not os.path.exists(pkg):
-            raise ProcessorError('Path to package or disk image does not exist: %s' % pkg)
+            raise ProcessorError(
+                "Path to package or disk image does not exist: %s" % pkg
+            )

--- a/Code/autopkglib/PathDeleter.py
+++ b/Code/autopkglib/PathDeleter.py
@@ -20,21 +20,23 @@ import shutil
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["PathDeleter"]
 
 
 class PathDeleter(Processor):
     """Deletes file paths."""
+
     input_variables = {
         "path_list": {
             "required": True,
-            "description":
-                ("An array or list of pathnames to be deleted, "
-                 "even if that list contains a single item."),
-        },
+            "description": (
+                "An array or list of pathnames to be deleted, "
+                "even if that list contains a single item."
+            ),
+        }
     }
-    output_variables = {
-    }
+    output_variables = {}
     description = __doc__
 
     def main(self):
@@ -51,15 +53,16 @@ class PathDeleter(Processor):
                     shutil.rmtree(path)
                 elif not os.path.exists(path):
                     raise ProcessorError(
-                        "Could not remove %s - it does not exist!" % path)
+                        "Could not remove %s - it does not exist!" % path
+                    )
                 else:
                     raise ProcessorError(
                         "Could not remove %s - it is not a file, link, "
-                        "or directory" % path)
+                        "or directory" % path
+                    )
                 self.output("Deleted %s" % path)
             except OSError as err:
-                raise ProcessorError(
-                    "Could not remove %s: %s" % (path, err))
+                raise ProcessorError("Could not remove %s: %s" % (path, err))
 
 
 if __name__ == "__main__":

--- a/Code/autopkglib/PkgCopier.py
+++ b/Code/autopkglib/PkgCopier.py
@@ -20,11 +20,13 @@ import os.path
 
 from autopkglib.Copier import Copier
 
+
 __all__ = ["PkgCopier"]
 
 
 class PkgCopier(Copier):
     """Copies source_pkg to pkg_path."""
+
     description = __doc__
     input_variables = {
         "source_pkg": {
@@ -33,31 +35,31 @@ class PkgCopier(Copier):
                 "Path to a pkg to copy. Can point to a path inside "
                 "a .dmg which will be mounted. This path may also contain "
                 "basic globbing characters such as the wildcard '*', but only "
-                "the first result will be returned."),
+                "the first result will be returned."
+            ),
         },
         "pkg_path": {
             "required": False,
-            "description": ("Path to destination. Defaults to "
-                            "RECIPE_CACHE_DIR/os.path.basename(source_pkg)"),
+            "description": (
+                "Path to destination. Defaults to "
+                "RECIPE_CACHE_DIR/os.path.basename(source_pkg)"
+            ),
         },
     }
     output_variables = {
-        "pkg_path": {
-            "description": "Path to copied pkg.",
-        },
+        "pkg_path": {"description": "Path to copied pkg."},
         "pkg_copier_summary_result": {
             "description": "Description of interesting results."
-        }
+        },
     }
 
     def main(self):
         # clear any pre-exising summary result
-        if 'pkg_copier_summary_result' in self.env:
-            del self.env['pkg_copier_summary_result']
+        if "pkg_copier_summary_result" in self.env:
+            del self.env["pkg_copier_summary_result"]
 
         # Check if we're trying to copy something inside a dmg.
-        (dmg_path, dmg, dmg_source_path) = self.parsePathForDMG(
-            self.env['source_pkg'])
+        (dmg_path, dmg, dmg_source_path) = self.parsePathForDMG(self.env["source_pkg"])
         try:
             if dmg:
                 # Mount dmg and copy path inside.
@@ -72,26 +74,26 @@ class PkgCopier(Copier):
             matched_source_path = matches[0]
             if len(matches) > 1:
                 self.output(
-                    "WARNING: Multiple paths match 'source_pkg' glob '%s':"
-                    % source_pkg)
+                    "WARNING: Multiple paths match 'source_pkg' glob '%s':" % source_pkg
+                )
                 for match in matches:
                     self.output("  - %s" % match)
 
-            if [c for c in '*?[]!' if c in source_pkg]:
-                self.output("Using path '%s' matched from globbed '%s'."
-                            % (matched_source_path, source_pkg))
+            if [c for c in "*?[]!" if c in source_pkg]:
+                self.output(
+                    "Using path '%s' matched from globbed '%s'."
+                    % (matched_source_path, source_pkg)
+                )
 
             # do the copy
-            pkg_path = (self.env.get("pkg_path") or
-                        os.path.join(self.env['RECIPE_CACHE_DIR'],
-                                     os.path.basename(source_pkg)))
+            pkg_path = self.env.get("pkg_path") or os.path.join(
+                self.env["RECIPE_CACHE_DIR"], os.path.basename(source_pkg)
+            )
             self.copy(matched_source_path, pkg_path, overwrite=True)
             self.env["pkg_path"] = pkg_path
             self.env["pkg_copier_summary_result"] = {
-                'summary_text': 'The following packages were copied:',
-                'data': {
-                    'pkg_path': pkg_path,
-                }
+                "summary_text": "The following packages were copied:",
+                "data": {"pkg_path": pkg_path},
             }
 
         finally:
@@ -99,6 +101,6 @@ class PkgCopier(Copier):
                 self.unmount(dmg_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = Copier()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/PkgCreator.py
+++ b/Code/autopkglib/PkgCreator.py
@@ -23,6 +23,7 @@ import xml.etree.ElementTree as ET
 import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
+
 AUTO_PKG_SOCKET = "/var/run/autopkgserver"
 
 
@@ -31,52 +32,54 @@ __all__ = ["PkgCreator"]
 
 class PkgCreator(Processor):
     """Calls autopkgserver to create a package."""
+
     description = __doc__
     input_variables = {
         "pkg_request": {
             "required": True,
             "description": (
                 "A package request dictionary. See "
-                "Code/autopkgserver/autopkgserver for more details.")
+                "Code/autopkgserver/autopkgserver for more details."
+            ),
         },
         "force_pkg_build": {
             "required": False,
             "description": (
                 "When set, this forces building a new package even if "
                 "a package already exists in the output directory with "
-                "the same identifier and version number. Defaults to False"),
+                "the same identifier and version number. Defaults to False"
+            ),
         },
     }
     output_variables = {
-        "pkg_path": {
-            "description": "The created package.",
-        },
+        "pkg_path": {"description": "The created package."},
         "new_package_request": {
             "description": (
                 "True if a new package was actually requested to be built. "
                 "False if a package with the same filename, identifier and "
                 "version already exists and thus no package was built (see "
-                "'force_pkg_build' input variable.")
+                "'force_pkg_build' input variable."
+            )
         },
         "pkg_creator_summary_result": {
             "description": "Description of interesting results."
-        }
+        },
     }
 
     def find_path_for_relpath(self, relpath):
-        '''Searches for the relative path.
+        """Searches for the relative path.
         Search order is:
             RECIPE_CACHE_DIR
             RECIPE_DIR
-            PARENT_RECIPE directories'''
-        cache_dir = self.env.get('RECIPE_CACHE_DIR')
-        recipe_dir = self.env.get('RECIPE_DIR')
+            PARENT_RECIPE directories"""
+        cache_dir = self.env.get("RECIPE_CACHE_DIR")
+        recipe_dir = self.env.get("RECIPE_DIR")
         search_dirs = [cache_dir, recipe_dir]
         if self.env.get("PARENT_RECIPES"):
             # also look in the directories containing the parent recipes
             parent_recipe_dirs = list(
-                set([os.path.dirname(item)
-                     for item in self.env["PARENT_RECIPES"]]))
+                set([os.path.dirname(item) for item in self.env["PARENT_RECIPES"]])
+            )
             search_dirs.extend(parent_recipe_dirs)
         for directory in search_dirs:
             test_item = os.path.join(directory, relpath)
@@ -86,28 +89,35 @@ class PkgCreator(Processor):
         raise ProcessorError("Can't find %s" % relpath)
 
     def xar_expand(self, source_path):
-        '''Uses xar to expand an archive'''
+        """Uses xar to expand an archive"""
         try:
-            xarcmd = ["/usr/bin/xar",
-                      "-x",
-                      "-C", self.env.get('RECIPE_CACHE_DIR'),
-                      "-f", source_path,
-                      "PackageInfo"]
-            proc = subprocess.Popen(xarcmd,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+            xarcmd = [
+                "/usr/bin/xar",
+                "-x",
+                "-C",
+                self.env.get("RECIPE_CACHE_DIR"),
+                "-f",
+                source_path,
+                "PackageInfo",
+            ]
+            proc = subprocess.Popen(
+                xarcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             (_, stderr) = proc.communicate()
         except OSError as err:
-            raise ProcessorError("xar execution failed with error code %d: %s"
-                                 % (err.errno, err.strerror))
+            raise ProcessorError(
+                "xar execution failed with error code %d: %s"
+                % (err.errno, err.strerror)
+            )
         if proc.returncode != 0:
-            raise ProcessorError("extraction of %s with xar failed: %s"
-                                 % (source_path, stderr))
+            raise ProcessorError(
+                "extraction of %s with xar failed: %s" % (source_path, stderr)
+            )
 
     def pkg_already_exists(self, pkg_path, identifier, version):
-        '''Check for an existing flat package in the output dir and compare its
+        """Check for an existing flat package in the output dir and compare its
            identifier and version to the one we're going to build.
-           Returns a boolean.'''
+           Returns a boolean."""
         if os.path.exists(pkg_path) and not self.env.get("force_pkg_build"):
             self.output("Package already exists at path %s." % pkg_path)
             try:
@@ -115,32 +125,30 @@ class PkgCreator(Processor):
             except ProcessorError as err:
                 self.output(err)
                 # just remove the pkg and return False
-                self.output('Removing %s' % pkg_path)
+                self.output("Removing %s" % pkg_path)
                 try:
                     os.unlink(pkg_path)
                 except OSError as err:
-                    raise ProcessorError(
-                        "Could not remove %s: %s" % pkg_path, err)
+                    raise ProcessorError("Could not remove %s: %s" % pkg_path, err)
                 return False
-            packageinfo_file = os.path.join(self.env['RECIPE_CACHE_DIR'],
-                                            'PackageInfo')
+            packageinfo_file = os.path.join(self.env["RECIPE_CACHE_DIR"], "PackageInfo")
             if not os.path.exists(packageinfo_file):
                 self.output(
                     "Failed to parse existing package, as no PackageInfo "
-                    "file could be found in the extracted archive.")
+                    "file could be found in the extracted archive."
+                )
                 # just remove the pkg and return False
-                self.output('Removing %s' % pkg_path)
+                self.output("Removing %s" % pkg_path)
                 try:
                     os.unlink(pkg_path)
                 except OSError as err:
-                    raise ProcessorError(
-                        "Could not remove %s: %s" % pkg_path, err)
+                    raise ProcessorError("Could not remove %s: %s" % pkg_path, err)
                 return False
             # parse the PackageInfo file for version and identifier
             tree = ET.parse(packageinfo_file)
             root = tree.getroot()
-            local_version = root.attrib['version']
-            local_id = root.attrib['identifier']
+            local_version = root.attrib["version"]
+            local_id = root.attrib["identifier"]
             try:
                 # clean up
                 os.unlink(packageinfo_file)
@@ -151,27 +159,29 @@ class PkgCreator(Processor):
         return False
 
     def package(self):
-        '''Build a packaging request, send it to the autopkgserver and get the
-        constructed package.'''
+        """Build a packaging request, send it to the autopkgserver and get the
+        constructed package."""
 
         # clear any pre-exising summary result
-        if 'pkg_creator_summary_result' in self.env:
-            del self.env['pkg_creator_summary_result']
+        if "pkg_creator_summary_result" in self.env:
+            del self.env["pkg_creator_summary_result"]
 
         request = self.env["pkg_request"]
-        if 'pkgdir' not in request:
-            request['pkgdir'] = self.env['RECIPE_CACHE_DIR']
+        if "pkgdir" not in request:
+            request["pkgdir"] = self.env["RECIPE_CACHE_DIR"]
 
         # Set variables, and check that all keys are in request.
-        for key in ("pkgroot",
-                    "pkgname",
-                    "pkgtype",
-                    "id",
-                    "version",
-                    "infofile",
-                    "resources",
-                    "options",
-                    "scripts"):
+        for key in (
+            "pkgroot",
+            "pkgname",
+            "pkgtype",
+            "id",
+            "version",
+            "infofile",
+            "resources",
+            "options",
+            "scripts",
+        ):
             if key not in request:
                 if key in self.env:
                     request[key] = self.env[key]
@@ -197,10 +207,11 @@ class PkgCreator(Processor):
 
         # Check for an existing flat package in the output dir and compare its
         # identifier and version to the one we're going to build.
-        pkg_path = os.path.join(request['pkgdir'], request['pkgname'] + '.pkg')
-        if self.pkg_already_exists(pkg_path, request['id'], request['version']):
-            self.output("Existing package matches version and identifier, "
-                        "not building.")
+        pkg_path = os.path.join(request["pkgdir"], request["pkgname"] + ".pkg")
+        if self.pkg_already_exists(pkg_path, request["id"], request["version"]):
+            self.output(
+                "Existing package matches version and identifier, " "not building."
+            )
             self.env["pkg_path"] = pkg_path
             self.env["new_package_request"] = False
             return
@@ -219,28 +230,27 @@ class PkgCreator(Processor):
         # Return path to pkg.
         self.env["pkg_path"] = pkg_path
         self.env["pkg_creator_summary_result"] = {
-            'summary_text': 'The following packages were built:',
-            'report_fields': ['identifier', 'version', 'pkg_path'],
-            'data': {
-                'identifier': request['id'],
-                'version': request['version'],
-                'pkg_path': pkg_path
-            }
+            "summary_text": "The following packages were built:",
+            "report_fields": ["identifier", "version", "pkg_path"],
+            "data": {
+                "identifier": request["id"],
+                "version": request["version"],
+                "pkg_path": pkg_path,
+            },
         }
 
     def connect(self):
-        '''Connect to autopkgserver'''
+        """Connect to autopkgserver"""
         try:
-            #pylint: disable=attribute-defined-outside-init
+            # pylint: disable=attribute-defined-outside-init
             self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            #pylint: enable=attribute-defined-outside-init
+            # pylint: enable=attribute-defined-outside-init
             self.socket.connect(AUTO_PKG_SOCKET)
         except socket.error as err:
-            raise ProcessorError(
-                "Couldn't connect to autopkgserver: %s" % err.strerror)
+            raise ProcessorError("Couldn't connect to autopkgserver: %s" % err.strerror)
 
     def send_request(self, request):
-        '''Send a packaging request to the autopkgserver'''
+        """Send a packaging request to the autopkgserver"""
         self.socket.send(FoundationPlist.writePlistToString(request))
         with os.fdopen(self.socket.fileno()) as fileref:
             reply = fileref.read()
@@ -251,18 +261,17 @@ class PkgCreator(Processor):
         errors = reply.rstrip().split("\n")
         if not errors:
             errors = ["ERROR:No reply from server (crash?), check system logs"]
-        raise ProcessorError(
-            ", ".join([s.replace("ERROR:", "") for s in errors]))
+        raise ProcessorError(", ".join([s.replace("ERROR:", "") for s in errors]))
 
     def disconnect(self):
-        '''Disconnect from the autopkgserver'''
+        """Disconnect from the autopkgserver"""
         self.socket.close()
 
     def main(self):
-        '''Package something!'''
+        """Package something!"""
         self.package()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = PkgCreator()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/PkgExtractor.py
+++ b/Code/autopkglib/PkgExtractor.py
@@ -23,32 +23,28 @@ import FoundationPlist
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 
+
 __all__ = ["PkgExtractor"]
 
 
 class PkgExtractor(DmgMounter):
     """Extracts the contents of a bundle-style pkg (possibly on a disk image)
     to pkgroot."""
+
     description = __doc__
     input_variables = {
-        "pkg_path": {
-            "required": True,
-            "description":
-                "Path to a package.",
-        },
+        "pkg_path": {"required": True, "description": "Path to a package."},
         "extract_root": {
             "required": True,
-            "description":
-                "Path to where the new package root will be created.",
+            "description": "Path to where the new package root will be created.",
         },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     def extract_payload(self, pkg_path, extract_root):
-        '''Extract package contents to extract_root, preserving intended
-         directory structure'''
-        #pylint: disable=no-self-use
+        """Extract package contents to extract_root, preserving intended
+         directory structure"""
+        # pylint: disable=no-self-use
         info_plist = os.path.join(pkg_path, "Contents/Info.plist")
         archive_path = os.path.join(pkg_path, "Contents/Archive.pax.gz")
         if not os.path.exists(info_plist):
@@ -76,25 +72,23 @@ class PkgExtractor(DmgMounter):
 
         # Unpack payload.
         try:
-            proc = subprocess.Popen(("/usr/bin/ditto",
-                                     "-x",
-                                     "-z",
-                                     archive_path,
-                                     extract_path),
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+            proc = subprocess.Popen(
+                ("/usr/bin/ditto", "-x", "-z", archive_path, extract_path),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
             (_, stderr) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 "ditto execution failed with error code %d: %s"
-                % (err.errno, err.strerror))
+                % (err.errno, err.strerror)
+            )
         if proc.returncode != 0:
             raise ProcessorError("Unpacking payload failed: %s" % stderr)
 
     def main(self):
         # Check if we're trying to read something inside a dmg.
-        (dmg_path, dmg, dmg_source_path) = (
-            self.parsePathForDMG(self.env['pkg_path']))
+        (dmg_path, dmg, dmg_source_path) = self.parsePathForDMG(self.env["pkg_path"])
         try:
             if dmg:
                 # Mount dmg and copy path inside.
@@ -102,7 +96,7 @@ class PkgExtractor(DmgMounter):
                 pkg_path = os.path.join(mount_point, dmg_source_path)
             else:
                 # just use the given path
-                pkg_path = self.env['pkg_path']
+                pkg_path = self.env["pkg_path"]
             self.extract_payload(pkg_path, self.env["extract_root"])
 
         finally:
@@ -110,6 +104,6 @@ class PkgExtractor(DmgMounter):
                 self.unmount(dmg_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = PkgExtractor()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/PkgRootCreator.py
+++ b/Code/autopkglib/PkgRootCreator.py
@@ -20,6 +20,7 @@ import shutil
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["PkgRootCreator"]
 
 
@@ -30,6 +31,7 @@ CHUNK_SIZE = 256 * 1024
 class PkgRootCreator(Processor):
     """Creates a package root and a directory structure.
     (Can also be used to create directory structures for other purposes.)"""
+
     description = __doc__
     input_variables = {
         "pkgroot": {
@@ -40,35 +42,38 @@ class PkgRootCreator(Processor):
             "required": True,
             "description": (
                 "A dictionary of directories to be created "
-                "inside the pkgroot, with their modes in octal form."),
-        }
+                "inside the pkgroot, with their modes in octal form."
+            ),
+        },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     def main(self):
         # Delete pkgroot if it exists.
         try:
-            if (os.path.islink(self.env['pkgroot'])
-                    or os.path.isfile(self.env['pkgroot'])):
-                os.unlink(self.env['pkgroot'])
-            elif os.path.isdir(self.env['pkgroot']):
-                shutil.rmtree(self.env['pkgroot'])
+            if os.path.islink(self.env["pkgroot"]) or os.path.isfile(
+                self.env["pkgroot"]
+            ):
+                os.unlink(self.env["pkgroot"])
+            elif os.path.isdir(self.env["pkgroot"]):
+                shutil.rmtree(self.env["pkgroot"])
         except OSError as err:
-            raise ProcessorError("Can't remove %s: %s" % (self.env['pkgroot'],
-                                                          err.strerror))
+            raise ProcessorError(
+                "Can't remove %s: %s" % (self.env["pkgroot"], err.strerror)
+            )
 
         # Create pkgroot. autopkghelper sets it to root:admin 01775.
         try:
-            os.makedirs(self.env['pkgroot'])
-            self.output("Created %s" % self.env['pkgroot'])
+            os.makedirs(self.env["pkgroot"])
+            self.output("Created %s" % self.env["pkgroot"])
         except OSError as err:
-            raise ProcessorError("Can't create %s: %s" % (self.env['pkgroot'],
-                                                          err.strerror))
+            raise ProcessorError(
+                "Can't create %s: %s" % (self.env["pkgroot"], err.strerror)
+            )
 
         # Create directories.
-        absroot = os.path.abspath(self.env['pkgroot'])
-        for directory, mode in sorted(self.env['pkgdirs'].items()):
+        absroot = os.path.abspath(self.env["pkgroot"])
+        for directory, mode in sorted(self.env["pkgdirs"].items()):
             self.output("Creating %s" % directory, verbose_level=2)
             # Make sure we don't get an absolute path.
             if directory.startswith("/"):
@@ -86,10 +91,11 @@ class PkgRootCreator(Processor):
                 os.chmod(dirpath, int(mode, 8))
                 self.output("Created %s" % dirpath)
             except OSError as err:
-                raise ProcessorError("Can't create %s with mode %s: %s"
-                                     % (dirpath, mode, err.strerror))
+                raise ProcessorError(
+                    "Can't create %s with mode %s: %s" % (dirpath, mode, err.strerror)
+                )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = PkgRootCreator()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/PlistEditor.py
+++ b/Code/autopkglib/PlistEditor.py
@@ -18,56 +18,56 @@
 import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["PlistEditor"]
 
 
 class PlistEditor(Processor):
     """Merges data with an input plist (which can be empty) and writes a new
     plist."""
+
     description = __doc__
     input_variables = {
         "input_plist_path": {
             "required": False,
-            "description":
-                ("File path to a plist; empty or undefined to start with "
-                 "an empty plist."),
+            "description": (
+                "File path to a plist; empty or undefined to start with "
+                "an empty plist."
+            ),
         },
         "output_plist_path": {
             "required": True,
-            "description":
-                "File path to a plist. Can be the same path as input_plist.",
+            "description": "File path to a plist. Can be the same path as input_plist.",
         },
         "plist_data": {
             "required": True,
-            "description":
-                ("A dictionary of data to be merged with the data from the "
-                 "input plist."),
+            "description": (
+                "A dictionary of data to be merged with the data from the "
+                "input plist."
+            ),
         },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     __doc__ = description
 
     def read_plist(self, pathname):
         """reads a plist from pathname"""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
         if not pathname:
             return {}
         try:
             return FoundationPlist.readPlist(pathname)
         except Exception as err:
-            raise ProcessorError(
-                'Could not read %s: %s' % (pathname, err))
+            raise ProcessorError("Could not read %s: %s" % (pathname, err))
 
     def write_plist(self, data, pathname):
         """writes a plist to pathname"""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
         try:
             FoundationPlist.writePlist(data, pathname)
         except Exception as err:
-            raise ProcessorError(
-                'Could not write %s: %s' % (pathname, err))
+            raise ProcessorError("Could not write %s: %s" % (pathname, err))
 
     def main(self):
         # read original plist (or empty plist)
@@ -83,6 +83,6 @@ class PlistEditor(Processor):
         self.output("Updated plist at %s" % self.env["output_plist_path"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = PlistEditor()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -26,15 +26,16 @@ from xml.etree import ElementTree
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["SparkleUpdateInfoProvider"]
 
 DEFAULT_XMLNS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
-SUPPORTED_ADDITIONAL_PKGINFO_KEYS = ["description",
-                                     "minimum_os_version"]
+SUPPORTED_ADDITIONAL_PKGINFO_KEYS = ["description", "minimum_os_version"]
 
 
 class SparkleUpdateInfoProvider(Processor):
     """Provides URL to the highest version number or latest update."""
+
     description = __doc__
     input_variables = {
         "appcast_url": {
@@ -43,46 +44,54 @@ class SparkleUpdateInfoProvider(Processor):
         },
         "appcast_request_headers": {
             "required": False,
-            "description":
-                "Dictionary of additional HTTP headers to include in request.",
+            "description": "Dictionary of additional HTTP headers to include in request.",
         },
         "appcast_query_pairs": {
             "required": False,
-            "description": ("Dictionary of additional query pairs to include "
-                            "in request. Manual url-encoding isn't necessary."),
+            "description": (
+                "Dictionary of additional query pairs to include "
+                "in request. Manual url-encoding isn't necessary."
+            ),
         },
         "alternate_xmlns_url": {
             "required": False,
-            "description": ("Alternate URL for the XML namespace, if the "
-                            "appcast is using an alternate one. Defaults to "
-                            "that used for 'vanilla' Sparkle appcasts."),
+            "description": (
+                "Alternate URL for the XML namespace, if the "
+                "appcast is using an alternate one. Defaults to "
+                "that used for 'vanilla' Sparkle appcasts."
+            ),
         },
         "pkginfo_keys_to_copy_from_sparkle_feed": {
             "required": False,
-            "description": ("Array of pkginfo keys that will be derived from "
-                            "any available metadata from the Sparkle feed and "
-                            "copied to 'additional_pkginfo'. The usefulness of "
-                            "these keys will depend on the admin's environment "
-                            "and the nature of the metadata provided by the "
-                            "application vendor. Note that the 'description' "
-                            "is usually equivalent to 'release notes' for that "
-                            "specific version. Defaults to "
-                            "['minimum_os_version']. "
-                            "Currently supported keys: %s." %
-                            ", ".join(SUPPORTED_ADDITIONAL_PKGINFO_KEYS))
+            "description": (
+                "Array of pkginfo keys that will be derived from "
+                "any available metadata from the Sparkle feed and "
+                "copied to 'additional_pkginfo'. The usefulness of "
+                "these keys will depend on the admin's environment "
+                "and the nature of the metadata provided by the "
+                "application vendor. Note that the 'description' "
+                "is usually equivalent to 'release notes' for that "
+                "specific version. Defaults to "
+                "['minimum_os_version']. "
+                "Currently supported keys: %s."
+                % ", ".join(SUPPORTED_ADDITIONAL_PKGINFO_KEYS)
+            ),
         },
-        "urlencode_path_component" : {
+        "urlencode_path_component": {
             "required": False,
-            "description": ("Boolean value to specify if the path component"
-                             "from the sparkle feed needs to be urlencoded. "
-                             "Defaults to True."),
+            "description": (
+                "Boolean value to specify if the path component"
+                "from the sparkle feed needs to be urlencoded. "
+                "Defaults to True."
+            ),
         },
-        "PKG" : {
+        "PKG": {
             "required": False,
-            "description":
-                ("Local path to the pkg/dmg we'd otherwise download. "
-                 "If provided, the download is skipped and we just use "
-                 "this package or disk image."),
+            "description": (
+                "Local path to the pkg/dmg we'd otherwise download. "
+                "If provided, the download is skipped and we just use "
+                "this package or disk image."
+            ),
         },
         "CURL_PATH": {
             "required": False,
@@ -91,21 +100,23 @@ class SparkleUpdateInfoProvider(Processor):
         },
     }
     output_variables = {
-        "url": {
-            "description": "URL for a download.",
-        },
+        "url": {"description": "URL for a download."},
         "version": {
-            "description": ("Version for the download extracted from the feed. "
-                            "This is a human-readable version if the feed has "
-                            "it (e.g., 2.3.4-pre4), and the basic machine-"
-                            "readable version (e.g., 823a) otherwise.")
+            "description": (
+                "Version for the download extracted from the feed. "
+                "This is a human-readable version if the feed has "
+                "it (e.g., 2.3.4-pre4), and the basic machine-"
+                "readable version (e.g., 823a) otherwise."
+            )
         },
         "additional_pkginfo": {
-            "description": ("A pkginfo containing additional keys extracted "
-                            "from the appcast feed. Currently this is "
-                            "'description' and 'minimum_os_version' if it was "
-                            "defined in the feed.")
-        }
+            "description": (
+                "A pkginfo containing additional keys extracted "
+                "from the appcast feed. Currently this is "
+                "'description' and 'minimum_os_version' if it was "
+                "defined in the feed."
+            )
+        },
     }
 
     def fetch_content(self, url, headers=None):
@@ -114,19 +125,17 @@ class SparkleUpdateInfoProvider(Processor):
         URLTextSearcher processor."""
 
         try:
-            cmd = [self.env['CURL_PATH'], '--location', '--compress']
+            cmd = [self.env["CURL_PATH"], "--location", "--compress"]
             if headers:
                 for header, value in headers.items():
-                    cmd.extend(['--header', '%s: %s' % (header, value)])
+                    cmd.extend(["--header", "%s: %s" % (header, value)])
             cmd.append(url)
-            proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (data, stderr) = proc.communicate()
             if proc.returncode:
-                raise ProcessorError(
-                    'Could not retrieve URL %s: %s' % (url, stderr))
+                raise ProcessorError("Could not retrieve URL %s: %s" % (url, stderr))
         except OSError:
-            raise ProcessorError('Could not retrieve URL: %s' % url)
+            raise ProcessorError("Could not retrieve URL: %s" % url)
 
         return data
 
@@ -176,12 +185,11 @@ class SparkleUpdateInfoProvider(Processor):
                 # URL-quote the path component to handle spaces, etc.
                 # (Panic apps do this)
                 url_bits = urlparse.urlsplit(enclosure.get("url"))
-                if self.env.get('urlencode_path_component', True):
+                if self.env.get("urlencode_path_component", True):
                     encoded_path = urllib.quote(url_bits.path)
                 else:
                     encoded_path = url_bits.path
-                built_url = (
-                    url_bits.scheme + "://" + url_bits.netloc + encoded_path)
+                built_url = url_bits.scheme + "://" + url_bits.netloc + encoded_path
                 if url_bits.query:
                     built_url += "?" + url_bits.query
                 item["url"] = built_url
@@ -198,16 +206,16 @@ class SparkleUpdateInfoProvider(Processor):
                     # We can even support OmniGroup's alternate appcast format
                     # by cheating and using the '-' as a delimiter to derive
                     # version info
-                    filename = os.path.basename(
-                        os.path.splitext(item["url"])[0])
-                    for delimiter in ['_', '-']:
+                    filename = os.path.basename(os.path.splitext(item["url"])[0])
+                    for delimiter in ["_", "-"]:
                         if delimiter in filename:
                             item["version"] = filename.split(delimiter)[-1]
                             break
                 # if we still found nothing, fail
                 if item["version"] is None:
                     raise ProcessorError(
-                        "Can't extract version info from item in feed!")
+                        "Can't extract version info from item in feed!"
+                    )
 
                 human_version = enclosure.get("{%s}shortVersionString" % xmlns)
                 if human_version is not None:
@@ -215,22 +223,21 @@ class SparkleUpdateInfoProvider(Processor):
                 min_version = item_elem.find("{%s}minimumSystemVersion" % xmlns)
                 if min_version is not None:
                     item["minimum_os_version"] = min_version.text
-                description_elem = item_elem.find(
-                    "{%s}releaseNotesLink" % xmlns)
+                description_elem = item_elem.find("{%s}releaseNotesLink" % xmlns)
                 # Strip possible surrounding whitespace around description_url
                 # element text as we'll be passing this as an argument to a
                 # curl process
                 if description_elem is not None:
                     item["description_url"] = description_elem.text.strip()
                 if item_elem.find("description") is not None:
-                    item["description_data"] = (
-                        item_elem.find("description").text)
+                    item["description_data"] = item_elem.find("description").text
                 versions.append(item)
 
         return versions
 
     def main(self):
         """Get URL for latest version in update feed"""
+
         def compare_version(this, that):
             """Compare loose versions"""
             # cmp() doesn't exist in Python3, so this uses the suggested
@@ -243,54 +250,58 @@ class SparkleUpdateInfoProvider(Processor):
 
         if "PKG" in self.env:
             self.output("Local PKG provided, no downloaded needed.")
-            self.output("WARNING: Skipping this processor means output "
-                        "variables 'version', 'additional_pkginfo' will "
-                        "not contain useful info. If these are needed "
-                        "in other recipe steps, this may give unexpected "
-                        "results.")
+            self.output(
+                "WARNING: Skipping this processor means output "
+                "variables 'version', 'additional_pkginfo' will "
+                "not contain useful info. If these are needed "
+                "in other recipe steps, this may give unexpected "
+                "results."
+            )
             self.env["url"] = self.env.get("PKG")
             self.env["additional_pkginfo"] = {}
             self.env["version"] = "NotSetBySparkleUpdateInfoProvider"
             return
 
         items = self.get_feed_data(self.env.get("appcast_url"))
-        sorted_items = sorted(items,
-                              key=itemgetter("version"),
-                              cmp=compare_version)
+        sorted_items = sorted(items, key=itemgetter("version"), cmp=compare_version)
         latest = sorted_items[-1]
         self.output("Version retrieved from appcast: %s" % latest["version"])
         if latest.get("human_version"):
-            self.output("User-facing version retrieved from appcast: %s"
-                        % latest["human_version"])
+            self.output(
+                "User-facing version retrieved from appcast: %s"
+                % latest["human_version"]
+            )
 
         pkginfo = {}
         # Handle any keys we may have defined
-        sparkle_pkginfo_keys = self.env.get(
-            "pkginfo_keys_to_copy_from_sparkle_feed")
+        sparkle_pkginfo_keys = self.env.get("pkginfo_keys_to_copy_from_sparkle_feed")
         if sparkle_pkginfo_keys:
             for k in sparkle_pkginfo_keys:
                 if k not in SUPPORTED_ADDITIONAL_PKGINFO_KEYS:
-                    self.output("Key %s isn't a supported key to copy from the "
-                                "Sparkle feed, ignoring it." % k)
+                    self.output(
+                        "Key %s isn't a supported key to copy from the "
+                        "Sparkle feed, ignoring it." % k
+                    )
             # Format description
             if "description" in sparkle_pkginfo_keys:
                 if "description_url" in latest.keys():
                     description = self.fetch_content(latest["description_url"])
                 elif "description_data" in latest.keys():
-                    description = ("<html><body>"
-                                   + latest["description_data"]
-                                   + "</html></body>")
+                    description = (
+                        "<html><body>" + latest["description_data"] + "</html></body>"
+                    )
                 else:
                     description = ""
                 pkginfo["description"] = description.decode("UTF-8")
 
             if "minimum_os_version" in sparkle_pkginfo_keys:
                 if latest.get("minimum_os_version") is not None:
-                    pkginfo["minimum_os_version"] = (
-                        latest.get("minimum_os_version"))
+                    pkginfo["minimum_os_version"] = latest.get("minimum_os_version")
             for copied_key in pkginfo.keys():
-                self.output("Copied key %s from Sparkle feed to additional "
-                            "pkginfo." % copied_key)
+                self.output(
+                    "Copied key %s from Sparkle feed to additional "
+                    "pkginfo." % copied_key
+                )
 
         self.env["url"] = latest["url"]
         if latest.get("human_version"):

--- a/Code/autopkglib/StopProcessingIf.py
+++ b/Code/autopkglib/StopProcessingIf.py
@@ -19,12 +19,13 @@ from __future__ import print_function
 
 from autopkglib import Processor, ProcessorError
 
-#pylint: disable=no-name-in-module
+
+# pylint: disable=no-name-in-module
 try:
     from Foundation import NSPredicate
 except:
     print("WARNING: Failed 'from Foundation import NSPredicate' in " + __name__)
-#pylint: disable=no-name-in-module
+# pylint: disable=no-name-in-module
 
 __all__ = ["StopProcessingIf"]
 
@@ -32,40 +33,43 @@ __all__ = ["StopProcessingIf"]
 class StopProcessingIf(Processor):
     """Sets a variable to tell AutoPackager to stop processing a recipe if a
        predicate comparison evaluates to true."""
+
     description = __doc__
     input_variables = {
         "predicate": {
             "required": True,
-            "description":
-                ("NSPredicate-style comparison against an environment key. See "
-                 "http://developer.apple.com/library/mac/#documentation/"
-                 "Cocoa/Conceptual/Predicates/Articles/pSyntax.html"),
-        },
+            "description": (
+                "NSPredicate-style comparison against an environment key. See "
+                "http://developer.apple.com/library/mac/#documentation/"
+                "Cocoa/Conceptual/Predicates/Articles/pSyntax.html"
+            ),
+        }
     }
     output_variables = {
         "stop_processing_recipe": {
-            "description": "Boolean. Should we stop processing the recipe?",
-        },
+            "description": "Boolean. Should we stop processing the recipe?"
+        }
     }
 
     def predicate_evaluates_as_true(self, predicate_string):
-        '''Evaluates predicate against our environment dictionary'''
+        """Evaluates predicate against our environment dictionary"""
         try:
             predicate = NSPredicate.predicateWithFormat_(predicate_string)
         except Exception as err:
             raise ProcessorError(
-                "Predicate error for '%s': %s"
-                % (predicate_string, err))
+                "Predicate error for '%s': %s" % (predicate_string, err)
+            )
 
         result = predicate.evaluateWithObject_(self.env)
         self.output("(%s) is %s" % (predicate_string, result))
         return result
 
     def main(self):
-        self.env["stop_processing_recipe"] = (
-            self.predicate_evaluates_as_true(self.env["predicate"]))
+        self.env["stop_processing_recipe"] = self.predicate_evaluates_as_true(
+            self.env["predicate"]
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = StopProcessingIf()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/Symlinker.py
+++ b/Code/autopkglib/Symlinker.py
@@ -19,53 +19,51 @@ import os
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["Symlinker"]
 
 
 class Symlinker(Processor):
     """Copies source_path to destination_path."""
+
     description = __doc__
     input_variables = {
         "source_path": {
             "required": True,
             "description": "Path to a file or directory to symlink.",
         },
-        "destination_path": {
-            "required": True,
-            "description": "Path to destination.",
-        },
+        "destination_path": {"required": True, "description": "Path to destination."},
         "overwrite": {
             "required": False,
-            "description":
-                "Whether the destination will be overwritten if necessary.",
+            "description": "Whether the destination will be overwritten if necessary.",
         },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     def main(self):
-        source_path = self.env['source_path']
-        destination_path = self.env['destination_path']
+        source_path = self.env["source_path"]
+        destination_path = self.env["destination_path"]
 
         # Remove destination if needed.
         if os.path.exists(destination_path):
-            if "overwrite" in self.env and self.env['overwrite']:
+            if "overwrite" in self.env and self.env["overwrite"]:
                 try:
                     os.unlink(destination_path)
                 except OSError as err:
-                    raise ProcessorError("Can't remove %s: %s"
-                                         % (destination_path, err.strerror))
+                    raise ProcessorError(
+                        "Can't remove %s: %s" % (destination_path, err.strerror)
+                    )
 
         # Make symlink.
         try:
             os.symlink(source_path, destination_path)
-            self.output("Symlinked %s to %s"
-                        % (source_path, destination_path))
+            self.output("Symlinked %s to %s" % (source_path, destination_path))
         except BaseException as err:
-            raise ProcessorError("Can't symlink %s to %s: %s"
-                                 % (source_path, destination_path, err))
+            raise ProcessorError(
+                "Can't symlink %s to %s: %s" % (source_path, destination_path, err)
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = Symlinker()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -23,6 +23,7 @@ import time
 import xattr
 from autopkglib import Processor, ProcessorError
 
+
 try:
     from autopkglib import BUNDLE_ID
 except ImportError:
@@ -46,29 +47,29 @@ def getxattr(pathname, attr):
 
 class URLDownloader(Processor):
     """Downloads a URL to the specified download_dir using curl."""
+
     description = __doc__
     input_variables = {
-        "url": {
-            "required": True,
-            "description": "The URL to download.",
-        },
+        "url": {"required": True, "description": "The URL to download."},
         "request_headers": {
             "required": False,
-            "description":
-                ("Optional dictionary of headers to include with the download "
-                 "request.")
+            "description": (
+                "Optional dictionary of headers to include with the download "
+                "request."
+            ),
         },
         "curl_opts": {
             "required": False,
-            "description":
-                ("Optional array of options to include with the download "
-                 "request.")
+            "description": (
+                "Optional array of options to include with the download " "request."
+            ),
         },
         "download_dir": {
             "required": False,
-            "description":
-                ("The directory where the file will be downloaded to. Defaults "
-                 "to RECIPE_CACHE_DIR/downloads."),
+            "description": (
+                "The directory where the file will be downloaded to. Defaults "
+                "to RECIPE_CACHE_DIR/downloads."
+            ),
         },
         "filename": {
             "required": False,
@@ -77,21 +78,24 @@ class URLDownloader(Processor):
         "CHECK_FILESIZE_ONLY": {
             "default": False,
             "required": False,
-            "description": ("If True, a server's ETag and Last-Modified "
-                            "headers will not be checked to verify whether "
-                            "a download is newer than a cached item, and only "
-                            "Content-Length (filesize) will be used. This "
-                            "is useful for cases where a download always "
-                            "redirects to different mirrors, which could "
-                            "cause items to be needlessly re-downloaded. "
-                            "Defaults to False."),
+            "description": (
+                "If True, a server's ETag and Last-Modified "
+                "headers will not be checked to verify whether "
+                "a download is newer than a cached item, and only "
+                "Content-Length (filesize) will be used. This "
+                "is useful for cases where a download always "
+                "redirects to different mirrors, which could "
+                "cause items to be needlessly re-downloaded. "
+                "Defaults to False."
+            ),
         },
         "PKG": {
             "required": False,
-            "description":
-                ("Local path to the pkg/dmg we'd otherwise download. "
-                 "If provided, the download is skipped and we just use "
-                 "this package or disk image."),
+            "description": (
+                "Local path to the pkg/dmg we'd otherwise download. "
+                "If provided, the download is skipped and we just use "
+                "this package or disk image."
+            ),
         },
         "CURL_PATH": {
             "required": False,
@@ -100,19 +104,16 @@ class URLDownloader(Processor):
         },
     }
     output_variables = {
-        "pathname": {
-            "description": "Path to the downloaded file.",
-        },
+        "pathname": {"description": "Path to the downloaded file."},
         "last_modified": {
-            "description": "last-modified header for the downloaded item.",
+            "description": "last-modified header for the downloaded item."
         },
-        "etag": {
-            "description": "etag header for the downloaded item.",
-        },
+        "etag": {"description": "etag header for the downloaded item."},
         "download_changed": {
-            "description":
-                ("Boolean indicating if the download has changed since the "
-                 "last time it was downloaded."),
+            "description": (
+                "Boolean indicating if the download has changed since the "
+                "last time it was downloaded."
+            )
         },
         "url_downloader_summary_result": {
             "description": "Description of interesting results."
@@ -121,8 +122,8 @@ class URLDownloader(Processor):
 
     def main(self):
         # clear any pre-exising summary result
-        if 'url_downloader_summary_result' in self.env:
-            del self.env['url_downloader_summary_result']
+        if "url_downloader_summary_result" in self.env:
+            del self.env["url_downloader_summary_result"]
 
         self.env["last_modified"] = ""
         self.env["etag"] = ""
@@ -139,8 +140,9 @@ class URLDownloader(Processor):
             filename = self.env["url"].rpartition("/")[2]
         else:
             filename = self.env["filename"]
-        download_dir = (self.env.get("download_dir") or
-                        os.path.join(self.env["RECIPE_CACHE_DIR"], "downloads"))
+        download_dir = self.env.get("download_dir") or os.path.join(
+            self.env["RECIPE_CACHE_DIR"], "downloads"
+        )
         pathname = os.path.join(download_dir, filename)
         # Save pathname to environment
         self.env["pathname"] = pathname
@@ -151,11 +153,11 @@ class URLDownloader(Processor):
                 os.makedirs(download_dir)
             except OSError as err:
                 raise ProcessorError(
-                    "Can't create %s: %s" % (download_dir, err.strerror))
+                    "Can't create %s: %s" % (download_dir, err.strerror)
+                )
 
         # Create a temp file
-        temporary_file = tempfile.NamedTemporaryFile(dir=download_dir,
-                                                     delete=False)
+        temporary_file = tempfile.NamedTemporaryFile(dir=download_dir, delete=False)
         pathname_temporary = temporary_file.name
         # Set permissions on the temp file as curl would set for a newly-downloaded
         # file. NamedTemporaryFile uses mkstemp(), which sets a mode of 0600, and
@@ -165,18 +167,27 @@ class URLDownloader(Processor):
         os.chmod(pathname_temporary, 0o644)
 
         # construct curl command.
-        curl_cmd = [self.env['CURL_PATH'],
-                    '--silent', '--show-error', '--no-buffer', '--fail',
-                    '--dump-header', '-',
-                    '--speed-time', '30',
-                    '--location',
-                    '--url', self.env["url"],
-                    '--output', pathname_temporary]
+        curl_cmd = [
+            self.env["CURL_PATH"],
+            "--silent",
+            "--show-error",
+            "--no-buffer",
+            "--fail",
+            "--dump-header",
+            "-",
+            "--speed-time",
+            "30",
+            "--location",
+            "--url",
+            self.env["url"],
+            "--output",
+            pathname_temporary,
+        ]
 
         if "request_headers" in self.env:
             headers = self.env["request_headers"]
             for header, value in headers.items():
-                curl_cmd.extend(['--header', '%s: %s' % (header, value)])
+                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
 
         if "curl_opts" in self.env:
             for item in self.env["curl_opts"]:
@@ -194,66 +205,73 @@ class URLDownloader(Processor):
             etag = getxattr(pathname, XATTR_ETAG)
             last_modified = getxattr(pathname, XATTR_LAST_MODIFIED)
             if etag:
-                curl_cmd.extend(['--header', 'If-None-Match: %s' % etag])
+                curl_cmd.extend(["--header", "If-None-Match: %s" % etag])
             if last_modified:
-                curl_cmd.extend(
-                    ['--header', 'If-Modified-Since: %s' % last_modified])
+                curl_cmd.extend(["--header", "If-Modified-Since: %s" % last_modified])
 
         # Open URL.
-        proc = subprocess.Popen(curl_cmd, shell=False, bufsize=1,
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            curl_cmd,
+            shell=False,
+            bufsize=1,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
         donewithheaders = False
         maxheaders = 15
         header = {}
-        header['http_result_code'] = '000'
-        header['http_result_description'] = ''
+        header["http_result_code"] = "000"
+        header["http_result_description"] = ""
         while True:
             if not donewithheaders:
-                info = proc.stdout.readline().strip('\r\n')
-                if info.startswith('HTTP/'):
+                info = proc.stdout.readline().strip("\r\n")
+                if info.startswith("HTTP/"):
                     try:
-                        header['http_result_code'] = info.split(None, 2)[1]
-                        header['http_result_description'] = (
-                            info.split(None, 2)[2])
+                        header["http_result_code"] = info.split(None, 2)[1]
+                        header["http_result_description"] = info.split(None, 2)[2]
                     except IndexError:
                         pass
-                elif ': ' in info:
+                elif ": " in info:
                     # got a header line
                     part = info.split(None, 1)
-                    fieldname = part[0].rstrip(':').lower()
+                    fieldname = part[0].rstrip(":").lower()
                     try:
                         header[fieldname] = part[1]
                     except IndexError:
-                        header[fieldname] = ''
-                elif self.env["url"].startswith('ftp://'):
+                        header[fieldname] = ""
+                elif self.env["url"].startswith("ftp://"):
                     part = info.split(None, 1)
                     responsecode = part[0]
-                    if responsecode == '213':
+                    if responsecode == "213":
                         # This is the reply to curl's SIZE command on the file
                         # We can map it to the HTTP content-length header
                         try:
-                            header['content-length'] = part[1]
+                            header["content-length"] = part[1]
                         except IndexError:
                             pass
-                    elif responsecode.startswith('55'):
-                        header['http_result_code'] = '404'
-                        header['http_result_description'] = info
-                    elif responsecode == '150' or responsecode == '125':
-                        header['http_result_code'] = '200'
-                        header['http_result_description'] = info
+                    elif responsecode.startswith("55"):
+                        header["http_result_code"] = "404"
+                        header["http_result_description"] = info
+                    elif responsecode == "150" or responsecode == "125":
+                        header["http_result_code"] = "200"
+                        header["http_result_description"] = info
                         donewithheaders = True
-                elif info == '':
+                elif info == "":
                     # we got an empty line; end of headers (or curl exited)
-                    if header.get('http_result_code') in [
-                            '301', '302', '303', '307', '308']:
+                    if header.get("http_result_code") in [
+                        "301",
+                        "302",
+                        "303",
+                        "307",
+                        "308",
+                    ]:
                         # redirect, so more headers are coming.
                         # Throw away the headers we've received so far
                         header = {}
-                        header['http_result_code'] = '000'
-                        header['http_result_description'] = ''
+                        header["http_result_code"] = "000"
+                        header["http_result_description"] = ""
                     else:
                         donewithheaders = True
             else:
@@ -268,9 +286,9 @@ class URLDownloader(Processor):
 
         retcode = proc.poll()
         if retcode:  # Non-zero exit code from curl => problem with download
-            curlerr = ''
+            curlerr = ""
             try:
-                curlerr = proc.stderr.read().rstrip('\n')
+                curlerr = proc.stderr.read().rstrip("\n")
                 curlerr = curlerr.split(None, 2)[2]
             except IndexError:
                 pass
@@ -281,22 +299,25 @@ class URLDownloader(Processor):
         # file, see if it matches the size of the cached file.
         # Useful for webservers that don't provide Last-Modified
         # and ETag headers.
-        if (
-            (not header.get("etag") and not header.get("last-modified"))
-            or self.env["CHECK_FILESIZE_ONLY"]
-        ):
+        if (not header.get("etag") and not header.get("last-modified")) or self.env[
+            "CHECK_FILESIZE_ONLY"
+        ]:
             size_header = header.get("content-length")
             if size_header and int(size_header) == existing_file_size:
                 self.env["download_changed"] = False
-                self.output("File size returned by webserver matches that "
-                            "of the cached file: %s bytes" % size_header)
-                self.output("WARNING: Matching a download by filesize is a "
-                            "fallback mechanism that does not guarantee "
-                            "that a build is unchanged.")
+                self.output(
+                    "File size returned by webserver matches that "
+                    "of the cached file: %s bytes" % size_header
+                )
+                self.output(
+                    "WARNING: Matching a download by filesize is a "
+                    "fallback mechanism that does not guarantee "
+                    "that a build is unchanged."
+                )
                 self.output("Using existing %s" % pathname)
                 return
 
-        if header['http_result_code'] == '304':
+        if header["http_result_code"] == "304":
             # resource not modified
             self.env["download_changed"] = False
             self.output("Item at URL is unchanged.")
@@ -316,35 +337,27 @@ class URLDownloader(Processor):
         try:
             os.rename(pathname_temporary, pathname)
         except OSError:
-            raise ProcessorError(
-                "Can't move %s to %s" % (pathname_temporary, pathname))
+            raise ProcessorError("Can't move %s to %s" % (pathname_temporary, pathname))
 
         # save last-modified header if it exists
         if header.get("last-modified"):
-            self.env["last_modified"] = (
-                header.get("last-modified"))
-            xattr.setxattr(
-                pathname, XATTR_LAST_MODIFIED,
-                header.get("last-modified"))
+            self.env["last_modified"] = header.get("last-modified")
+            xattr.setxattr(pathname, XATTR_LAST_MODIFIED, header.get("last-modified"))
             self.output(
-                "Storing new Last-Modified header: %s"
-                % header.get("last-modified"))
+                "Storing new Last-Modified header: %s" % header.get("last-modified")
+            )
 
         # save etag if it exists
         self.env["etag"] = ""
         if header.get("etag"):
             self.env["etag"] = header.get("etag")
-            xattr.setxattr(
-                pathname, XATTR_ETAG, header.get("etag"))
-            self.output("Storing new ETag header: %s"
-                        % header.get("etag"))
+            xattr.setxattr(pathname, XATTR_ETAG, header.get("etag"))
+            self.output("Storing new ETag header: %s" % header.get("etag"))
 
         self.output("Downloaded %s" % pathname)
-        self.env['url_downloader_summary_result'] = {
-            'summary_text': 'The following new items were downloaded:',
-            'data': {
-                'download_path': pathname,
-            }
+        self.env["url_downloader_summary_result"] = {
+            "summary_text": "The following new items were downloaded:",
+            "data": {"download_path": pathname},
         }
 
 

--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -21,50 +21,55 @@ import subprocess
 
 from autopkglib import Processor, ProcessorError
 
+
 __all__ = ["Unarchiver"]
 
 EXTNS = {
-    'zip': ['zip'],
-    'tar_gzip': ['tar.gz', 'tgz'],
-    'tar_bzip2': ['tar.bz2', 'tbz'],
-    'tar': ['tar'],
-    'gzip': ['gzip'],
+    "zip": ["zip"],
+    "tar_gzip": ["tar.gz", "tgz"],
+    "tar_bzip2": ["tar.bz2", "tbz"],
+    "tar": ["tar"],
+    "gzip": ["gzip"],
 }
 
 
 class Unarchiver(Processor):
     """Archive decompressor for zip and common tar-compressed formats."""
+
     description = __doc__
     input_variables = {
         "archive_path": {
             "required": False,
             "description": "Path to an archive. Defaults to contents of the "
-                           "'pathname' variable, for example as is set by "
-                           "URLDownloader.",
+            "'pathname' variable, for example as is set by "
+            "URLDownloader.",
         },
         "destination_path": {
             "required": False,
-            "description": ("Directory where archive will be unpacked, created "
-                            "if necessary. Defaults to RECIPE_CACHE_DIR/NAME.")
+            "description": (
+                "Directory where archive will be unpacked, created "
+                "if necessary. Defaults to RECIPE_CACHE_DIR/NAME."
+            ),
         },
         "purge_destination": {
             "required": False,
             "description": "Whether the contents of the destination directory "
-                           "will be removed before unpacking.",
+            "will be removed before unpacking.",
         },
         "archive_format": {
             "required": False,
-            "description": ("The archive format. Currently supported: 'zip', "
-                            "'tar_gzip', 'tar_bzip2', 'tar'. If omitted, the "
-                            "file extension is used to guess the format.")
-        }
+            "description": (
+                "The archive format. Currently supported: 'zip', "
+                "'tar_gzip', 'tar_bzip2', 'tar'. If omitted, the "
+                "file extension is used to guess the format."
+            ),
+        },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     def get_archive_format(self, archive_path):
         """Guess archive format based on filename extension"""
-        #pylint: disable=no-self-use
+        # pylint: disable=no-self-use
         for format_str, extns in EXTNS.items():
             for extn in extns:
                 if archive_path.endswith(extn):
@@ -78,19 +83,22 @@ class Unarchiver(Processor):
         archive_path = self.env.get("archive_path", self.env.get("pathname"))
         if not archive_path:
             raise ProcessorError(
-                "Expected an 'archive_path' input variable but none is set!")
+                "Expected an 'archive_path' input variable but none is set!"
+            )
         destination_path = self.env.get(
             "destination_path",
-            os.path.join(self.env["RECIPE_CACHE_DIR"], self.env["NAME"]))
+            os.path.join(self.env["RECIPE_CACHE_DIR"], self.env["NAME"]),
+        )
 
         # Create the directory if needed.
         if not os.path.exists(destination_path):
             try:
                 os.makedirs(destination_path)
             except OSError as err:
-                raise ProcessorError("Can't create %s: %s"
-                                     % (destination_path, err.strerror))
-        elif self.env.get('purge_destination'):
+                raise ProcessorError(
+                    "Can't create %s: %s" % (destination_path, err.strerror)
+                )
+        elif self.env.get("purge_destination"):
             for entry in os.listdir(destination_path):
                 path = os.path.join(destination_path, entry)
                 try:
@@ -99,8 +107,7 @@ class Unarchiver(Processor):
                     else:
                         os.unlink(path)
                 except OSError as err:
-                    raise ProcessorError("Can't remove %s: %s"
-                                         % (path, err.strerror))
+                    raise ProcessorError("Can't remove %s: %s" % (path, err.strerror))
 
         fmt = self.env.get("archive_format")
         if fmt is None:
@@ -108,34 +115,31 @@ class Unarchiver(Processor):
             if not fmt:
                 raise ProcessorError(
                     "Can't guess archive format for filename %s"
-                    % os.path.basename(archive_path))
-            self.output("Guessed archive format '%s' from filename %s"
-                        % (fmt, os.path.basename(archive_path)))
+                    % os.path.basename(archive_path)
+                )
+            self.output(
+                "Guessed archive format '%s' from filename %s"
+                % (fmt, os.path.basename(archive_path))
+            )
         elif fmt not in EXTNS.keys():
             raise ProcessorError(
                 "'%s' is not valid for the 'archive_format' variable. "
-                "Must be one of %s." % (fmt, ", ".join(EXTNS.keys())))
+                "Must be one of %s." % (fmt, ", ".join(EXTNS.keys()))
+            )
 
         if fmt == "zip":
-            cmd = ["/usr/bin/ditto",
-                   "--noqtn",
-                   "-x",
-                   "-k",
-                   archive_path,
-                   destination_path]
+            cmd = [
+                "/usr/bin/ditto",
+                "--noqtn",
+                "-x",
+                "-k",
+                archive_path,
+                destination_path,
+            ]
         elif fmt == "gzip":
-            cmd = ["/usr/bin/ditto",
-                  "--noqtn",
-                  "-x",
-                  archive_path,
-                  destination_path]
+            cmd = ["/usr/bin/ditto", "--noqtn", "-x", archive_path, destination_path]
         elif fmt.startswith("tar"):
-            cmd = ["/usr/bin/tar",
-                   "-x",
-                   "-f",
-                   archive_path,
-                   "-C",
-                   destination_path]
+            cmd = ["/usr/bin/tar", "-x", "-f", archive_path, "-C", destination_path]
             if fmt.endswith("gzip"):
                 cmd.append("-z")
             elif fmt.endswith("bzip2"):
@@ -143,22 +147,22 @@ class Unarchiver(Processor):
 
         # Call command.
         try:
-            proc = subprocess.Popen(cmd,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             (_, stderr) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 "%s execution failed with error code %d: %s"
-                % (os.path.basename(cmd[0]), err.errno, err.strerror))
+                % (os.path.basename(cmd[0]), err.errno, err.strerror)
+            )
         if proc.returncode != 0:
             raise ProcessorError(
                 "Unarchiving %s with %s failed: %s"
-                % (archive_path, os.path.basename(cmd[0]), stderr))
+                % (archive_path, os.path.basename(cmd[0]), stderr)
+            )
 
         self.output("Unarchived %s to %s" % (archive_path, destination_path))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = Unarchiver()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/Versioner.py
+++ b/Code/autopkglib/Versioner.py
@@ -21,39 +21,39 @@ import FoundationPlist
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 
+
 __all__ = ["Versioner"]
 
 
 class Versioner(DmgMounter):
     """Returns version information from a plist"""
+
     description = __doc__
 
     input_variables = {
         "input_plist_path": {
             "required": True,
-            "description":
-                ("File path to a plist. Can point to a path inside a .dmg "
-                 "which will be mounted."),
+            "description": (
+                "File path to a plist. Can point to a path inside a .dmg "
+                "which will be mounted."
+            ),
         },
         "plist_version_key": {
             "required": False,
             "default": "CFBundleShortVersionString",
-            "description":
-                ("Which plist key to use; defaults to "
-                 "CFBundleShortVersionString"),
+            "description": (
+                "Which plist key to use; defaults to " "CFBundleShortVersionString"
+            ),
         },
     }
-    output_variables = {
-        "version": {
-            "description": "Version of the item.",
-        },
-    }
+    output_variables = {"version": {"description": "Version of the item."}}
 
     def main(self):
         """Return a version for file at input_plist_path"""
         # Check if we're trying to read something inside a dmg.
-        (dmg_path, dmg, dmg_source_path) = (
-            self.parsePathForDMG(self.env['input_plist_path']))
+        (dmg_path, dmg, dmg_source_path) = self.parsePathForDMG(
+            self.env["input_plist_path"]
+        )
         try:
             if dmg:
                 # Mount dmg and copy path inside.
@@ -61,17 +61,19 @@ class Versioner(DmgMounter):
                 input_plist_path = os.path.join(mount_point, dmg_source_path)
             else:
                 # just use the given path
-                input_plist_path = self.env['input_plist_path']
+                input_plist_path = self.env["input_plist_path"]
             if not os.path.exists(input_plist_path):
                 raise ProcessorError(
-                    "File '%s' does not exist or could not be read." %
-                    input_plist_path)
+                    "File '%s' does not exist or could not be read." % input_plist_path
+                )
             try:
                 plist = FoundationPlist.readPlist(input_plist_path)
                 version_key = self.env.get("plist_version_key")
-                self.env['version'] = plist.get(version_key, "UNKNOWN_VERSION")
-                self.output("Found version %s in file %s"
-                            % (self.env['version'], input_plist_path))
+                self.env["version"] = plist.get(version_key, "UNKNOWN_VERSION")
+                self.output(
+                    "Found version %s in file %s"
+                    % (self.env["version"], input_plist_path)
+                )
             except FoundationPlist.FoundationPlistException as err:
                 raise ProcessorError(err)
 
@@ -80,6 +82,6 @@ class Versioner(DmgMounter):
                 self.unmount(dmg_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = Versioner()
     PROCESSOR.execute_shell()

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -25,14 +25,16 @@ import sys
 
 from autopkglib import curl_cmd, get_pref
 
+
 BASE_URL = "https://api.github.com"
 TOKEN_LOCATION = os.path.expanduser("~/.autopkg_gh_token")
 
 
 class GitHubSession(object):
     """Handles a session with the GitHub API"""
+
     def __init__(self):
-        token = get_pref('GITHUB_TOKEN')
+        token = get_pref("GITHUB_TOKEN")
         if token:
             self.token = token
         elif os.path.exists(TOKEN_LOCATION):
@@ -41,8 +43,9 @@ class GitHubSession(object):
                     self.token = tokenf.read()
             except IOError as err:
                 print(
-                    "Couldn't read token file at %s! Error: %s"
-                    % (TOKEN_LOCATION, err), file=sys.stderr)
+                    "Couldn't read token file at %s! Error: %s" % (TOKEN_LOCATION, err),
+                    file=sys.stderr,
+                )
                 self.token = None
         else:
             self.token = None
@@ -53,11 +56,13 @@ class GitHubSession(object):
         if it exists."""
 
         if not os.path.exists(TOKEN_LOCATION):
-            print("""Create a new token in your GitHub settings page:
+            print(
+                """Create a new token in your GitHub settings page:
 
     https://github.com/settings/tokens
 
-To save the token, paste it to the following prompt.""")
+To save the token, paste it to the following prompt."""
+            )
 
             token = raw_input("Token: ")
             if token:
@@ -69,7 +74,9 @@ To save the token, paste it to the following prompt.""")
                 except IOError as err:
                     print(
                         "Couldn't write token file at %s! Error: %s"
-                        % (TOKEN_LOCATION, err), file=sys.stderr)
+                        % (TOKEN_LOCATION, err),
+                        file=sys.stderr,
+                    )
             else:
                 print("Skipping token file creation.", file=sys.stderr)
         else:
@@ -78,16 +85,24 @@ To save the token, paste it to the following prompt.""")
                     token = tokenf.read()
             except IOError as err:
                 print(
-                    "Couldn't read token file at %s! Error: %s"
-                    % (TOKEN_LOCATION, err), file=sys.stderr)
+                    "Couldn't read token file at %s! Error: %s" % (TOKEN_LOCATION, err),
+                    file=sys.stderr,
+                )
 
             # TODO: validate token given we found one but haven't checked its
             # auth status
 
         self.token = token
 
-    def call_api(self, endpoint, method="GET", query=None, data=None,
-                 headers=None, accept="application/vnd.github.v3+json"):
+    def call_api(
+        self,
+        endpoint,
+        method="GET",
+        query=None,
+        data=None,
+        headers=None,
+        accept="application/vnd.github.v3+json",
+    ):
         """Return a tuple of a serialized JSON response and HTTP status code
         from a call to a GitHub API endpoint. Certain APIs return no JSON
         result and so the first item in the tuple (the response) will be None.
@@ -112,29 +127,32 @@ To save the token, paste it to the following prompt.""")
                 return (None, None)
             cmd = [
                 curl_path,
-                '--location',
-                '--silent',
-                '--show-error',
-                '--fail',
-                '--dump-header', '-'
+                "--location",
+                "--silent",
+                "--show-error",
+                "--fail",
+                "--dump-header",
+                "-",
             ]
-            cmd.extend(['-X', method])
-            cmd.extend(['--header', '%s: %s' % ("User-Agent", "AutoPkg")])
-            cmd.extend(['--header', '%s: %s' % ("Accept", accept)])
+            cmd.extend(["-X", method])
+            cmd.extend(["--header", "%s: %s" % ("User-Agent", "AutoPkg")])
+            cmd.extend(["--header", "%s: %s" % ("Accept", accept)])
 
             # Pass the GitHub token as a header
             if self.token:
-                cmd.extend(['--header', '%s: %s' % ("Authorization", "token %s" % self.token)])
+                cmd.extend(
+                    ["--header", "%s: %s" % ("Authorization", "token %s" % self.token)]
+                )
 
             # Additional headers if defined
             if headers:
                 for header, value in headers.items():
-                    cmd.extend(['--header', '%s: %s' % (header, value)])
+                    cmd.extend(["--header", "%s: %s" % (header, value)])
 
             # Set the data header if defined
             if data:
                 data = json.dumps(data)
-                cmd.extend(['-d', data, '--header', 'Content-Type: application/json'])
+                cmd.extend(["-d", data, "--header", "Content-Type: application/json"])
 
             # Final argument to curl is the URL
             cmd.append(url)
@@ -145,12 +163,12 @@ To save the token, paste it to the following prompt.""")
                 shell=False,
                 bufsize=1,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
             )
 
             header = {}
-            header['http_result_code'] = '000'
-            header['http_result_description'] = ''
+            header["http_result_code"] = "000"
+            header["http_result_description"] = ""
             donewithheaders = False
             maxheaders = 15
 
@@ -160,18 +178,18 @@ To save the token, paste it to the following prompt.""")
             while True:
                 info = proc.stdout.readline()
                 if not donewithheaders:
-                    info = info.strip('\r\n')
+                    info = info.strip("\r\n")
                     if info:
-                        if info.startswith('HTTP/'):
+                        if info.startswith("HTTP/"):
                             part = info.split(None, 2)
-                            header['http_result_code'] = part[1]
+                            header["http_result_code"] = part[1]
                             try:
-                                header['http_result_description'] = part[2]
+                                header["http_result_description"] = part[2]
                             except IndexError:
                                 pass
-                        elif ': ' in info:
+                        elif ": " in info:
                             part = info.split(None, 1)
-                            fieldname = part[0].rstrip(':').lower()
+                            fieldname = part[0].rstrip(":").lower()
                             try:
                                 header[fieldname] = part[1]
                             except IndexError:
@@ -181,7 +199,7 @@ To save the token, paste it to the following prompt.""")
                 else:
                     page_content += info
 
-                if (proc.poll() is not None):
+                if proc.poll() is not None:
                     # For small download files curl may exit before all headers
                     # have been parsed, don't immediately exit.
                     maxheaders -= 1
@@ -191,9 +209,9 @@ To save the token, paste it to the following prompt.""")
             # All curl output should now be parsed
             retcode = proc.poll()
             if retcode:
-                curlerr = ''
+                curlerr = ""
                 try:
-                    curlerr = proc.stderr.read().rstrip('\n')
+                    curlerr = proc.stderr.read().rstrip("\n")
                     curlerr = curlerr.split(None, 2)[2]
                 except IndexError:
                     pass
@@ -201,14 +219,11 @@ To save the token, paste it to the following prompt.""")
                     # 22 means any 400 series return code. Note: header seems not to
                     # be dumped to STDOUT for immediate failures. Hence
                     # http_result_code is likely blank/000. Read it from stderr.
-                    if re.search(r'URL returned error: [0-9]+', curlerr):
+                    if re.search(r"URL returned error: [0-9]+", curlerr):
                         m = re.match(r".* (?P<status_code>\d+) .*", curlerr)
-                        if m.group('status_code'):
-                            header['http_result_code'] = m.group('status_code')
-                print(
-                    'Could not retrieve URL %s: %s' % (url, curlerr),
-                    file=sys.stderr
-                )
+                        if m.group("status_code"):
+                            header["http_result_code"] = m.group("status_code")
+                print("Could not retrieve URL %s: %s" % (url, curlerr), file=sys.stderr)
 
             if page_content:
                 resp_data = json.loads(page_content)
@@ -216,8 +231,8 @@ To save the token, paste it to the following prompt.""")
                 resp_data = None
 
         except OSError:
-            print('Could not retrieve URL: %s' % url, file=sys.stderr)
+            print("Could not retrieve URL: %s" % url, file=sys.stderr)
             resp_data = None
 
-        http_result_code = int(header.get('http_result_code'))
+        http_result_code = int(header.get("http_result_code"))
         return (resp_data, http_result_code)

--- a/Code/autopkgserver/autopkginstalld
+++ b/Code/autopkgserver/autopkginstalld
@@ -14,27 +14,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-'''A server that installs Apple packages'''
+"""A server that installs Apple packages"""
 
+import logging
+import logging.handlers
 import os
+import platform
+import plistlib
+import socket
+import SocketServer
+import stat
+import struct
 import sys
 import time
-import stat
-import logging, logging.handlers
-import SocketServer
-import socket
-import plistlib
-import struct
-import platform
 
-from itemcopier import ItemCopier, ItemCopierError
 from installer import Installer, InstallerError
+from itemcopier import ItemCopier, ItemCopierError
+
 
 APPNAME = "autopkginstalld"
 VERSION = "0.2"
 
+
 class RunHandler(SocketServer.StreamRequestHandler):
-    '''Handler for autopkginstalld run requests'''
+    """Handler for autopkginstalld run requests"""
 
     def verify_request_syntax(self, plist):
         """Verify the basic syntax of an installation request plist."""
@@ -49,7 +52,7 @@ class RunHandler(SocketServer.StreamRequestHandler):
             return False, errors
 
         syntax_ok = True
-        for key in ['package']:
+        for key in ["package"]:
             if not key in plist:
                 syntax_ok = False
                 errors.append("Request does not contain %s" % key)
@@ -82,13 +85,13 @@ class RunHandler(SocketServer.StreamRequestHandler):
         xucred_fmt = "IIh%dI" % NGROUPS
         res = struct.unpack(
             xucred_fmt,
-            self.request.getsockopt(
-                0, LOCAL_PEERCRED, struct.calcsize(xucred_fmt)))
+            self.request.getsockopt(0, LOCAL_PEERCRED, struct.calcsize(xucred_fmt)),
+        )
 
         if res[cr_version] != XUCRED_VERSION:
             raise OSError("Incompatible struct xucred version")
 
-        return res[cr_uid], res[cr_groups:cr_groups + res[cr_ngroups]]
+        return res[cr_uid], res[cr_groups : cr_groups + res[cr_ngroups]]
 
     def handle(self):
         """Handle an incoming run request."""
@@ -101,8 +104,7 @@ class RunHandler(SocketServer.StreamRequestHandler):
             # Get uid and primary gid of connecting peer.
             uid, gids = self.getpeerid()
             gid = gids[0]
-            self.log.debug(
-                "Got run request from uid %d gid %d" % (uid, gid))
+            self.log.debug("Got run request from uid %d gid %d" % (uid, gid))
 
             # Receive a plist.
             plist_string = self.request.recv(8192)
@@ -116,10 +118,11 @@ class RunHandler(SocketServer.StreamRequestHandler):
                 return
             self.log.debug("Parsed request plist")
 
-            if 'package' in plist:
+            if "package" in plist:
                 self.log.info(
                     "Dispatching Installer worker to process request for "
-                    "user %d" % uid)
+                    "user %d" % uid
+                )
                 try:
                     installer = Installer(self.log, self.request, plist)
                     installer.install()
@@ -127,10 +130,11 @@ class RunHandler(SocketServer.StreamRequestHandler):
                 except InstallerError as err:
                     self.log.error("Installing failed: %s" % err)
                     self.request.send(str(err) + "\n")
-            elif 'mount_point' in plist:
+            elif "mount_point" in plist:
                 self.log.info(
                     "Dispatching ItemCopier worker to process request for "
-                    "user %d" % uid)
+                    "user %d" % uid
+                )
                 try:
                     copier = ItemCopier(self.log, self.request, plist)
                     copier.copy()
@@ -149,6 +153,7 @@ class RunHandler(SocketServer.StreamRequestHandler):
 
 class AutoPkgInstallDaemonError(Exception):
     """Exception class for AutoPkgInstallDaemon errors"""
+
     pass
 
 
@@ -163,12 +168,11 @@ class AutoPkgInstallDaemon(SocketServer.UnixStreamServer):
     def __init__(self, socket_fd, RequestHandlerClass):
         # Avoid initialization of UnixStreamServer as we need to open the
         # socket from a file descriptor instead of creating our own.
-        self.socket = socket.fromfd(
-            socket_fd, socket.AF_UNIX, socket.SOCK_STREAM)
+        self.socket = socket.fromfd(socket_fd, socket.AF_UNIX, socket.SOCK_STREAM)
         self.socket.listen(self.request_queue_size)
-        SocketServer.BaseServer.__init__(self,
-                                         self.socket.getsockname(),
-                                         RequestHandlerClass)
+        SocketServer.BaseServer.__init__(
+            self, self.socket.getsockname(), RequestHandlerClass
+        )
         self.timed_out = False
 
     def setup_logging(self):
@@ -180,17 +184,14 @@ class AutoPkgInstallDaemon(SocketServer.UnixStreamServer):
             log_console = logging.StreamHandler()
             log_console.setLevel(logging.DEBUG)
             log_file = logging.handlers.RotatingFileHandler(
-                "/private/var/log/%s" % APPNAME,
-                "a",
-                100000,
-                9,
-                "utf-8")
+                "/private/var/log/%s" % APPNAME, "a", 100000, 9, "utf-8"
+            )
             log_file.setLevel(logging.DEBUG)
 
             console_formatter = logging.Formatter("%(message)s")
             file_formatter = logging.Formatter(
-                "%(asctime)s %(module)s[%(process)d]: "
-                "%(message)s   (%(funcName)s)")
+                "%(asctime)s %(module)s[%(process)d]: " "%(message)s   (%(funcName)s)"
+            )
 
             log_console.setFormatter(console_formatter)
             log_file.setFormatter(file_formatter)
@@ -198,8 +199,7 @@ class AutoPkgInstallDaemon(SocketServer.UnixStreamServer):
             self.log.addHandler(log_console)
             self.log.addHandler(log_file)
         except (OSError, IOError) as err:
-            raise AutoPkgInstallDaemonError(
-                "Can't open log: %s" % (err.strerror))
+            raise AutoPkgInstallDaemonError("Can't open log: %s" % (err.strerror))
 
     def handle_timeout(self):
         self.timed_out = True
@@ -208,7 +208,7 @@ class AutoPkgInstallDaemon(SocketServer.UnixStreamServer):
 def main(argv):
     # Make sure we're launched as root
     if os.geteuid() != 0:
-        print >> sys.stderr, "%s must be run as root." % APPNAME
+        print >>sys.stderr, "%s must be run as root." % APPNAME
         # Sleep to avoid respawn.
         time.sleep(10)
         return 1
@@ -224,13 +224,13 @@ def main(argv):
     while True:
         info = os.stat(exepath)
         if info.st_uid != root_uid:
-            print >> sys.stderr, "%s must be owned by root." % exepath
+            print >>sys.stderr, "%s must be owned by root." % exepath
             path_ok = False
         if info.st_gid not in (wheel_gid, admin_gid):
-            print >> sys.stderr, "%s must have group wheel or admin." % exepath
+            print >>sys.stderr, "%s must have group wheel or admin." % exepath
             path_ok = False
         if info.st_mode & stat.S_IWOTH:
-            print >> sys.stderr, "%s mustn't be world writeable." % exepath
+            print >>sys.stderr, "%s mustn't be world writeable." % exepath
             path_ok = False
         exepath = os.path.dirname(exepath)
         if exepath == "/":
@@ -247,6 +247,7 @@ def main(argv):
     # Get socket file descriptors from launchd.
     if int(platform.mac_ver()[0].split(u".")[1]) >= 10:
         import launch2
+
         try:
             sockets = launch2.launch_activate_socket("autopkginstalld")
         except launch2.LaunchDError as err:
@@ -258,6 +259,7 @@ def main(argv):
 
     else:
         import launch
+
         try:
             sockets = launch.get_launchd_socket_fds()
         except launch.LaunchDCheckInError as err:
@@ -289,13 +291,15 @@ def main(argv):
         if run_time < 10.0:
             # Only sleep for a short while in case new requests pop up.
             sleep_time = min(1.0, 10.0 - run_time)
-            daemon.log.debug( \
-                "sleeping for %f seconds to make launchd happy" % sleep_time)
+            daemon.log.debug(
+                "sleeping for %f seconds to make launchd happy" % sleep_time
+            )
             time.sleep(sleep_time)
         else:
             break
 
     return 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/Code/autopkgserver/autopkgserver
+++ b/Code/autopkgserver/autopkgserver
@@ -72,17 +72,18 @@ Request format:
 
 """
 
+import logging
+import logging.handlers
 import os
-import sys
-import time
-import stat
-import logging, logging.handlers
-import SocketServer
-import socket
+import platform
 import plistlib
 import re
+import socket
+import SocketServer
+import stat
 import struct
-import platform
+import sys
+import time
 
 from packager import Packager, PackagerError
 
@@ -107,14 +108,9 @@ request_structure = {
     "infofile": str,
     "resources": str,
     "chown": list,
-    "scripts": str
+    "scripts": str,
 }
-chown_structure = {
-    "path": str,
-    "user": (str, int),
-    "group": (str, int),
-    "mode": str
-}
+chown_structure = {"path": str, "user": (str, int), "group": (str, int), "mode": str}
 
 
 #################
@@ -123,23 +119,24 @@ chown_structure = {
 
 
 # Set up signal handlers.
-#def sig_handler(num, frame):
+# def sig_handler(num, frame):
 #    log.error("%s aborted with signal %d" % (APPNAME, num))
 #
-#signal.signal(signal.SIGHUP, sig_handler)
-#signal.signal(signal.SIGINT, sig_handler)
-#signal.signal(signal.SIGTERM, sig_handler)
+# signal.signal(signal.SIGHUP, sig_handler)
+# signal.signal(signal.SIGINT, sig_handler)
+# signal.signal(signal.SIGTERM, sig_handler)
 
 
 class AutoPkgServerError(Exception):
     """Exception class for AutoPkgServer errors"""
+
     pass
+
 
 class PkgHandler(SocketServer.StreamRequestHandler):
     """Handler for packaging requests."""
 
-    re_uid_gid = re.compile(
-        r'^AUTH:AUTHENTICATE (?P<uid>\d{1,10}):(?P<gid>\d{1,10})$')
+    re_uid_gid = re.compile(r"^AUTH:AUTHENTICATE (?P<uid>\d{1,10}):(?P<gid>\d{1,10})$")
 
     def verify_request_syntax(self, plist):
         """Verify the basic syntax of request plist."""
@@ -162,9 +159,9 @@ class PkgHandler(SocketServer.StreamRequestHandler):
                 syntax_ok = False
             else:
                 if not isinstance(plist[key], keytype):
-                    errors.append( \
-                        "Request key %s is not of type %s" % \
-                        (key, str(keytype)))
+                    errors.append(
+                        "Request key %s is not of type %s" % (key, str(keytype))
+                    )
                     syntax_ok = False
 
         if syntax_ok:
@@ -185,9 +182,10 @@ class PkgHandler(SocketServer.StreamRequestHandler):
                         errors.append("chown entry is missing %s" % key)
                     else:
                         if not isinstance(chown_entry[key], keytype):
-                            errors.append( \
-                                "Request key chown.%s is not of type %s" % \
-                                (key, str(keytype)))
+                            errors.append(
+                                "Request key chown.%s is not of type %s"
+                                % (key, str(keytype))
+                            )
                             syntax_ok = False
 
         return (syntax_ok, errors)
@@ -218,13 +216,13 @@ class PkgHandler(SocketServer.StreamRequestHandler):
         xucred_fmt = "IIh%dI" % NGROUPS
         res = struct.unpack(
             xucred_fmt,
-            self.request.getsockopt(
-                0, LOCAL_PEERCRED, struct.calcsize(xucred_fmt)))
+            self.request.getsockopt(0, LOCAL_PEERCRED, struct.calcsize(xucred_fmt)),
+        )
 
         if res[cr_version] != XUCRED_VERSION:
             raise OSError("Incompatible struct xucred version")
 
-        return res[cr_uid], res[cr_groups:cr_groups + res[cr_ngroups]]
+        return res[cr_uid], res[cr_groups : cr_groups + res[cr_ngroups]]
 
     def handle(self):
         """Handle an incoming packaging request."""
@@ -237,8 +235,7 @@ class PkgHandler(SocketServer.StreamRequestHandler):
             # Get uid and primary gid of connecting peer.
             uid, gids = self.getpeerid()
             gid = gids[0]
-            self.log.debug(
-                "Got packaging request from uid %d gid %d" % (uid, gid))
+            self.log.debug("Got packaging request from uid %d gid %d" % (uid, gid))
 
             # Receive a plist.
             plist_string = self.request.recv(8192)
@@ -265,8 +262,7 @@ class PkgHandler(SocketServer.StreamRequestHandler):
                 self.request.send("ERROR:Can't find pkgroot")
                 return
 
-            self.log.info(
-                "Dispatching worker to process request for user %d" % (uid))
+            self.log.info("Dispatching worker to process request for user %d" % (uid))
             try:
                 pkgr = Packager(self.log, plist, name, uid, gid)
                 pkgpath = pkgr.package()
@@ -293,15 +289,14 @@ class AutoPkgServer(SocketServer.UnixStreamServer):
     def __init__(self, socket_fd, RequestHandlerClass):
         # Avoid initialization of UnixStreamServer as we need to open the
         # socket from a file descriptor instead of creating our own.
-        self.socket = socket.fromfd(
-            socket_fd, socket.AF_UNIX, socket.SOCK_STREAM)
+        self.socket = socket.fromfd(socket_fd, socket.AF_UNIX, socket.SOCK_STREAM)
         self.socket.listen(self.request_queue_size)
-        SocketServer.BaseServer.__init__(self,
-                                         self.socket.getsockname(),
-                                         RequestHandlerClass)
+        SocketServer.BaseServer.__init__(
+            self, self.socket.getsockname(), RequestHandlerClass
+        )
         self.timed_out = False
 
-    #def server_bind(self):
+    # def server_bind(self):
     #    """Override binding to inherit socket from launchd."""
     #
 
@@ -313,17 +308,14 @@ class AutoPkgServer(SocketServer.UnixStreamServer):
             log_console = logging.StreamHandler()
             log_console.setLevel(logging.DEBUG)
             log_file = logging.handlers.RotatingFileHandler(
-                "/private/var/log/%s" % APPNAME,
-                "a",
-                100000,
-                9,
-                "utf-8")
+                "/private/var/log/%s" % APPNAME, "a", 100000, 9, "utf-8"
+            )
             log_file.setLevel(logging.DEBUG)
 
             console_formatter = logging.Formatter("%(message)s")
-            file_formatter = \
-                logging.Formatter("%(asctime)s %(module)s[%(process)d]: " + \
-                                  "%(message)s   (%(funcName)s)")
+            file_formatter = logging.Formatter(
+                "%(asctime)s %(module)s[%(process)d]: " + "%(message)s   (%(funcName)s)"
+            )
 
             log_console.setFormatter(console_formatter)
             log_file.setFormatter(file_formatter)
@@ -379,6 +371,7 @@ def main(argv):
     # Get socket file descriptors from launchd.
     if int(platform.mac_ver()[0].split(u".")[1]) >= 10:
         import launch2
+
         try:
             sockets = launch2.launch_activate_socket("AutoPkgServer")
         except launch2.LaunchDError as err:
@@ -390,6 +383,7 @@ def main(argv):
 
     else:
         import launch
+
         try:
             sockets = launch.get_launchd_socket_fds()
         except launch.LaunchDCheckInError as err:
@@ -425,17 +419,18 @@ def main(argv):
                 # Only sleep for a short while in case new requests pop up.
                 sleep_time = min(1.0, 10.0 - run_time)
                 server.log.debug(
-                    "sleeping for %f seconds to make launchd happy"
-                    % sleep_time)
+                    "sleeping for %f seconds to make launchd happy" % sleep_time
+                )
                 time.sleep(sleep_time)
             else:
                 break
     finally:
         # Make sure the socket is removed.
-        #os.unlink(SOCKET)
+        # os.unlink(SOCKET)
         pass
 
     return 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/Code/autopkgserver/installer.py
+++ b/Code/autopkgserver/installer.py
@@ -13,19 +13,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-'''Runs installer to install a package. Can install a package located inside a
-disk image file.'''
+"""Runs installer to install a package. Can install a package located inside a
+disk image file."""
 
 import subprocess
 
 
 class InstallerError(Exception):
-    '''Base error for Installer errors'''
+    """Base error for Installer errors"""
+
     pass
 
 
 class Installer(object):
-    '''Runs /usr/sbin/installer to install a package'''
+    """Runs /usr/sbin/installer to install a package"""
 
     def __init__(self, log, socket, request):
         """Arguments:
@@ -40,32 +41,35 @@ class Installer(object):
         self.request = request
 
     def verify_request(self):
-        '''Make sure copy request has everything we need'''
+        """Make sure copy request has everything we need"""
         self.log.debug("Verifying install request")
         for key in ["package"]:
             if key not in self.request:
                 raise InstallerError("ERROR:No %s in request" % key)
 
     def do_install(self):
-        '''Call /usr/sbin/installer'''
-        pkg_path = self.request['package']
+        """Call /usr/sbin/installer"""
+        pkg_path = self.request["package"]
         try:
-            cmd = ['/usr/sbin/installer', '-verboseR',
-                   '-pkg', pkg_path, '-target', '/']
-            proc = subprocess.Popen(cmd, shell=False, bufsize=-1,
-                                    stdin=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.STDOUT)
+            cmd = ["/usr/sbin/installer", "-verboseR", "-pkg", pkg_path, "-target", "/"]
+            proc = subprocess.Popen(
+                cmd,
+                shell=False,
+                bufsize=-1,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
             while True:
-                output = proc.stdout.readline().decode('UTF-8')
+                output = proc.stdout.readline().decode("UTF-8")
                 if not output and (proc.poll() is not None):
                     break
-                self.socket.send("STATUS:%s" % output.encode('UTF-8'))
+                self.socket.send("STATUS:%s" % output.encode("UTF-8"))
                 self.log.info(output.rstrip())
 
             if proc.returncode != 0:
                 raise InstallerError("ERROR:%s\n" % proc.returncode)
-            self.log.info('install request completed.')
+            self.log.info("install request completed.")
             return True
         except BaseException as err:
             self.log.error("Install failed: %s" % err)

--- a/Code/autopkgserver/launch.py
+++ b/Code/autopkgserver/launch.py
@@ -15,6 +15,7 @@
 
 from ctypes import *
 
+
 libc = CDLL("/usr/lib/libc.dylib")
 
 
@@ -25,7 +26,7 @@ launch_data_array_get_count = libc.launch_data_array_get_count
 launch_data_array_get_count.restype = c_size_t
 launch_data_array_get_count.argtypes = [c_launch_data_t]
 
-#launch_data_t launch_data_array_get_index(const launch_data_t, size_t) __ld_getter;
+# launch_data_t launch_data_array_get_index(const launch_data_t, size_t) __ld_getter;
 launch_data_array_get_index = libc.launch_data_array_get_index
 launch_data_array_get_index.restype = c_launch_data_t
 launch_data_array_get_index.argtypes = [c_launch_data_t, c_size_t]
@@ -40,7 +41,7 @@ launch_data_dict_lookup = libc.launch_data_dict_lookup
 launch_data_dict_lookup.restype = c_launch_data_t
 launch_data_dict_lookup.argtypes = [c_launch_data_t, c_char_p]
 
-#void launch_data_dict_iterate(const launch_data_t, void (*)(const launch_data_t, const char *, void *), void *) __ld_iterator(1, 2)
+# void launch_data_dict_iterate(const launch_data_t, void (*)(const launch_data_t, const char *, void *), void *) __ld_iterator(1, 2)
 DICTITCALLBACK = CFUNCTYPE(c_void_p, c_launch_data_t, c_char_p, c_void_p)
 launch_data_dict_iterate = libc.launch_data_dict_iterate
 launch_data_dict_iterate.restype = None
@@ -77,111 +78,111 @@ launch_msg.restype = c_launch_data_t
 launch_msg.argtypes = [c_launch_data_t]
 
 
-LAUNCH_KEY_SUBMITJOB						= c_char_p("SubmitJob")
-LAUNCH_KEY_REMOVEJOB						= c_char_p("RemoveJob")
-LAUNCH_KEY_STARTJOB							= c_char_p("StartJob")
-LAUNCH_KEY_STOPJOB							= c_char_p("StopJob")
-LAUNCH_KEY_GETJOB							= c_char_p("GetJob")
-LAUNCH_KEY_GETJOBS							= c_char_p("GetJobs")
-LAUNCH_KEY_CHECKIN							= c_char_p("CheckIn")
+LAUNCH_KEY_SUBMITJOB = c_char_p("SubmitJob")
+LAUNCH_KEY_REMOVEJOB = c_char_p("RemoveJob")
+LAUNCH_KEY_STARTJOB = c_char_p("StartJob")
+LAUNCH_KEY_STOPJOB = c_char_p("StopJob")
+LAUNCH_KEY_GETJOB = c_char_p("GetJob")
+LAUNCH_KEY_GETJOBS = c_char_p("GetJobs")
+LAUNCH_KEY_CHECKIN = c_char_p("CheckIn")
 
-LAUNCH_JOBKEY_LABEL							= c_char_p("Label")
-LAUNCH_JOBKEY_DISABLED						= c_char_p("Disabled")
-LAUNCH_JOBKEY_USERNAME						= c_char_p("UserName")
-LAUNCH_JOBKEY_GROUPNAME						= c_char_p("GroupName")
-LAUNCH_JOBKEY_TIMEOUT						= c_char_p("TimeOut")
-LAUNCH_JOBKEY_EXITTIMEOUT					= c_char_p("ExitTimeOut")
-LAUNCH_JOBKEY_INITGROUPS					= c_char_p("InitGroups")
-LAUNCH_JOBKEY_SOCKETS						= c_char_p("Sockets")
-LAUNCH_JOBKEY_MACHSERVICES					= c_char_p("MachServices")
-LAUNCH_JOBKEY_MACHSERVICELOOKUPPOLICIES		= c_char_p("MachServiceLookupPolicies")
-LAUNCH_JOBKEY_INETDCOMPATIBILITY			= c_char_p("inetdCompatibility")
-LAUNCH_JOBKEY_ENABLEGLOBBING				= c_char_p("EnableGlobbing")
-LAUNCH_JOBKEY_PROGRAMARGUMENTS				= c_char_p("ProgramArguments")
-LAUNCH_JOBKEY_PROGRAM						= c_char_p("Program")
-LAUNCH_JOBKEY_ONDEMAND						= c_char_p("OnDemand")
-LAUNCH_JOBKEY_KEEPALIVE						= c_char_p("KeepAlive")
-LAUNCH_JOBKEY_LIMITLOADTOHOSTS				= c_char_p("LimitLoadToHosts")
-LAUNCH_JOBKEY_LIMITLOADFROMHOSTS			= c_char_p("LimitLoadFromHosts")
-LAUNCH_JOBKEY_LIMITLOADTOSESSIONTYPE		= c_char_p("LimitLoadToSessionType")
-LAUNCH_JOBKEY_RUNATLOAD						= c_char_p("RunAtLoad")
-LAUNCH_JOBKEY_ROOTDIRECTORY					= c_char_p("RootDirectory")
-LAUNCH_JOBKEY_WORKINGDIRECTORY				= c_char_p("WorkingDirectory")
-LAUNCH_JOBKEY_ENVIRONMENTVARIABLES			= c_char_p("EnvironmentVariables")
-LAUNCH_JOBKEY_USERENVIRONMENTVARIABLES		= c_char_p("UserEnvironmentVariables")
-LAUNCH_JOBKEY_UMASK							= c_char_p("Umask")
-LAUNCH_JOBKEY_NICE							= c_char_p("Nice")
-LAUNCH_JOBKEY_HOPEFULLYEXITSFIRST	  		= c_char_p("HopefullyExitsFirst")
-LAUNCH_JOBKEY_HOPEFULLYEXITSLAST   			= c_char_p("HopefullyExitsLast")
-LAUNCH_JOBKEY_LOWPRIORITYIO					= c_char_p("LowPriorityIO")
-LAUNCH_JOBKEY_SESSIONCREATE					= c_char_p("SessionCreate")
-LAUNCH_JOBKEY_STARTONMOUNT					= c_char_p("StartOnMount")
-LAUNCH_JOBKEY_SOFTRESOURCELIMITS			= c_char_p("SoftResourceLimits")
-LAUNCH_JOBKEY_HARDRESOURCELIMITS			= c_char_p("HardResourceLimits")
-LAUNCH_JOBKEY_STANDARDINPATH				= c_char_p("StandardInPath")
-LAUNCH_JOBKEY_STANDARDOUTPATH				= c_char_p("StandardOutPath")
-LAUNCH_JOBKEY_STANDARDERRORPATH				= c_char_p("StandardErrorPath")
-LAUNCH_JOBKEY_DEBUG							= c_char_p("Debug")
-LAUNCH_JOBKEY_WAITFORDEBUGGER				= c_char_p("WaitForDebugger")
-LAUNCH_JOBKEY_QUEUEDIRECTORIES				= c_char_p("QueueDirectories")
-LAUNCH_JOBKEY_WATCHPATHS					= c_char_p("WatchPaths")
-LAUNCH_JOBKEY_STARTINTERVAL					= c_char_p("StartInterval")
-LAUNCH_JOBKEY_STARTCALENDARINTERVAL			= c_char_p("StartCalendarInterval")
-LAUNCH_JOBKEY_BONJOURFDS					= c_char_p("BonjourFDs")
-LAUNCH_JOBKEY_LASTEXITSTATUS				= c_char_p("LastExitStatus")
-LAUNCH_JOBKEY_PID							= c_char_p("PID")
-LAUNCH_JOBKEY_THROTTLEINTERVAL				= c_char_p("ThrottleInterval")
-LAUNCH_JOBKEY_LAUNCHONLYONCE				= c_char_p("LaunchOnlyOnce")
-LAUNCH_JOBKEY_ABANDONPROCESSGROUP			= c_char_p("AbandonProcessGroup")
-LAUNCH_JOBKEY_IGNOREPROCESSGROUPATSHUTDOWN	= c_char_p("IgnoreProcessGroupAtShutdown")
-LAUNCH_JOBKEY_POLICIES						= c_char_p("Policies")
-LAUNCH_JOBKEY_ENABLETRANSACTIONS			= c_char_p("EnableTransactions")
+LAUNCH_JOBKEY_LABEL = c_char_p("Label")
+LAUNCH_JOBKEY_DISABLED = c_char_p("Disabled")
+LAUNCH_JOBKEY_USERNAME = c_char_p("UserName")
+LAUNCH_JOBKEY_GROUPNAME = c_char_p("GroupName")
+LAUNCH_JOBKEY_TIMEOUT = c_char_p("TimeOut")
+LAUNCH_JOBKEY_EXITTIMEOUT = c_char_p("ExitTimeOut")
+LAUNCH_JOBKEY_INITGROUPS = c_char_p("InitGroups")
+LAUNCH_JOBKEY_SOCKETS = c_char_p("Sockets")
+LAUNCH_JOBKEY_MACHSERVICES = c_char_p("MachServices")
+LAUNCH_JOBKEY_MACHSERVICELOOKUPPOLICIES = c_char_p("MachServiceLookupPolicies")
+LAUNCH_JOBKEY_INETDCOMPATIBILITY = c_char_p("inetdCompatibility")
+LAUNCH_JOBKEY_ENABLEGLOBBING = c_char_p("EnableGlobbing")
+LAUNCH_JOBKEY_PROGRAMARGUMENTS = c_char_p("ProgramArguments")
+LAUNCH_JOBKEY_PROGRAM = c_char_p("Program")
+LAUNCH_JOBKEY_ONDEMAND = c_char_p("OnDemand")
+LAUNCH_JOBKEY_KEEPALIVE = c_char_p("KeepAlive")
+LAUNCH_JOBKEY_LIMITLOADTOHOSTS = c_char_p("LimitLoadToHosts")
+LAUNCH_JOBKEY_LIMITLOADFROMHOSTS = c_char_p("LimitLoadFromHosts")
+LAUNCH_JOBKEY_LIMITLOADTOSESSIONTYPE = c_char_p("LimitLoadToSessionType")
+LAUNCH_JOBKEY_RUNATLOAD = c_char_p("RunAtLoad")
+LAUNCH_JOBKEY_ROOTDIRECTORY = c_char_p("RootDirectory")
+LAUNCH_JOBKEY_WORKINGDIRECTORY = c_char_p("WorkingDirectory")
+LAUNCH_JOBKEY_ENVIRONMENTVARIABLES = c_char_p("EnvironmentVariables")
+LAUNCH_JOBKEY_USERENVIRONMENTVARIABLES = c_char_p("UserEnvironmentVariables")
+LAUNCH_JOBKEY_UMASK = c_char_p("Umask")
+LAUNCH_JOBKEY_NICE = c_char_p("Nice")
+LAUNCH_JOBKEY_HOPEFULLYEXITSFIRST = c_char_p("HopefullyExitsFirst")
+LAUNCH_JOBKEY_HOPEFULLYEXITSLAST = c_char_p("HopefullyExitsLast")
+LAUNCH_JOBKEY_LOWPRIORITYIO = c_char_p("LowPriorityIO")
+LAUNCH_JOBKEY_SESSIONCREATE = c_char_p("SessionCreate")
+LAUNCH_JOBKEY_STARTONMOUNT = c_char_p("StartOnMount")
+LAUNCH_JOBKEY_SOFTRESOURCELIMITS = c_char_p("SoftResourceLimits")
+LAUNCH_JOBKEY_HARDRESOURCELIMITS = c_char_p("HardResourceLimits")
+LAUNCH_JOBKEY_STANDARDINPATH = c_char_p("StandardInPath")
+LAUNCH_JOBKEY_STANDARDOUTPATH = c_char_p("StandardOutPath")
+LAUNCH_JOBKEY_STANDARDERRORPATH = c_char_p("StandardErrorPath")
+LAUNCH_JOBKEY_DEBUG = c_char_p("Debug")
+LAUNCH_JOBKEY_WAITFORDEBUGGER = c_char_p("WaitForDebugger")
+LAUNCH_JOBKEY_QUEUEDIRECTORIES = c_char_p("QueueDirectories")
+LAUNCH_JOBKEY_WATCHPATHS = c_char_p("WatchPaths")
+LAUNCH_JOBKEY_STARTINTERVAL = c_char_p("StartInterval")
+LAUNCH_JOBKEY_STARTCALENDARINTERVAL = c_char_p("StartCalendarInterval")
+LAUNCH_JOBKEY_BONJOURFDS = c_char_p("BonjourFDs")
+LAUNCH_JOBKEY_LASTEXITSTATUS = c_char_p("LastExitStatus")
+LAUNCH_JOBKEY_PID = c_char_p("PID")
+LAUNCH_JOBKEY_THROTTLEINTERVAL = c_char_p("ThrottleInterval")
+LAUNCH_JOBKEY_LAUNCHONLYONCE = c_char_p("LaunchOnlyOnce")
+LAUNCH_JOBKEY_ABANDONPROCESSGROUP = c_char_p("AbandonProcessGroup")
+LAUNCH_JOBKEY_IGNOREPROCESSGROUPATSHUTDOWN = c_char_p("IgnoreProcessGroupAtShutdown")
+LAUNCH_JOBKEY_POLICIES = c_char_p("Policies")
+LAUNCH_JOBKEY_ENABLETRANSACTIONS = c_char_p("EnableTransactions")
 
-LAUNCH_JOBPOLICY_DENYCREATINGOTHERJOBS		= c_char_p("DenyCreatingOtherJobs")
+LAUNCH_JOBPOLICY_DENYCREATINGOTHERJOBS = c_char_p("DenyCreatingOtherJobs")
 
-LAUNCH_JOBINETDCOMPATIBILITY_WAIT			= c_char_p("Wait")
+LAUNCH_JOBINETDCOMPATIBILITY_WAIT = c_char_p("Wait")
 
-LAUNCH_JOBKEY_MACH_RESETATCLOSE				= c_char_p("ResetAtClose")
-LAUNCH_JOBKEY_MACH_HIDEUNTILCHECKIN			= c_char_p("HideUntilCheckIn")
-LAUNCH_JOBKEY_MACH_DRAINMESSAGESONCRASH		= c_char_p("DrainMessagesOnCrash")
+LAUNCH_JOBKEY_MACH_RESETATCLOSE = c_char_p("ResetAtClose")
+LAUNCH_JOBKEY_MACH_HIDEUNTILCHECKIN = c_char_p("HideUntilCheckIn")
+LAUNCH_JOBKEY_MACH_DRAINMESSAGESONCRASH = c_char_p("DrainMessagesOnCrash")
 
-LAUNCH_JOBKEY_KEEPALIVE_SUCCESSFULEXIT		= c_char_p("SuccessfulExit")
-LAUNCH_JOBKEY_KEEPALIVE_NETWORKSTATE		= c_char_p("NetworkState")
-LAUNCH_JOBKEY_KEEPALIVE_PATHSTATE			= c_char_p("PathState")
-LAUNCH_JOBKEY_KEEPALIVE_OTHERJOBACTIVE		= c_char_p("OtherJobActive")
-LAUNCH_JOBKEY_KEEPALIVE_OTHERJOBENABLED		= c_char_p("OtherJobEnabled")
-LAUNCH_JOBKEY_KEEPALIVE_AFTERINITIALDEMAND	= c_char_p("AfterInitialDemand")
+LAUNCH_JOBKEY_KEEPALIVE_SUCCESSFULEXIT = c_char_p("SuccessfulExit")
+LAUNCH_JOBKEY_KEEPALIVE_NETWORKSTATE = c_char_p("NetworkState")
+LAUNCH_JOBKEY_KEEPALIVE_PATHSTATE = c_char_p("PathState")
+LAUNCH_JOBKEY_KEEPALIVE_OTHERJOBACTIVE = c_char_p("OtherJobActive")
+LAUNCH_JOBKEY_KEEPALIVE_OTHERJOBENABLED = c_char_p("OtherJobEnabled")
+LAUNCH_JOBKEY_KEEPALIVE_AFTERINITIALDEMAND = c_char_p("AfterInitialDemand")
 
-LAUNCH_JOBKEY_CAL_MINUTE					= c_char_p("Minute")
-LAUNCH_JOBKEY_CAL_HOUR						= c_char_p("Hour")
-LAUNCH_JOBKEY_CAL_DAY						= c_char_p("Day")
-LAUNCH_JOBKEY_CAL_WEEKDAY					= c_char_p("Weekday")
-LAUNCH_JOBKEY_CAL_MONTH						= c_char_p("Month")
+LAUNCH_JOBKEY_CAL_MINUTE = c_char_p("Minute")
+LAUNCH_JOBKEY_CAL_HOUR = c_char_p("Hour")
+LAUNCH_JOBKEY_CAL_DAY = c_char_p("Day")
+LAUNCH_JOBKEY_CAL_WEEKDAY = c_char_p("Weekday")
+LAUNCH_JOBKEY_CAL_MONTH = c_char_p("Month")
 
-LAUNCH_JOBKEY_RESOURCELIMIT_CORE			= c_char_p("Core")
-LAUNCH_JOBKEY_RESOURCELIMIT_CPU				= c_char_p("CPU")
-LAUNCH_JOBKEY_RESOURCELIMIT_DATA			= c_char_p("Data")
-LAUNCH_JOBKEY_RESOURCELIMIT_FSIZE			= c_char_p("FileSize")
-LAUNCH_JOBKEY_RESOURCELIMIT_MEMLOCK			= c_char_p("MemoryLock")
-LAUNCH_JOBKEY_RESOURCELIMIT_NOFILE			= c_char_p("NumberOfFiles")
-LAUNCH_JOBKEY_RESOURCELIMIT_NPROC			= c_char_p("NumberOfProcesses")
-LAUNCH_JOBKEY_RESOURCELIMIT_RSS				= c_char_p("ResidentSetSize")
-LAUNCH_JOBKEY_RESOURCELIMIT_STACK			= c_char_p("Stack")
+LAUNCH_JOBKEY_RESOURCELIMIT_CORE = c_char_p("Core")
+LAUNCH_JOBKEY_RESOURCELIMIT_CPU = c_char_p("CPU")
+LAUNCH_JOBKEY_RESOURCELIMIT_DATA = c_char_p("Data")
+LAUNCH_JOBKEY_RESOURCELIMIT_FSIZE = c_char_p("FileSize")
+LAUNCH_JOBKEY_RESOURCELIMIT_MEMLOCK = c_char_p("MemoryLock")
+LAUNCH_JOBKEY_RESOURCELIMIT_NOFILE = c_char_p("NumberOfFiles")
+LAUNCH_JOBKEY_RESOURCELIMIT_NPROC = c_char_p("NumberOfProcesses")
+LAUNCH_JOBKEY_RESOURCELIMIT_RSS = c_char_p("ResidentSetSize")
+LAUNCH_JOBKEY_RESOURCELIMIT_STACK = c_char_p("Stack")
 
-LAUNCH_JOBKEY_DISABLED_MACHINETYPE			= c_char_p("MachineType")
-LAUNCH_JOBKEY_DISABLED_MODELNAME			= c_char_p("ModelName")
+LAUNCH_JOBKEY_DISABLED_MACHINETYPE = c_char_p("MachineType")
+LAUNCH_JOBKEY_DISABLED_MODELNAME = c_char_p("ModelName")
 
-LAUNCH_JOBSOCKETKEY_TYPE					= c_char_p("SockType")
-LAUNCH_JOBSOCKETKEY_PASSIVE					= c_char_p("SockPassive")
-LAUNCH_JOBSOCKETKEY_BONJOUR					= c_char_p("Bonjour")
-LAUNCH_JOBSOCKETKEY_SECUREWITHKEY			= c_char_p("SecureSocketWithKey")
-LAUNCH_JOBSOCKETKEY_PATHNAME				= c_char_p("SockPathName")
-LAUNCH_JOBSOCKETKEY_PATHMODE				= c_char_p("SockPathMode")
-LAUNCH_JOBSOCKETKEY_NODENAME				= c_char_p("SockNodeName")
-LAUNCH_JOBSOCKETKEY_SERVICENAME				= c_char_p("SockServiceName")
-LAUNCH_JOBSOCKETKEY_FAMILY					= c_char_p("SockFamily")
-LAUNCH_JOBSOCKETKEY_PROTOCOL				= c_char_p("SockProtocol")
-LAUNCH_JOBSOCKETKEY_MULTICASTGROUP			= c_char_p("MulticastGroup")
+LAUNCH_JOBSOCKETKEY_TYPE = c_char_p("SockType")
+LAUNCH_JOBSOCKETKEY_PASSIVE = c_char_p("SockPassive")
+LAUNCH_JOBSOCKETKEY_BONJOUR = c_char_p("Bonjour")
+LAUNCH_JOBSOCKETKEY_SECUREWITHKEY = c_char_p("SecureSocketWithKey")
+LAUNCH_JOBSOCKETKEY_PATHNAME = c_char_p("SockPathName")
+LAUNCH_JOBSOCKETKEY_PATHMODE = c_char_p("SockPathMode")
+LAUNCH_JOBSOCKETKEY_NODENAME = c_char_p("SockNodeName")
+LAUNCH_JOBSOCKETKEY_SERVICENAME = c_char_p("SockServiceName")
+LAUNCH_JOBSOCKETKEY_FAMILY = c_char_p("SockFamily")
+LAUNCH_JOBSOCKETKEY_PROTOCOL = c_char_p("SockProtocol")
+LAUNCH_JOBSOCKETKEY_MULTICASTGROUP = c_char_p("MulticastGroup")
 
 
 (
@@ -194,12 +195,13 @@ LAUNCH_JOBSOCKETKEY_MULTICASTGROUP			= c_char_p("MulticastGroup")
     LAUNCH_DATA_STRING,
     LAUNCH_DATA_OPAQUE,
     LAUNCH_DATA_ERRNO,
-    LAUNCH_DATA_MACHPORT
+    LAUNCH_DATA_MACHPORT,
 ) = range(1, 11)
 
 
 class LaunchDCheckInError(Exception):
     pass
+
 
 def get_launchd_socket_fds():
     """Check in with launchd to get socket file descriptors."""
@@ -210,24 +212,28 @@ def get_launchd_socket_fds():
     # Callback for dict iterator.
     def add_socket(launch_array, name, context=None):
         if launch_data_get_type(launch_array) != LAUNCH_DATA_ARRAY:
-            raise LaunchDCheckInError("Could not get file descriptor array: Type mismatch")
+            raise LaunchDCheckInError(
+                "Could not get file descriptor array: Type mismatch"
+            )
         fds = list()
         for i in range(launch_data_array_get_count(launch_array)):
             data_fd = launch_data_array_get_index(launch_array, i)
             if launch_data_get_type(data_fd) != LAUNCH_DATA_FD:
-                raise LaunchDCheckInError("Could not get file descriptor array entry: Type mismatch")
+                raise LaunchDCheckInError(
+                    "Could not get file descriptor array entry: Type mismatch"
+                )
             fds.append(launch_data_get_fd(data_fd))
         launchd_socket_fds[name] = fds
 
     # Wrap in try/finally to free resources allocated during lookup.
     try:
         # Create a checkin request.
-        checkin_request = launch_data_new_string(LAUNCH_KEY_CHECKIN);
+        checkin_request = launch_data_new_string(LAUNCH_KEY_CHECKIN)
         if checkin_request == None:
             raise LaunchDCheckInError("Could not create checkin request")
 
         # Check the checkin response.
-        checkin_response = launch_msg(checkin_request);
+        checkin_response = launch_msg(checkin_request)
         if checkin_response == None:
             raise LaunchDCheckInError("Error checking in")
 
@@ -236,12 +242,16 @@ def get_launchd_socket_fds():
             raise LaunchDCheckInError("Checkin failed")
 
         # Get a dictionary of sockets.
-        sockets = launch_data_dict_lookup(checkin_response, LAUNCH_JOBKEY_SOCKETS);
+        sockets = launch_data_dict_lookup(checkin_response, LAUNCH_JOBKEY_SOCKETS)
         if sockets == None:
-            raise LaunchDCheckInError("Could not get socket dictionary from checkin response")
+            raise LaunchDCheckInError(
+                "Could not get socket dictionary from checkin response"
+            )
 
         if launch_data_get_type(sockets) != LAUNCH_DATA_DICTIONARY:
-            raise LaunchDCheckInError("Could not get socket dictionary from checkin response: Type mismatch")
+            raise LaunchDCheckInError(
+                "Could not get socket dictionary from checkin response: Type mismatch"
+            )
 
         # Iterate over the items with add_socket callback.
         launch_data_dict_iterate(sockets, DICTITCALLBACK(add_socket), None)

--- a/Code/autopkgserver/launch2.py
+++ b/Code/autopkgserver/launch2.py
@@ -17,12 +17,17 @@
 import os
 from ctypes import *
 
+
 libc = CDLL("/usr/lib/libc.dylib")
 
 
 # int launch_activate_socket(const char *name, int **fds, size_t *cnt)
 libc.launch_activate_socket.restype = c_int
-libc.launch_activate_socket.argtypes = [c_char_p, POINTER(POINTER(c_int)), POINTER(c_size_t)]
+libc.launch_activate_socket.argtypes = [
+    c_char_p,
+    POINTER(POINTER(c_int)),
+    POINTER(c_size_t),
+]
 
 
 class LaunchDError(Exception):
@@ -38,7 +43,9 @@ def launch_activate_socket(name):
         cnt = c_size_t(0)
         err = libc.launch_activate_socket(name, byref(fds), byref(cnt))
         if err:
-            raise LaunchDError("Failed to retrieve sockets from launchd: %s" % os.strerror(err))
+            raise LaunchDError(
+                "Failed to retrieve sockets from launchd: %s" % os.strerror(err)
+            )
 
         # Return a list of file descriptors.
         return list(fds[x] for x in xrange(cnt.value))

--- a/Scripts/generate_processor_docs.py
+++ b/Scripts/generate_processor_docs.py
@@ -25,7 +25,8 @@ import sys
 from tempfile import mkdtemp
 from textwrap import dedent
 
-#pylint: disable=import-error
+
+# pylint: disable=import-error
 # Grabbing some functions from the Code directory
 try:
     CODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../Code"))
@@ -44,14 +45,14 @@ try:
 except ImportError:
     print("Unable to import code from autopkg!", file=sys.stderr)
     sys.exit(1)
-#pylint: enable=import-error
+# pylint: enable=import-error
 
 
 def writefile(stringdata, path):
     """Writes string data to path."""
     try:
-        fileobject = open(path, mode='w', buffering=1)
-        print(stringdata.encode('UTF-8'), file=fileobject)
+        fileobject = open(path, mode="w", buffering=1)
+        print(stringdata.encode("UTF-8"), file=fileobject)
         fileobject.close()
     except (OSError, IOError):
         print("Couldn't write to %s" % path, file=fileobject)
@@ -74,8 +75,7 @@ def generate_markdown(dict_data, indent=0):
             string += " " * indent + "- **%s:**\n" % escape(key)
             string += generate_markdown(value, indent=indent + 4)
         else:
-            string += (" " * indent + "- **%s:** %s\n"
-                       % (escape(key), escape(value)))
+            string += " " * indent + "- **%s:** %s\n" % (escape(key), escape(value))
     return string
 
 
@@ -119,10 +119,7 @@ def generate_sidebar(sidebar_path):
         if line == processor_heading:
             past_processors_section = True
             processors_start = index
-        if (
-            (indent_length(line) <= section_indent)
-            and past_processors_section
-        ):
+        if (indent_length(line) <= section_indent) and past_processors_section:
             processors_end = index
 
     # Build the new sidebar
@@ -136,28 +133,34 @@ def generate_sidebar(sidebar_path):
 
 def main(_):
     """Do it all"""
-    usage = dedent("""%prog VERSION
+    usage = dedent(
+        """%prog VERSION
 
-    ..where VERSION is the release version for which docs are being generated.""")
+    ..where VERSION is the release version for which docs are being generated."""
+    )
     parser = optparse.OptionParser(usage=usage)
     parser.description = (
         "Generate GitHub Wiki documentation from the core processors present "
         "in autopkglib. The autopkg.wiki repo is cloned locally, changes are "
         "committed, a diff shown and the user is interactively given the "
-        "option to push to the remote.")
+        "option to push to the remote."
+    )
     parser.add_option(
-        "-d", "--directory", metavar="CLONEDIRECTORY",
+        "-d",
+        "--directory",
+        metavar="CLONEDIRECTORY",
         help=(
             "Directory path in which to clone the repo. If not "
             "specified, a temporary directory will be used."
-        )
+        ),
     )
     parser.add_option(
-        "-p", "--processor",
+        "-p",
+        "--processor",
         help=(
             "Generate changes for only a specific processor. "
             "This does not update the Sidebar."
-        )
+        ),
     )
     options, arguments = parser.parse_args()
     if len(arguments) < 1:
@@ -247,7 +250,8 @@ def main(_):
         "Shown above is the commit log for the changes to the wiki markdown. \n"
         "Type 'push' to accept and push the changes to GitHub. The wiki repo \n"
         "local clone can be also inspected at:\n"
-        "%s." % output_dir)
+        "%s." % output_dir
+    )
 
     push_commit = raw_input()
     if push_commit == "push":

--- a/Scripts/make_new_release.py
+++ b/Scripts/make_new_release.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Script to run the AutoPkg GitHub release workflow as outlined here:
-#https://github.com/autopkg/autopkg/wiki/Packaging-AutoPkg-For-Release-on-GitHub
+# https://github.com/autopkg/autopkg/wiki/Packaging-AutoPkg-For-Release-on-GitHub
 #
 # This includes tagging and setting appropriate release notes for the release,
 # uploading the actual built package, and incrementing the version number for
@@ -34,11 +34,18 @@ from time import strftime
 
 class GitHubAPIError(BaseException):
     """Base error for GitHub API interactions"""
+
     pass
 
 
-def api_call(endpoint, token, baseurl='https://api.github.com', data=None,
-             json_data=True, additional_headers=None):
+def api_call(
+    endpoint,
+    token,
+    baseurl="https://api.github.com",
+    data=None,
+    json_data=True,
+    additional_headers=None,
+):
     """endpoint: of the form '/repos/username/repo/etc'.
     token: the API token for Authorization.
     baseurl: the base URL for the API endpoint. for asset uploads this ends up
@@ -48,8 +55,10 @@ def api_call(endpoint, token, baseurl='https://api.github.com', data=None,
     additional_headers: a dict of additional headers for the API call"""
     if data and json_data:
         data = json.dumps(data, ensure_ascii=False)
-    headers = {'Accept': 'application/vnd.github.v3+json',
-               'Authorization': 'token %s' % token}
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": "token %s" % token,
+    }
     if additional_headers:
         for header, value in additional_headers.items():
             headers[header] = value
@@ -62,7 +71,7 @@ def api_call(endpoint, token, baseurl='https://api.github.com', data=None,
         print(err, file=sys.stderr)
         error_json = err.read()
         error = json.loads(error_json)
-        print("API message: %s" % error['message'], file=sys.stderr)
+        print("API message: %s" % error["message"], file=sys.stderr)
         sys.exit(1)
     if results:
         try:
@@ -93,24 +102,40 @@ def main():
     """
     usage = __doc__
     parser = optparse.OptionParser(usage=usage)
-    parser.add_option('-t', '--token',
-                      help="GitHub API OAuth token. Required.")
-    parser.add_option('-v', '--next-version',
-                      help=("Next version to which AutoPkg will be "
-                            "incremented. Required."))
-    parser.add_option('-p', '--prerelease',
-                      help=("Mark this release as a pre-release, applying "
-                            "a given suffix to the tag, i.e. 'RC1'"))
-    parser.add_option('--dry-run', action='store_true',
-                      help=("Don't actually push any changes to "
-                            "Git remotes, and skip the actual release "
-                            "creation. Useful for testing changes "
-                            "to this script. Any GitHub API calls made "
-                            "are read-only."))
-    parser.add_option('--user-repo', default='autopkg/autopkg',
-                      help=("Alternate org/user and repo to use for "
-                            "the release, useful for testing. Defaults to "
-                            "'autopkg/autopkg'."))
+    parser.add_option("-t", "--token", help="GitHub API OAuth token. Required.")
+    parser.add_option(
+        "-v",
+        "--next-version",
+        help=("Next version to which AutoPkg will be " "incremented. Required."),
+    )
+    parser.add_option(
+        "-p",
+        "--prerelease",
+        help=(
+            "Mark this release as a pre-release, applying "
+            "a given suffix to the tag, i.e. 'RC1'"
+        ),
+    )
+    parser.add_option(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Don't actually push any changes to "
+            "Git remotes, and skip the actual release "
+            "creation. Useful for testing changes "
+            "to this script. Any GitHub API calls made "
+            "are read-only."
+        ),
+    )
+    parser.add_option(
+        "--user-repo",
+        default="autopkg/autopkg",
+        help=(
+            "Alternate org/user and repo to use for "
+            "the release, useful for testing. Defaults to "
+            "'autopkg/autopkg'."
+        ),
+    )
 
     opts = parser.parse_args()[0]
     if not opts.next_version:
@@ -120,93 +145,107 @@ def main():
     next_version = opts.next_version
     if opts.dry_run:
         print("Running in 'dry-run' mode..")
-    publish_user, publish_repo = opts.user_repo.split('/')
+    publish_user, publish_repo = opts.user_repo.split("/")
     token = opts.token
 
     # ensure our OAuth token works before we go any further
-    api_call('/users/%s' % publish_user, token)
+    api_call("/users/%s" % publish_user, token)
 
     # set up some paths and important variables
     autopkg_root = tempfile.mkdtemp()
-    version_plist_path = os.path.join(autopkg_root,
-                                      'Code/autopkglib/version.plist')
-    changelog_path = os.path.join(autopkg_root, 'CHANGELOG.md')
+    version_plist_path = os.path.join(autopkg_root, "Code/autopkglib/version.plist")
+    changelog_path = os.path.join(autopkg_root, "CHANGELOG.md")
 
     # clone Git master
     subprocess.check_call(
-        ['git', 'clone',
-         'https://github.com/%s/%s' % (publish_user, publish_repo),
-         autopkg_root])
+        [
+            "git",
+            "clone",
+            "https://github.com/%s/%s" % (publish_user, publish_repo),
+            autopkg_root,
+        ]
+    )
     os.chdir(autopkg_root)
 
     # get the current autopkg version
     try:
         plist = plistlib.readPlist(version_plist_path)
-        current_version = plist['Version']
+        current_version = plist["Version"]
     except BaseException:
         sys.exit("Couldn't determine current autopkg version!")
     print("Current AutoPkg version: %s" % current_version)
     if LooseVersion(next_version) <= LooseVersion(current_version):
         sys.exit(
             "Next version (gave %s) must be greater than current version %s!"
-            % (next_version, current_version))
+            % (next_version, current_version)
+        )
 
-    tag_name = 'v%s' % current_version
+    tag_name = "v%s" % current_version
     if opts.prerelease:
         tag_name += opts.prerelease
     published_releases = api_call(
-        '/repos/%s/%s/releases' % (publish_user, publish_repo), token)
+        "/repos/%s/%s/releases" % (publish_user, publish_repo), token
+    )
     for rel in published_releases:
-        if rel['tag_name'] == tag_name:
+        if rel["tag_name"] == tag_name:
             print(
                 "There's already a published release on GitHub with the tag "
                 "{0}. It should first be manually removed. "
                 "Release data printed below:".format(tag_name),
-                file=sys.stderr
+                file=sys.stderr,
             )
             pprint(rel, stream=sys.stderr)
             sys.exit()
 
     # write today's date in the changelog
-    with open(changelog_path, 'r') as fdesc:
+    with open(changelog_path, "r") as fdesc:
         changelog = fdesc.read()
-    release_date = strftime('(%B %d, %Y)')
-    new_changelog = re.sub(r'\(Unreleased\)', release_date, changelog)
-    new_changelog = re.sub('...HEAD', '...v%s' % current_version, new_changelog)
-    with open(changelog_path, 'w') as fdesc:
+    release_date = strftime("(%B %d, %Y)")
+    new_changelog = re.sub(r"\(Unreleased\)", release_date, changelog)
+    new_changelog = re.sub("...HEAD", "...v%s" % current_version, new_changelog)
+    with open(changelog_path, "w") as fdesc:
         fdesc.write(new_changelog)
 
     # commit and push the new release
-    subprocess.check_call(['git', 'add', changelog_path])
+    subprocess.check_call(["git", "add", changelog_path])
     subprocess.check_call(
-        ['git', 'commit', '-m', 'Release version %s.' % current_version])
-    subprocess.check_call(['git', 'tag', tag_name])
+        ["git", "commit", "-m", "Release version %s." % current_version]
+    )
+    subprocess.check_call(["git", "tag", tag_name])
     if not opts.dry_run:
-        subprocess.check_call(['git', 'push', 'origin', 'master'])
-        subprocess.check_call(['git', 'push', '--tags', 'origin', 'master'])
+        subprocess.check_call(["git", "push", "origin", "master"])
+        subprocess.check_call(["git", "push", "--tags", "origin", "master"])
 
     # extract release notes for this new version
     notes_rex = r"(?P<current_ver_notes>\#\#\# \[%s\].+?)\#\#\#" % current_version
     match = re.search(notes_rex, new_changelog, re.DOTALL)
     if not match:
         sys.exit("Couldn't extract release notes for this version!")
-    release_notes = match.group('current_ver_notes')
+    release_notes = match.group("current_ver_notes")
 
     # run the actual AutoPkg.pkg recipe
     recipes_dir = tempfile.mkdtemp()
     subprocess.check_call(
-        ['git', 'clone', 'https://github.com/autopkg/recipes', recipes_dir])
+        ["git", "clone", "https://github.com/autopkg/recipes", recipes_dir]
+    )
     # running using the system AutoPkg directory so that we ensure we're at the
     # minimum required version to run the AutoPkg recipe
     report_plist_path = tempfile.mkstemp()[1]
-    proc = subprocess.Popen(['/Library/AutoPkg/autopkg',
-                             'run',
-                             '-k', 'force_pkg_build=true',
-                             '--search-dir', recipes_dir,
-                             '--report-plist', report_plist_path,
-                             'AutoPkgGitMaster.pkg'],
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+    proc = subprocess.Popen(
+        [
+            "/Library/AutoPkg/autopkg",
+            "run",
+            "-k",
+            "force_pkg_build=true",
+            "--search-dir",
+            recipes_dir,
+            "--report-plist",
+            report_plist_path,
+            "AutoPkgGitMaster.pkg",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     out, err = proc.communicate()
     print(out)
     print(err, file=sys.stderr)
@@ -214,85 +253,86 @@ def main():
         report = plistlib.readPlist(report_plist_path)
     except BaseException as err:
         print(
-            "Couldn't parse a valid report plist from the autopkg run!",
-            file=sys.stderr
+            "Couldn't parse a valid report plist from the autopkg run!", file=sys.stderr
         )
         sys.exit(err)
     os.remove(report_plist_path)
 
-    if report['failures']:
-        sys.exit("Recipe run error: %s" % report['failures'][0]['message'])
+    if report["failures"]:
+        sys.exit("Recipe run error: %s" % report["failures"][0]["message"])
 
     # collect pkg file data
-    pkg_result = report['summary_results']['pkg_creator_summary_result']
-    built_pkg_path = pkg_result['data_rows'][0]['pkg_path']
+    pkg_result = report["summary_results"]["pkg_creator_summary_result"]
+    built_pkg_path = pkg_result["data_rows"][0]["pkg_path"]
     pkg_filename = os.path.basename(built_pkg_path)
-    with open(built_pkg_path, 'rb') as fdesc:
+    with open(built_pkg_path, "rb") as fdesc:
         pkg_data = fdesc.read()
 
     # prepare release metadata
     release_data = dict()
-    release_data['tag_name'] = tag_name
-    release_data['target_commitish'] = 'master'
-    release_data['name'] = "AutoPkg " + current_version
-    release_data['body'] = release_notes
-    release_data['draft'] = False
+    release_data["tag_name"] = tag_name
+    release_data["target_commitish"] = "master"
+    release_data["name"] = "AutoPkg " + current_version
+    release_data["body"] = release_notes
+    release_data["draft"] = False
     if opts.prerelease:
-        release_data['prerelease'] = True
+        release_data["prerelease"] = True
 
     # create the release
     if not opts.dry_run:
         create_release = api_call(
-            '/repos/%s/%s/releases' % (publish_user, publish_repo),
+            "/repos/%s/%s/releases" % (publish_user, publish_repo),
             token,
-            data=release_data)
+            data=release_data,
+        )
         if create_release:
             print("Release successfully created. Server response:")
             pprint(create_release)
             print()
 
             # upload the pkg as a release asset
-            new_release_id = create_release['id']
-            endpoint = ('/repos/%s/%s/releases/%s/assets?name=%s'
-                        % (publish_user,
-                           publish_repo,
-                           new_release_id,
-                           pkg_filename))
+            new_release_id = create_release["id"]
+            endpoint = "/repos/%s/%s/releases/%s/assets?name=%s" % (
+                publish_user,
+                publish_repo,
+                new_release_id,
+                pkg_filename,
+            )
             upload_asset = api_call(
                 endpoint,
                 token,
-                baseurl='https://uploads.github.com',
+                baseurl="https://uploads.github.com",
                 data=pkg_data,
                 json_data=False,
-                additional_headers={'Content-Type': 'application/octet-stream'})
+                additional_headers={"Content-Type": "application/octet-stream"},
+            )
             if upload_asset:
-                print(
-                    "Successfully attached .pkg release asset. Server response:"
-                )
+                print("Successfully attached .pkg release asset. Server response:")
                 pprint(upload_asset)
                 print()
 
     # increment version
     print("Incrementing version to %s.." % next_version)
-    plist['Version'] = next_version
+    plist["Version"] = next_version
     plistlib.writePlist(plist, version_plist_path)
 
     # increment changelog
-    new_changelog = "### [{0}](https://github.com/{1}/{2}/compare/v{3}...HEAD) (Unreleased)\n\n".format(
-        next_version,
-        publish_user,
-        publish_repo,
-        current_version) + new_changelog
-    with open(changelog_path, 'w') as fdesc:
+    new_changelog = (
+        "### [{0}](https://github.com/{1}/{2}/compare/v{3}...HEAD) (Unreleased)\n\n".format(
+            next_version, publish_user, publish_repo, current_version
+        )
+        + new_changelog
+    )
+    with open(changelog_path, "w") as fdesc:
         fdesc.write(new_changelog)
 
     # commit and push increment
-    subprocess.check_call(['git', 'add', version_plist_path, changelog_path])
+    subprocess.check_call(["git", "add", version_plist_path, changelog_path])
     subprocess.check_call(
-        ['git', 'commit', '-m',
-         'Bumping to v%s for development.' % next_version])
+        ["git", "commit", "-m", "Bumping to v%s for development." % next_version]
+    )
     if not opts.dry_run:
-        subprocess.check_call(['git', 'push', 'origin', 'master'])
+        subprocess.check_call(["git", "push", "origin", "master"])
     else:
         print(
             "Ended dry-run mode. Final state of the AutoPkg repo can be "
@@ -302,5 +342,5 @@ def main():
     rmtree(recipes_dir)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
The time has come. This runs `black` through all code in AutoPkg.

Since there are no decisions to make, and no choices about what we like, don't like, etc., it's pretty much an all-or-nothing. I don't think there's that much value in doing this file-by-file, because there will be no difference in the outcome.

This was accomplished by installing Python3 using Greg Neagle's relocatable-python framework and using pip to install black, isort, and flake8, and then using the black from Python 3 to run on the autopkg github checkout.