### PR TITLE
Limit flake8 to python2 only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,9 @@ repos:
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: 'dc9ed97'  # Use the revision sha / tag you want to point at
     hooks:
-    -   id: isort
+    - id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3  # Use the ref you want to point at
     hooks:
-    -   id: flake8
+    - id: flake8
+      language_version: python2.7


### PR DESCRIPTION
Flake8 was being too aggressive, so let's limit to python-2 limitations only.

Also removed an extra spacing in the pre-commit file itself.

Before, with py3 flake8 being run (examples, results are edited for brevity):
```
$ pre-commit run --all-files
black....................................................................Passed
isort....................................................................Passed
Flake8...................................................................Failed
hookid: flake8

Code/autopkglib/github/__init__.py:66:21: F821 undefined name 'raw_input'
Code/FoundationPlist/FoundationPlist.py:144:12: F821 undefined name 'buffer'
Code/autopkgserver/launch.py:16:1: F403 'from ctypes import *' used; unable to detect undefined names
Code/autopkgserver/launch.py:18:8: F405 'CDLL' may be undefined, or defined from star imports: ctypes
...
```

After, the py2 vs. py3 things are no longer showing up:
```
$ pre-commit run --all-files
black....................................................................Passed
isort....................................................................Passed
Flake8...................................................................Failed
hookid: flake8

Code/autopkgserver/launch.py:16:1: F403 'from ctypes import *' used; unable to detect undefined names
Code/autopkgserver/launch.py:18:8: F405 'CDLL' may be undefined, or defined from star imports: ctypes
...
```