### PR TITLE
Adding platform-specific determination functions

### DIFF
--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import glob
 import imp
 import os
+import platform
 import pprint
 import re
 import subprocess
@@ -28,6 +29,40 @@ import sys
 from distutils.version import LooseVersion
 
 import FoundationPlist
+
+
+class memoize(dict):
+    """Class to cache the return values of an expensive function.
+    This version supports only functions with non-keyword arguments"""
+
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args):
+        return self[args]
+
+    def __missing__(self, key):
+        result = self[key] = self.func(*key)
+        return result
+
+
+@memoize
+def is_mac():
+    """Return True if current OS is macOS."""
+    return "Darwin" in platform.platform()
+
+
+@memoize
+def is_windows():
+    """Return True if current OS is Windows."""
+    return "Windows" in platform.platform()
+
+
+@memoize
+def is_linux():
+    """Return True if current OS is Linux."""
+    return "Linux" in platform.platform()
+
 
 # pylint: disable=no-name-in-module
 try:


### PR DESCRIPTION
This opens the door for AutoPkg on alternative platforms. The memoization is so that we don't have to make another call to platforms() every time we want to do this lookup - the result is cached in each invocation.