### PR TITLE
Log instead of print

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -66,8 +66,8 @@ if sys.platform != "darwin":
 try:
     import FoundationPlist
 except:
-    print("WARNING: importing plistlib as FoundationPlist;")
-    print("WARNING: some plist formats will be unsupported")
+    log("WARNING: importing plistlib as FoundationPlist;")
+    log("WARNING: some plist formats will be unsupported")
     import plistlib as FoundationPlist
 
 # If any recipe fails during 'autopkg run', return this exit code
@@ -265,7 +265,7 @@ def locate_recipe(
             results = do_gh_code_search(query, use_token=False)
 
             if not results or not results.get("total_count"):
-                print("Nothing found.")
+                log("Nothing found.")
                 return None
 
             results_items = results["items"]
@@ -291,7 +291,7 @@ def locate_recipe(
             #                     if name.lower() in item['name'].lower()]
 
             if not results_items:
-                print("Nothing found.")
+                log("Nothing found.")
                 return None
 
             print_gh_search_results(results_items)
@@ -988,7 +988,7 @@ def search_recipes(argv):
 
     count = results.get("total_count", 0)
     if count == 0:
-        print("No results.")
+        log("No results.")
         return
 
     print_gh_search_results(results["items"])
@@ -1517,9 +1517,7 @@ def get_trust_info(recipe, search_dirs=None):
             processor_hash = getsha256hash(processor_path)
             git_hash = get_git_commit_hash(processor_path)
         else:
-            print(
-                "WARNING: processor path not found for %s" % processor, file=sys.stderr
-            )
+            log_err('WARNING: processor path not found for %s' % processor)
             processor_path = ""
             processor_hash = "PROCESSOR FILEPATH NOT FOUND"
             git_hash = None
@@ -1808,7 +1806,7 @@ def update_trust_info(argv):
         if "ParentRecipeTrustInfo" not in recipe and not recipe_in_override_dir(
             recipe_path, override_dirs
         ):
-            print("%s does not appear to be a recipe override." % recipe_name)
+            log("%s does not appear to be a recipe override." % recipe_name)
             if recipe_from_external_repo(recipe_path):
                 # don't offer to add parent trust info to a recipe from
                 # an external repo

--- a/Code/autopkglib/AppDmgVersioner.py
+++ b/Code/autopkglib/AppDmgVersioner.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 """See docstring for AppDmgVersioner class"""
 
-from __future__ import print_function
-
 import glob
 import os.path
 

--- a/Code/autopkglib/AppDmgVersioner.py
+++ b/Code/autopkglib/AppDmgVersioner.py
@@ -20,20 +20,19 @@ from __future__ import print_function
 import glob
 import os.path
 
-from autopkglib import ProcessorError
+from autopkglib import ProcessorError, log
 from autopkglib.DmgMounter import DmgMounter
-
 
 # pylint: disable=no-name-in-module
 try:
     from Foundation import NSData, NSPropertyListSerialization
     from Foundation import NSPropertyListMutableContainers
 except:
-    print(
+    log(
         "WARNING: Failed 'from Foundation import NSData, "
         "NSPropertyListSerialization' in " + __name__
     )
-    print(
+    log(
         "WARNING: Failed 'from Foundation import "
         "NSPropertyListMutableContainers' in " + __name__
     )

--- a/Code/autopkglib/DmgMounter.py
+++ b/Code/autopkglib/DmgMounter.py
@@ -21,8 +21,7 @@ import subprocess
 import sys
 
 import FoundationPlist
-from autopkglib import Processor, ProcessorError
-
+from autopkglib import Processor, ProcessorError, log, log_err
 
 __all__ = ["DmgMounter"]
 
@@ -191,10 +190,10 @@ if __name__ == "__main__":
     try:
         DMGMOUNTER = DmgMounter()
         MOUNTPOINT = DMGMOUNTER.mount("Download/Firefox-sv-SE.dmg")
-        print("Mounted at %s" % MOUNTPOINT)
+        log("Mounted at %s" % MOUNTPOINT)
         DMGMOUNTER.unmount("Download/Firefox-sv-SE.dmg")
     except ProcessorError as err:
-        print("ProcessorError: %s" % err, file=sys.stderr)
+        log_err("ProcessorError: %s" % err)
         sys.exit(10)
     else:
         sys.exit(0)

--- a/Code/autopkglib/DmgMounter.py
+++ b/Code/autopkglib/DmgMounter.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 """See docstring for DmgMounter class"""
 
-from __future__ import print_function
-
 import subprocess
 import sys
 

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -20,14 +20,13 @@ from __future__ import print_function
 import subprocess
 
 import FoundationPlist
-from autopkglib import Processor, ProcessorError
-
+from autopkglib import Processor, ProcessorError, log
 
 # pylint: disable=no-name-in-module
 try:
     from Foundation import NSDictionary
 except:
-    print("WARNING: Failed 'from Foundation import NSDictionary' in " + __name__)
+    log("WARNING: Failed 'from Foundation import NSDictionary' in " + __name__)
 # pylint: enable=no-name-in-module
 
 __all__ = ["MunkiInstallsItemsCreator"]

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 """See docstring for MunkiInstallsItemsCreator class"""
 
-from __future__ import print_function
-
 import subprocess
 
 import FoundationPlist

--- a/Code/autopkglib/MunkiSetDefaultCatalog.py
+++ b/Code/autopkglib/MunkiSetDefaultCatalog.py
@@ -16,14 +16,15 @@
 # limitations under the License.
 """See docstring for MunkiSetDefaultCatalog class"""
 
-from autopkglib import Processor
+from __future__ import print_function
 
+from autopkglib import Processor, log
 
 # pylint: disable=no-name-in-module
 try:
     from Foundation import CFPreferencesCopyAppValue
 except:
-    print(
+    log(
         "WARNING: Failed 'from Foundation import CFPreferencesCopyAppValue' "
         "in " + __name__
     )

--- a/Code/autopkglib/MunkiSetDefaultCatalog.py
+++ b/Code/autopkglib/MunkiSetDefaultCatalog.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 """See docstring for MunkiSetDefaultCatalog class"""
 
-from __future__ import print_function
-
 from autopkglib import Processor, log
 
 # pylint: disable=no-name-in-module

--- a/Code/autopkglib/StopProcessingIf.py
+++ b/Code/autopkglib/StopProcessingIf.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 """See docstring for StopProcessingIf class"""
 
-from __future__ import print_function
-
 from autopkglib import Processor, ProcessorError, log
 
 

--- a/Code/autopkglib/StopProcessingIf.py
+++ b/Code/autopkglib/StopProcessingIf.py
@@ -17,14 +17,14 @@
 
 from __future__ import print_function
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import Processor, ProcessorError, log
 
 
 # pylint: disable=no-name-in-module
 try:
     from Foundation import NSPredicate
 except:
-    print("WARNING: Failed 'from Foundation import NSPredicate' in " + __name__)
+    log("WARNING: Failed 'from Foundation import NSPredicate' in " + __name__)
 # pylint: disable=no-name-in-module
 
 __all__ = ["StopProcessingIf"]

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -78,10 +78,8 @@ try:
         kCFPreferencesCurrentHost,
     )
 except:
-    print(
-        "WARNING: Failed 'from Foundation import NSArray, NSDictionary' in " + __name__
-    )
-    print(
+    log("WARNING: Failed 'from Foundation import NSArray, NSDictionary' in " + __name__)
+    log(
         "WARNING: Failed 'from CoreFoundation import "
         "CFPreferencesAppSynchronize, ...' in " + __name__
     )
@@ -187,9 +185,8 @@ def get_identifier_from_recipe_file(filename):
         # __future__, which is a significant change requiring a lot of
         # testing. For now, we're going to leave this as-is until
         # the conversion to python3 is more mature.
-        print(
-            "WARNING: plist error for %s: %s" % (filename, unicode(err)),  # noqa TODO
-            file=sys.stderr,
+        log_err(
+            "WARNING: plist error for %s: %s" % (filename, unicode(err))  # noqa TODO
         )
         return None
     return get_identifier(recipe_plist)
@@ -247,10 +244,7 @@ def update_data(a_dict, key, value):
             try:
                 item = RE_KEYREF.sub(getdata, item)
             except KeyError as err:
-                print(
-                    "Use of undefined key in variable substitution: %s" % err,
-                    file=sys.stderr,
-                )
+                log_err("Use of undefined key in variable substitution: %s" % err)
         elif isinstance(item, (list, NSArray)):
             for index in range(len(item)):
                 item[index] = do_variable_substitution(item[index])
@@ -434,7 +428,7 @@ class Processor(object):
             self.main()
             self.write_output_plist()
         except ProcessorError as err:
-            print("ProcessorError: %s" % err, file=sys.stderr)
+            log_err("ProcessorError: %s" % err)
             sys.exit(10)
         else:
             sys.exit(0)
@@ -467,7 +461,7 @@ class AutoPackager(object):
         """Return the identifier given an input recipe plist."""
         identifier = recipe.get("Identifier") or recipe["Input"].get("IDENTIFIER")
         if not identifier:
-            print("ID NOT FOUND")
+            log("ID NOT FOUND")
             # build a pseudo-identifier based on the recipe pathname
             recipe_path = self.env.get("RECIPE_PATH")
             # get rid of filename extension
@@ -592,7 +586,7 @@ class AutoPackager(object):
                 # here to ensure that unexpected/unhandled exceptions
                 # from one processor do not prevent execution of
                 # subsequent recipes.
-                print(unicode(err), file=sys.stderr)  # noqa TODO
+                log_err(unicode(err))  # noqa TODO
                 raise AutoPackagerError(
                     "Error in %s: Processor: %s: Error: %s"
                     % (identifier, step["Processor"], unicode(err))
@@ -740,9 +734,7 @@ def get_processor(processor_name, recipe=None, env=None):
                 except (ImportError, AttributeError) as err:
                     # if we aren't successful, that might be OK, we're
                     # going see if the processor was already imported
-                    print(
-                        "WARNING: %s: %s" % (processor_filename, err), file=sys.stderr
-                    )
+                    log_err("WARNING: %s: %s" % (processor_filename, err))
 
     return globals()[processor_name]
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -461,7 +461,7 @@ class AutoPackager(object):
         """Return the identifier given an input recipe plist."""
         identifier = recipe.get("Identifier") or recipe["Input"].get("IDENTIFIER")
         if not identifier:
-            log("ID NOT FOUND")
+            log_err("ID NOT FOUND")
             # build a pseudo-identifier based on the recipe pathname
             recipe_path = self.env.get("RECIPE_PATH")
             # get rid of filename extension

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -21,10 +21,8 @@ import json
 import os
 import re
 import subprocess
-import sys
 
-from autopkglib import curl_cmd, get_pref
-
+from autopkglib import curl_cmd, get_pref, log, log_err
 
 BASE_URL = "https://api.github.com"
 TOKEN_LOCATION = os.path.expanduser("~/.autopkg_gh_token")
@@ -42,9 +40,8 @@ class GitHubSession(object):
                 with open(TOKEN_LOCATION, "r") as tokenf:
                     self.token = tokenf.read()
             except IOError as err:
-                print(
-                    "Couldn't read token file at %s! Error: %s" % (TOKEN_LOCATION, err),
-                    file=sys.stderr,
+                log_err(
+                    "Couldn't read token file at %s! Error: %s" % (TOKEN_LOCATION, err)
                 )
                 self.token = None
         else:
@@ -66,27 +63,25 @@ To save the token, paste it to the following prompt."""
 
             token = raw_input("Token: ")
             if token:
-                print("""Writing token file %s.""" % TOKEN_LOCATION)
+                log("""Writing token file %s.""" % TOKEN_LOCATION)
                 try:
                     with open(TOKEN_LOCATION, "w") as tokenf:
                         tokenf.write(token)
                     os.chmod(TOKEN_LOCATION, 0o600)
                 except IOError as err:
-                    print(
+                    log_err(
                         "Couldn't write token file at %s! Error: %s"
-                        % (TOKEN_LOCATION, err),
-                        file=sys.stderr,
+                        % (TOKEN_LOCATION, err)
                     )
             else:
-                print("Skipping token file creation.", file=sys.stderr)
+                log("Skipping token file creation.")
         else:
             try:
                 with open(TOKEN_LOCATION, "r") as tokenf:
                     token = tokenf.read()
             except IOError as err:
-                print(
-                    "Couldn't read token file at %s! Error: %s" % (TOKEN_LOCATION, err),
-                    file=sys.stderr,
+                log_err(
+                    "Couldn't read token file at %s! Error: %s" % (TOKEN_LOCATION, err)
                 )
 
             # TODO: validate token given we found one but haven't checked its
@@ -223,7 +218,7 @@ To save the token, paste it to the following prompt."""
                         m = re.match(r".* (?P<status_code>\d+) .*", curlerr)
                         if m.group("status_code"):
                             header["http_result_code"] = m.group("status_code")
-                print("Could not retrieve URL %s: %s" % (url, curlerr), file=sys.stderr)
+                log_err("Could not retrieve URL %s: %s" % (url, curlerr))
 
             if page_content:
                 resp_data = json.loads(page_content)
@@ -231,7 +226,7 @@ To save the token, paste it to the following prompt."""
                 resp_data = None
 
         except OSError:
-            print("Could not retrieve URL: %s" % url, file=sys.stderr)
+            log_err("Could not retrieve URL: %s" % url)
             resp_data = None
 
         http_result_code = int(header.get("http_result_code"))


### PR DESCRIPTION
This PR is the implementation of [suggestion](https://groups.google.com/d/msg/autopkg-discuss/YcO2oQR5JME/-19T870MAgAJ) in Google group [thread](https://groups.google.com/forum/#!topic/autopkg-discuss/YcO2oQR5JME) about Python2 EOL..

It does two things:

- ~~Moves `log()` and `log_err()` functions from `autopkg` to `autopkglib`. ba270f1~~ Already in master
- Replaces `print()` function with `log()` and `log_err()` where it makes sense. 1af50fd6d24ba8179227c053164ebef3c07c8ac8
- Remove now unnecessary `print_function` imports da82c92626d881415d81a15b76854633852a41fd
- Switch `ID NOT FOUND` message from stdout to stderr 5e06c381ed8b0bbfa3a6026566fd89715d824e93