### PR TITLE
Adding some basic unit tests to AutoPkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # .DS_Store files!
 .DS_Store
 
-# don't track .pyc files
+# don't track .pyc files or autopkgc
 *.pyc
+autopkgc
 
 # IDE-specific files
 .vscode

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -78,8 +78,10 @@ try:
         kCFPreferencesCurrentHost,
     )
 except:
-    log("WARNING: Failed 'from Foundation import NSArray, NSDictionary' in " + __name__)
-    log(
+    print(
+        "WARNING: Failed 'from Foundation import NSArray, NSDictionary' in " + __name__
+    )
+    print(
         "WARNING: Failed 'from CoreFoundation import "
         "CFPreferencesAppSynchronize, ...' in " + __name__
     )

--- a/Code/tests/test_autopkglib.py
+++ b/Code/tests/test_autopkglib.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+
+import imp
+import plistlib
+import unittest
+from textwrap import dedent
+
+from mock import patch
+
+
+# DO NOT MOVE THIS! This needs to happen BEFORE importing autopkglib
+patch("autopkglib.memoize", lambda x: x).start()
+import autopkglib  # isort: skip
+
+autopkg = imp.load_source("autopkg", "autopkg")
+
+
+class TestAutoPkg(unittest.TestCase):
+    """Test class for AutoPkglib itself."""
+
+    def setUp(self):
+        # This forces autopkglib to accept our patching of memoize
+        imp.reload(autopkglib)
+        self.download_recipe = dedent(
+            """\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>Description</key>
+                <string>Downloads latest Google Chrome disk image.</string>
+                <key>Identifier</key>
+                <string>com.github.autopkg.download.googlechrome</string>
+                <key>Input</key>
+                <dict>
+                    <key>NAME</key>
+                    <string>GoogleChrome</string>
+                    <key>DOWNLOAD_URL</key>
+                    <string>https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg</string>
+                </dict>
+                <key>MinimumVersion</key>
+                <string>0.2.0</string>
+                <key>Process</key>
+                <array>
+                    <dict>
+                        <key>Processor</key>
+                        <string>URLDownloader</string>
+                        <key>Arguments</key>
+                        <dict>
+                            <key>url</key>
+                            <string>%DOWNLOAD_URL%</string>
+                            <key>filename</key>
+                            <string>%NAME%.dmg</string>
+                        </dict>
+                    </dict>
+                    <dict>
+                        <key>Processor</key>
+                        <string>EndOfCheckPhase</string>
+                    </dict>
+                    <dict>
+                        <key>Processor</key>
+                        <string>CodeSignatureVerifier</string>
+                        <key>Arguments</key>
+                        <dict>
+                            <key>input_path</key>
+                            <string>%pathname%/Google Chrome.app</string>
+                            <key>strict_verification</key>
+                            <false/>
+                            <key>requirement</key>
+                            <string>(identifier "com.google.Chrome" or identifier "com.google.Chrome.beta" or identifier "com.google.Chrome.dev" or identifier "com.google.Chrome.canary") and (certificate leaf = H"85cee8254216185620ddc8851c7a9fc4dfe120ef" or certificate leaf = H"c9a99324ca3fcb23dbcc36bd5fd4f9753305130a")</string>
+                        </dict>
+                    </dict>
+                </array>
+            </dict>
+            </plist>
+        """
+        )
+        self.munki_recipe = dedent(
+            """\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>Description</key>
+                <string>Downloads the latest Google Chrome disk image and imports into Munki.</string>
+                <key>Identifier</key>
+                <string>com.github.autopkg.munki.google-chrome</string>
+                <key>Input</key>
+                <dict>
+                    <key>NAME</key>
+                    <string>GoogleChrome</string>
+                    <key>MUNKI_REPO_SUBDIR</key>
+                    <string>apps</string>
+                    <key>pkginfo</key>
+                    <dict>
+                        <key>catalogs</key>
+                        <array>
+                            <string>testing</string>
+                        </array>
+                        <key>description</key>
+                        <string>Chrome is a fast, simple, and secure web browser, built for the modern web.</string>
+                        <key>display_name</key>
+                        <string>Google Chrome</string>
+                        <key>name</key>
+                        <string>%NAME%</string>
+                        <key>unattended_install</key>
+                        <true/>
+                    </dict>
+                </dict>
+                <key>MinimumVersion</key>
+                <string>0.2.0</string>
+                <key>ParentRecipe</key>
+                <string>com.github.autopkg.download.googlechrome</string>
+                <key>Process</key>
+                <array>
+                    <dict>
+                        <key>Arguments</key>
+                        <dict>
+                            <key>pkg_path</key>
+                            <string>%pathname%</string>
+                            <key>repo_subdirectory</key>
+                            <string>%MUNKI_REPO_SUBDIR%</string>
+                        </dict>
+                        <key>Processor</key>
+                        <string>MunkiImporter</string>
+                    </dict>
+                </array>
+            </dict>
+            </plist>
+        """
+        )
+
+    def tearDown(self):
+        pass
+
+    @patch("autopkglib.platform.platform")
+    def test_is_mac_returns_true_on_mac(self, mock_platform):
+        """On macOS, is_mac() should return True."""
+        mock_platform.return_value = "Darwin-somethingsomething"
+        result = autopkglib.is_mac()
+        self.assertEqual(result, True)
+
+    @patch("autopkglib.platform.platform")
+    def test_is_mac_returns_false_on_not_mac(self, mock_platform):
+        """On not-macOS, is_mac() should return False."""
+        mock_platform.return_value = "Windows-somethingsomething"
+        result = autopkglib.is_mac()
+        self.assertEqual(result, False)
+
+    @patch("autopkglib.platform.platform")
+    def test_is_windows_returns_true_on_windows(self, mock_platform):
+        """On Windows, is_windows() should return True."""
+        mock_platform.return_value = "Windows-somethingsomething"
+        result = autopkglib.is_windows()
+        self.assertEqual(result, True)
+
+    @patch("autopkglib.platform.platform")
+    def test_is_windows_returns_false_on_not_windows(self, mock_platform):
+        """On not-Windows, is_windows() should return False."""
+        mock_platform.return_value = "Darwin-somethingsomething"
+        result = autopkglib.is_windows()
+        self.assertEqual(result, False)
+
+    @patch("autopkglib.platform.platform")
+    def test_is_linux_returns_true_on_linux(self, mock_platform):
+        """On Linux, is_linux() should return True."""
+        mock_platform.return_value = "Linux-somethingsomething"
+        result = autopkglib.is_linux()
+        self.assertEqual(result, True)
+
+    @patch("autopkglib.platform.platform")
+    def test_is_linux_returns_false_on_not_linux(self, mock_platform):
+        """On not-Linux, is_linux() should return False."""
+        mock_platform.return_value = "Windows-somethingsomething"
+        result = autopkglib.is_linux()
+        self.assertEqual(result, False)
+
+    def test_get_identifier_returns_identifier(self):
+        """get_identifier should return the identifier."""
+        recipe = plistlib.readPlistFromString(self.download_recipe)
+        id = autopkglib.get_identifier(recipe)
+        self.assertEqual(id, "com.github.autopkg.download.googlechrome")
+
+    def test_get_identifier_returns_none(self):
+        """get_identifier should return None if no identifier is found."""
+        recipe = plistlib.readPlistFromString(self.download_recipe)
+        del recipe["Identifier"]
+        id = autopkglib.get_identifier(recipe)
+        self.assertIsNone(id)
+
+    @patch("autopkg.FoundationPlist.readPlist")
+    def test_get_identifier_from_recipe_file_returns_identifier(self, mock_read):
+        """get_identifier_from_recipe-file should return identifier."""
+        mock_read.return_value = plistlib.readPlistFromString(self.download_recipe)
+        id = autopkglib.get_identifier_from_recipe_file("fake")
+        self.assertEqual(id, "com.github.autopkg.download.googlechrome")
+
+    @patch("autopkg.FoundationPlist.readPlist")
+    def test_get_identifier_from_recipe_file_returns_none(self, mock_read):
+        """get_identifier_from_recipe-file should return None if no identifier."""
+        mock_read.return_value = plistlib.readPlistFromString(self.download_recipe)
+        del mock_read.return_value["Identifier"]
+        id = autopkglib.get_identifier_from_recipe_file("fake")
+        self.assertIsNone(id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Code/tests/test_filefinder.py
+++ b/Code/tests/test_filefinder.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import plistlib
+import StringIO
+import unittest
+
+import mock
+from autopkglib import ProcessorError
+from autopkglib.FileFinder import FileFinder
+
+
+class TestFileFinder(unittest.TestCase):
+    """Test class for FileFinder Processor."""
+
+    def setUp(self):
+        self.good_env = {"find_method": "glob", "pattern": "test"}
+        self.bad_env = {"find_method": "fake"}
+        self.input_plist = StringIO.StringIO(plistlib.writePlistToString(self.good_env))
+        self.processor = FileFinder(infile=self.input_plist)
+
+    def tearDown(self):
+        self.input_plist.close()
+
+    def test_raise_if_not_glob(self):
+        """Raise an exception if glob is not passed to find_method."""
+        self.processor.env = self.bad_env
+        with self.assertRaises(ProcessorError):
+            self.processor.main()
+
+    @mock.patch("autopkglib.FileFinder.globfind")
+    def test_no_fail_if_good_env(self, mock_glob):
+        """The processor should not raise any exceptions if run normally."""
+        self.processor.env = self.good_env
+        mock_glob.return_value = "test"
+        self.processor.main()
+
+    @mock.patch("autopkglib.FileFinder.globfind")
+    def test_found_a_match(self, mock_glob):
+        """If we find a match, it should be in the env."""
+        self.processor.env = self.good_env
+        mock_glob.return_value = "test"
+        self.processor.main()
+        self.assertEqual(self.processor.env["found_filename"], "test")
+
+    @mock.patch("autopkglib.FileFinder.unmount")
+    @mock.patch("autopkglib.FileFinder.mount")
+    @mock.patch("autopkglib.FileFinder.globfind")
+    def test_found_a_dmg_match(self, mock_glob, mock_mount, mock_unmount):
+        """If we find a match inside a DMG, it should be in the env."""
+        self.processor.env = {
+            "find_method": "glob",
+            "pattern": "/tmp/fake.dmg/whatever",
+        }
+        mock_mount.return_value = "/tmp/fake_dmg_mount"
+        mock_glob.return_value = "/tmp/fake_dmg_mount/whatever"
+        mock_unmount.return_value = None
+        self.processor.main()
+        self.assertEqual(self.processor.env["found_filename"], mock_glob.return_value)
+        self.assertEqual(self.processor.env["dmg_found_filename"], "whatever")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python2_requirements.txt
+++ b/python2_requirements.txt
@@ -6,6 +6,7 @@ contextlib2==0.5.5
 entrypoints==0.3
 enum34==1.1.6
 flake8==3.7.7
+funcsigs==1.0.2
 functools32==3.2.3.post2
 futures==3.2.0
 identify==1.4.3
@@ -13,6 +14,7 @@ importlib-metadata==0.13
 importlib-resources==1.0.2
 isort==4.3.20
 mccabe==0.6.1
+mock==3.0.5
 nodeenv==1.3.3
 pathlib2==2.3.3
 pre-commit==1.16.1


### PR DESCRIPTION
This gets the template in place for doing unit testing for AutoPkg. To start with, I provided a unit test for one Processor (FileFinder, because it's easy)

To run the tests, you can do it using the unittest module via the command line. You can do it in a virtualenv, or if you feel like messing with system python, you can install mock there:
```
$ PATH=/usr/bin python -m unittest discover
..............
----------------------------------------------------------------------
Ran 14 tests in 0.026s

OK
```

If you want verbose results for the tests:
```
$ PATH=/usr/bin python -m unittest discover -v
test_get_identifier_from_recipe_file_returns_identifier (tests.test_autopkglib.TestAutoPkg)
get_identifier_from_recipe-file should return identifier. ... ok
test_get_identifier_from_recipe_file_returns_none (tests.test_autopkglib.TestAutoPkg)
get_identifier_from_recipe-file should return None if no identifier. ... ok
test_get_identifier_returns_identifier (tests.test_autopkglib.TestAutoPkg)
get_identifier should return the identifier. ... ok
test_get_identifier_returns_none (tests.test_autopkglib.TestAutoPkg)
get_identifier should return None if no identifier is found. ... ok
test_is_linux_returns_false_on_not_linux (tests.test_autopkglib.TestAutoPkg)
On not-Linux, is_linux() should return False. ... ok
test_is_linux_returns_true_on_linux (tests.test_autopkglib.TestAutoPkg)
On Linux, is_linux() should return True. ... ok
test_is_mac_returns_false_on_not_mac (tests.test_autopkglib.TestAutoPkg)
On not-macOS, is_mac() should return False. ... ok
test_is_mac_returns_true_on_mac (tests.test_autopkglib.TestAutoPkg)
On macOS, is_mac() should return True. ... ok
test_is_windows_returns_false_on_not_windows (tests.test_autopkglib.TestAutoPkg)
On not-Windows, is_windows() should return False. ... ok
test_is_windows_returns_true_on_windows (tests.test_autopkglib.TestAutoPkg)
On Windows, is_windows() should return True. ... ok
test_found_a_dmg_match (tests.test_filefinder.TestFileFinder)
If we find a match inside a DMG, it should be in the env. ... ok
test_found_a_match (tests.test_filefinder.TestFileFinder)
If we find a match, it should be in the env. ... ok
test_no_fail_if_good_env (tests.test_filefinder.TestFileFinder)
The processor should not raise any exceptions if run normally. ... ok
test_raise_if_not_glob (tests.test_filefinder.TestFileFinder)
Raise an exception if glob is not passed to find_method. ... ok

----------------------------------------------------------------------
Ran 14 tests in 0.031s

OK
```

A screenshot from the test runner in Visual Studio Code:
![tests](https://user-images.githubusercontent.com/1202655/59526798-b71ad500-8e8e-11e9-8329-e56cf7b5815f.PNG)