### PR TITLE
URLDownloader refactoring using URLGetter

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 #
+# Refactoring 2018 Michal Moravec
 # Copyright 2015 Greg Neagle
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +17,10 @@
 """See docstring for URLDownloader class"""
 
 import os.path
-import subprocess
 import tempfile
-import time
 
-from autopkglib import BUNDLE_ID, Processor, ProcessorError, is_mac
+from autopkglib import BUNDLE_ID, ProcessorError, is_mac
+from autopkglib.URLGetter import URLGetter
 
 if is_mac():
     import xattr
@@ -28,20 +28,8 @@ if is_mac():
 
 __all__ = ["URLDownloader"]
 
-# XATTR names for Etag and Last-Modified headers
-XATTR_ETAG = "%s.etag" % BUNDLE_ID
-XATTR_LAST_MODIFIED = "%s.last-modified" % BUNDLE_ID
 
-
-def getxattr(pathname, attr):
-    """Get a named xattr from a file. Return None if not present"""
-    if attr in xattr.listxattr(pathname):
-        return xattr.getxattr(pathname, attr)
-    else:
-        return None
-
-
-class URLDownloader(Processor):
+class URLDownloader(URLGetter):
     """Downloads a URL to the specified download_dir using curl."""
 
     description = __doc__
@@ -116,57 +104,16 @@ class URLDownloader(Processor):
         },
     }
 
-    def main(self):
-        if not is_mac():
-            raise ProcessorError("This processor is Mac-only!")
-        # clear any pre-exising summary result
-        if "url_downloader_summary_result" in self.env:
-            del self.env["url_downloader_summary_result"]
+    def getxattr(self, attr):
+        """Get a named xattr from a file. Return None if not present"""
+        if attr in xattr.listxattr(self.env["pathname"]):
+            return xattr.getxattr(self.env["pathname"], attr)
+        return None
 
-        self.env["last_modified"] = ""
-        self.env["etag"] = ""
-        existing_file_size = None
-
-        if "PKG" in self.env:
-            self.env["pathname"] = os.path.expanduser(self.env["PKG"])
-            self.env["download_changed"] = True
-            self.output("Given %s, no download needed." % self.env["pathname"])
-            return
-
-        if "filename" not in self.env:
-            # Generate filename.
-            filename = self.env["url"].rpartition("/")[2]
-        else:
-            filename = self.env["filename"]
-        download_dir = self.env.get("download_dir") or os.path.join(
-            self.env["RECIPE_CACHE_DIR"], "downloads"
-        )
-        pathname = os.path.join(download_dir, filename)
-        # Save pathname to environment
-        self.env["pathname"] = pathname
-
-        # create download_dir if needed
-        if not os.path.exists(download_dir):
-            try:
-                os.makedirs(download_dir)
-            except OSError as err:
-                raise ProcessorError(
-                    "Can't create %s: %s" % (download_dir, err.strerror)
-                )
-
-        # Create a temp file
-        temporary_file = tempfile.NamedTemporaryFile(dir=download_dir, delete=False)
-        pathname_temporary = temporary_file.name
-        # Set permissions on the temp file as curl would set for a newly-downloaded
-        # file. NamedTemporaryFile uses mkstemp(), which sets a mode of 0600, and
-        # this can cause issues if this item is eventually copied to a Munki repo
-        # with the same permissions and the file is inaccessible by (for example)
-        # the webserver.
-        os.chmod(pathname_temporary, 0o644)
-
-        # construct curl command.
+    def prepare_curl_cmd(self, pathname_temporary):
+        """Assemble curl command and return it."""
         curl_cmd = [
-            self.env["CURL_PATH"],
+            super(URLDownloader, self).curl_binary(),
             "--silent",
             "--show-error",
             "--no-buffer",
@@ -182,117 +129,86 @@ class URLDownloader(Processor):
             pathname_temporary,
         ]
 
-        if "request_headers" in self.env:
-            headers = self.env["request_headers"]
-            for header, value in headers.items():
-                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+        super(URLDownloader, self).add_curl_common_opts(curl_cmd)
 
-        if "curl_opts" in self.env:
-            for item in self.env["curl_opts"]:
-                curl_cmd.extend([item])
-
-        # if file already exists and the size is 0, discard it and download
-        # again
-        if os.path.exists(pathname) and os.path.getsize(pathname) == 0:
-            os.remove(pathname)
+        # if file already exists and the size is 0, discard it and download again
+        if (
+            os.path.exists(self.env["pathname"])
+            and os.path.getsize(self.env["pathname"]) == 0
+        ):
+            os.remove(self.env["pathname"])
 
         # if file already exists, add some headers to the request
         # so we don't retrieve the content if it hasn't changed
-        if os.path.exists(pathname):
-            existing_file_size = os.path.getsize(pathname)
-            etag = getxattr(pathname, XATTR_ETAG)
-            last_modified = getxattr(pathname, XATTR_LAST_MODIFIED)
+        if os.path.exists(self.env["pathname"]):
+            self.existing_file_size = os.path.getsize(self.env["pathname"])
+            etag = self.getxattr(self.xattr_etag)
+            last_modified = self.getxattr(self.xattr_last_modified)
             if etag:
                 curl_cmd.extend(["--header", "If-None-Match: %s" % etag])
             if last_modified:
                 curl_cmd.extend(["--header", "If-Modified-Since: %s" % last_modified])
 
-        # Open URL.
-        proc = subprocess.Popen(
-            curl_cmd,
-            shell=False,
-            bufsize=1,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+        return curl_cmd
+
+    def clear_vars(self):
+        """Clear and initializace variables"""
+        # Delete summary result if exists
+        if "url_downloader_summary_result" in self.env:
+            del self.env["url_downloader_summary_result"]
+
+        # XATTR names for Etag and Last-Modified headers
+        self.xattr_etag = "%s.etag" % BUNDLE_ID
+        self.xattr_last_modified = "%s.last-modified" % BUNDLE_ID
+
+        self.env["last_modified"] = ""
+        self.env["etag"] = ""
+        self.existing_file_size = None
+
+    def get_filename(self):
+        """Obtain filename from PKG variable or URL."""
+        if "PKG" in self.env:
+            self.env["pathname"] = os.path.expanduser(self.env["PKG"])
+            self.env["download_changed"] = True
+            self.output("Given %s, no download needed." % self.env["pathname"])
+            return None
+
+        if "filename" in self.env:
+            filename = self.env["filename"]
+        else:
+            # Generate filename from URL.
+            filename = self.env["url"].rpartition("/")[2]
+
+        return filename
+
+    def get_download_dir(self):
+        """Create download dir and return its path."""
+        download_dir = self.env.get("download_dir") or os.path.join(
+            self.env["RECIPE_CACHE_DIR"], "downloads"
         )
-
-        donewithheaders = False
-        maxheaders = 15
-        header = {}
-        header["http_result_code"] = "000"
-        header["http_result_description"] = ""
-        while True:
-            if not donewithheaders:
-                info = proc.stdout.readline().strip("\r\n")
-                if info.startswith("HTTP/"):
-                    try:
-                        header["http_result_code"] = info.split(None, 2)[1]
-                        header["http_result_description"] = info.split(None, 2)[2]
-                    except IndexError:
-                        pass
-                elif ": " in info:
-                    # got a header line
-                    part = info.split(None, 1)
-                    fieldname = part[0].rstrip(":").lower()
-                    try:
-                        header[fieldname] = part[1]
-                    except IndexError:
-                        header[fieldname] = ""
-                elif self.env["url"].startswith("ftp://"):
-                    part = info.split(None, 1)
-                    responsecode = part[0]
-                    if responsecode == "213":
-                        # This is the reply to curl's SIZE command on the file
-                        # We can map it to the HTTP content-length header
-                        try:
-                            header["content-length"] = part[1]
-                        except IndexError:
-                            pass
-                    elif responsecode.startswith("55"):
-                        header["http_result_code"] = "404"
-                        header["http_result_description"] = info
-                    elif responsecode == "150" or responsecode == "125":
-                        header["http_result_code"] = "200"
-                        header["http_result_description"] = info
-                        donewithheaders = True
-                elif info == "":
-                    # we got an empty line; end of headers (or curl exited)
-                    if header.get("http_result_code") in [
-                        "301",
-                        "302",
-                        "303",
-                        "307",
-                        "308",
-                    ]:
-                        # redirect, so more headers are coming.
-                        # Throw away the headers we've received so far
-                        header = {}
-                        header["http_result_code"] = "000"
-                        header["http_result_description"] = ""
-                    else:
-                        donewithheaders = True
-            else:
-                time.sleep(0.1)
-
-            if proc.poll() is not None:
-                # For small download files curl may exit before all headers
-                # have been parsed, don't immediately exit.
-                maxheaders -= 1
-                if donewithheaders or maxheaders <= 0:
-                    break
-
-        retcode = proc.poll()
-        if retcode:  # Non-zero exit code from curl => problem with download
-            curlerr = ""
+        if not os.path.exists(download_dir):
             try:
-                curlerr = proc.stderr.read().rstrip("\n")
-                curlerr = curlerr.split(None, 2)[2]
-            except IndexError:
-                pass
+                os.makedirs(download_dir)
+            except OSError as err:
+                raise ProcessorError(
+                    "Can't create %s: %s" % (download_dir, err.strerror)
+                )
+        return download_dir
 
-            raise ProcessorError("Curl failure: %s (exit code %s)" % (curlerr, retcode))
+    def create_temp_file(self, download_dir):
+        """Create temporary file and return its path."""
+        temporary_file = tempfile.NamedTemporaryFile(dir=download_dir, delete=False)
+        pathname_temporary = temporary_file.name
+        # Set permissions on the temp file as curl would set for a newly-downloaded
+        # file. NamedTemporaryFile uses mkstemp(), which sets a mode of 0600, and
+        # this can cause issues if this item is eventually copied to a Munki repo
+        # with the same permissions and the file is inaccessible by (for example)
+        # the webserver.
+        os.chmod(pathname_temporary, 0o644)
+        return pathname_temporary
 
+    def download_changed(self, header):
+        """Check if downloaded file changed on server."""
         # If Content-Length header is present and we had a cached
         # file, see if it matches the size of the cached file.
         # Useful for webservers that don't provide Last-Modified
@@ -301,7 +217,7 @@ class URLDownloader(Processor):
             "CHECK_FILESIZE_ONLY"
         ]:
             size_header = header.get("content-length")
-            if size_header and int(size_header) == existing_file_size:
+            if size_header and int(size_header) == self.existing_file_size:
                 self.env["download_changed"] = False
                 self.output(
                     "File size returned by webserver matches that "
@@ -312,50 +228,90 @@ class URLDownloader(Processor):
                     "fallback mechanism that does not guarantee "
                     "that a build is unchanged."
                 )
-                self.output("Using existing %s" % pathname)
-                return
+                self.output("Using existing %s" % self.env["pathname"])
+                return False
 
         if header["http_result_code"] == "304":
             # resource not modified
             self.env["download_changed"] = False
             self.output("Item at URL is unchanged.")
-            self.output("Using existing %s" % pathname)
+            self.output("Using existing %s" % self.env["pathname"])
+            return False
 
-            # Discard the temp file
-            os.remove(pathname_temporary)
+        return True
 
-            return
-
-        self.env["download_changed"] = True
-
-        # New resource was downloaded. Move the temporary download file
-        # to the pathname
-        if os.path.exists(pathname):
-            os.remove(pathname)
+    def move_temp_file(self, pathname_temporary):
+        """Move temporary download file to pathname."""
+        if os.path.exists(self.env["pathname"]):
+            os.remove(self.env["pathname"])
         try:
-            os.rename(pathname_temporary, pathname)
+            os.rename(pathname_temporary, self.env["pathname"])
         except OSError:
-            raise ProcessorError("Can't move %s to %s" % (pathname_temporary, pathname))
+            raise ProcessorError(
+                "Can't move %s to %s" % (pathname_temporary, self.env["pathname"])
+            )
 
-        # save last-modified header if it exists
+    def store_headers(self, header):
+        """Store last-modified and etag headers in pathname xattr."""
         if header.get("last-modified"):
             self.env["last_modified"] = header.get("last-modified")
-            xattr.setxattr(pathname, XATTR_LAST_MODIFIED, header.get("last-modified"))
+            xattr.setxattr(
+                self.env["pathname"],
+                self.xattr_last_modified,
+                header.get("last-modified"),
+            )
             self.output(
                 "Storing new Last-Modified header: %s" % header.get("last-modified")
             )
 
-        # save etag if it exists
         self.env["etag"] = ""
         if header.get("etag"):
             self.env["etag"] = header.get("etag")
-            xattr.setxattr(pathname, XATTR_ETAG, header.get("etag"))
+            xattr.setxattr(self.env["pathname"], self.xattr_etag, header.get("etag"))
             self.output("Storing new ETag header: %s" % header.get("etag"))
 
-        self.output("Downloaded %s" % pathname)
+    def main(self):
+        if not is_mac():
+            raise ProcessorError("This processor is Mac-only!")
+
+        # Clear and initiazize data structures
+        self.clear_vars()
+
+        # Ensure existence of necessary files, directories and paths
+        filename = self.get_filename()
+        if filename is None:
+            return
+        download_dir = self.get_download_dir()
+        self.env["pathname"] = os.path.join(download_dir, filename)
+        pathname_temporary = self.create_temp_file(download_dir)
+
+        # Prepare curl command
+        curl_cmd = self.prepare_curl_cmd(pathname_temporary)
+
+        # Execute curl command and parse headers
+        raw_header = super(URLDownloader, self).download(curl_cmd)
+        header = {}
+        super(URLDownloader, self).clear_header(header)
+        super(URLDownloader, self).parse_headers(raw_header, header)
+
+        if self.download_changed(header):
+            self.env["download_changed"] = True
+        else:
+            # Discard the temp file
+            os.remove(pathname_temporary)
+            return
+
+        # New resource was downloaded. Move the temporary download file to the pathname
+        self.move_temp_file(pathname_temporary)
+
+        # Save last-modified and etag headers to files xattr
+        self.store_headers(header)
+
+        # Generate output messages and variables
+        self.output("Downloaded %s" % self.env["pathname"])
         self.env["url_downloader_summary_result"] = {
             "summary_text": "The following new items were downloaded:",
-            "data": {"download_path": pathname},
+            "data": {"download_path": self.env["pathname"]},
         }
 
 

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python
+#
+# Copyright 2018 Michal Moravec
+# Based on code from Greg Neagle, Timothy Sutton and Per Olofsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for URLGetter class"""
+
+import os.path
+import subprocess
+
+from autopkglib import Processor, ProcessorError, get_pref, log_err
+
+__all__ = ["URLGetter"]
+
+
+class URLGetter(Processor):
+    """Handles curl HTTP operatios. Server only as superclass. Not for direct use."""
+
+    description = __doc__
+
+    def curl_binary(self):
+        """Returns a path to a curl binary, priority in the order below.
+        Returns None if none found.
+        1. env['CURL_PATH']
+        2. app pref 'CURL_PATH'
+        3. a 'curl' binary that can be found in the PATH environment variable
+        4. '/usr/bin/curl'
+        """
+
+        def is_executable(exe_path):
+            """Is exe_path executable?"""
+            return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
+
+        if "CURL_PATH" in self.env and is_executable(self.env["CURL_PATH"]):
+            return self.env["CURL_PATH"]
+
+        curl_path_pref = get_pref("CURL_PATH")
+        if curl_path_pref:
+            if is_executable(curl_path_pref):
+                # take a CURL_PATH pref
+                return curl_path_pref
+            else:
+                log_err(
+                    "WARNING: Curl path given in the 'CURL_PATH' preference:'%s' "
+                    "either doesn't exist or is not executable! Falling back "
+                    "to one set in PATH, or /usr/bin/curl." % curl_path_pref
+                )
+
+        for path_env in os.environ["PATH"].split(":"):
+            curlbin = os.path.join(path_env, "curl")
+            if is_executable(curlbin):
+                # take the first 'curl' in PATH that we find
+                return curlbin
+
+        if is_executable("/usr/bin/curl"):
+            # fall back to /usr/bin/curl
+            return "/usr/bin/curl"
+
+        raise ProcessorError("Unable to execute any curl binary")
+
+    def add_curl_common_opts(self, curl_cmd):
+        """Adds request_headers and curl_opts to curl_cmd"""
+        if "request_headers" in self.env:
+            headers = self.env["request_headers"]
+            for header, value in headers.items():
+                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+        if "curl_opts" in self.env:
+            for item in self.env["curl_opts"]:
+                curl_cmd.extend([item])
+
+    def clear_header(self, header):
+        """Clear header dictionary"""
+        header.clear()
+        header["http_result_code"] = "000"
+        header["http_result_description"] = ""
+
+    def parse_http_protocol(self, line, header):
+        """Parse first HTTP header line"""
+        try:
+            header["http_result_code"] = line.split(None, 2)[1]
+            header["http_result_description"] = line.split(None, 2)[2]
+        except IndexError:
+            pass
+
+    def parse_http_header(self, line, header):
+        """Parse single HTTP header line."""
+        part = line.split(None, 1)
+        fieldname = part[0].rstrip(":").lower()
+        try:
+            header[fieldname] = part[1]
+        except IndexError:
+            header[fieldname] = ""
+
+    def parse_curl_error(self, proc_stderr):
+        """Report Curl failure."""
+        curl_err = ""
+        try:
+            curl_err = proc_stderr.rstrip("\n")
+            curl_err = curl_err.split(None, 2)[2]
+        except IndexError:
+            pass
+
+        return curl_err
+
+    def parse_ftp_header(self, line, header):
+        """Parse single FTP header line."""
+        part = line.split(None, 1)
+        responsecode = part[0]
+        if responsecode == "213":
+            # This is the reply to curl's SIZE command on the file
+            # We can map it to the HTTP content-length header
+            try:
+                header["content-length"] = part[1]
+            except IndexError:
+                pass
+        elif responsecode.startswith("55"):
+            header["http_result_code"] = "404"
+            header["http_result_description"] = line
+        elif responsecode == "150" or responsecode == "125":
+            header["http_result_code"] = "200"
+            header["http_result_description"] = line
+
+    def parse_headers(self, proc_stdout, header):
+        """Parse headers from Curl."""
+        for line in proc_stdout.splitlines():
+            if line.startswith("HTTP/"):
+                self.parse_http_protocol(line, header)
+            elif ": " in line:
+                self.parse_http_header(line, header)
+            elif self.env["url"].startswith("ftp://"):
+                self.parse_ftp_header(line, header)
+            elif line == "":
+                # we got an empty line; end of headers (or curl exited)
+                if header.get("http_result_code") in [
+                    "301",
+                    "302",
+                    "303",
+                    "307",
+                    "308",
+                ]:
+                    # redirect, so more headers are coming.
+                    # Throw away the headers we've received so far
+                    self.clear_header(header)
+
+    def execute_curl(self, curl_cmd):
+        """Executes curl comamnd. Returns stdout, stderr and return code."""
+        proc = subprocess.Popen(
+            curl_cmd,
+            shell=False,
+            bufsize=1,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        proc_stdout, proc_stderr = proc.communicate()
+        retcode = proc.returncode
+
+        return proc_stdout, proc_stderr, retcode
+
+    def download(self, curl_cmd):
+        """Launches curl returns its output and handles failures."""
+
+        proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)
+
+        if retcode:  # Non-zero exit code from curl => problem with download
+            curl_err = self.parse_curl_error(proc_stderr)
+            raise ProcessorError(
+                "Curl failure: %s (exit code %s)" % (curl_err, retcode)
+            )
+
+        return proc_stdout
+
+    def main(self):
+        pass
+
+
+if __name__ == "__main__":
+    PROCESSOR = URLGetter()
+    PROCESSOR.execute_shell()

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -71,13 +71,11 @@ class URLGetter(Processor):
 
     def add_curl_common_opts(self, curl_cmd):
         """Adds request_headers and curl_opts to curl_cmd"""
-        if "request_headers" in self.env:
-            headers = self.env["request_headers"]
-            for header, value in headers.items():
-                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
-        if "curl_opts" in self.env:
-            for item in self.env["curl_opts"]:
-                curl_cmd.extend([item])
+        for header, value in self.env.get("request_headers", {}).items():
+            curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+
+        for item in self.env.get("curl_opts", []):
+            curl_cmd.extend([item])
 
     def clear_header(self, header):
         """Clear header dictionary"""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -19,7 +19,7 @@
 import os.path
 import subprocess
 
-from autopkglib import Processor, ProcessorError, get_pref, log_err
+from autopkglib import Processor, ProcessorError, get_pref, is_executable, log_err
 
 __all__ = ["URLGetter"]
 
@@ -37,10 +37,6 @@ class URLGetter(Processor):
         3. a 'curl' binary that can be found in the PATH environment variable
         4. '/usr/bin/curl'
         """
-
-        def is_executable(exe_path):
-            """Is exe_path executable?"""
-            return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
 
         if "CURL_PATH" in self.env and is_executable(self.env["CURL_PATH"]):
             return self.env["CURL_PATH"]

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -48,7 +48,6 @@ class URLGetter(Processor):
         curl_path_pref = get_pref("CURL_PATH")
         if curl_path_pref:
             if is_executable(curl_path_pref):
-                # take a CURL_PATH pref
                 return curl_path_pref
             else:
                 log_err(
@@ -60,11 +59,9 @@ class URLGetter(Processor):
         for path_env in os.environ["PATH"].split(":"):
             curlbin = os.path.join(path_env, "curl")
             if is_executable(curlbin):
-                # take the first 'curl' in PATH that we find
                 return curlbin
 
         if is_executable("/usr/bin/curl"):
-            # fall back to /usr/bin/curl
             return "/usr/bin/curl"
 
         raise ProcessorError("Unable to execute any curl binary")

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -64,7 +64,7 @@ class URLGetter(Processor):
         if is_executable("/usr/bin/curl"):
             return "/usr/bin/curl"
 
-        raise ProcessorError("Unable to execute any curl binary")
+        raise ProcessorError("Unable to locate or execute any curl binary")
 
     def add_curl_common_opts(self, curl_cmd):
         """Adds request_headers and curl_opts to curl_cmd"""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -163,9 +163,8 @@ class URLGetter(Processor):
         )
 
         proc_stdout, proc_stderr = proc.communicate()
-        retcode = proc.returncode
 
-        return proc_stdout, proc_stderr, retcode
+        return proc_stdout, proc_stderr, proc.returncode
 
     def download(self, curl_cmd):
         """Launches curl returns its output and handles failures."""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -25,13 +25,13 @@ __all__ = ["URLGetter"]
 
 
 class URLGetter(Processor):
-    """Handles curl HTTP operatios. Server only as superclass. Not for direct use."""
+    """Handles curl HTTP operations. Serves only as superclass. Not for direct use."""
 
     description = __doc__
 
     def curl_binary(self):
-        """Returns a path to a curl binary, priority in the order below.
-        Returns None if none found.
+        """Return a path to a curl binary, priority in the order below.
+        Return None if none found.
         1. env['CURL_PATH']
         2. app pref 'CURL_PATH'
         3. a 'curl' binary that can be found in the PATH environment variable
@@ -47,7 +47,7 @@ class URLGetter(Processor):
                 return curl_path_pref
             else:
                 log_err(
-                    "WARNING: Curl path given in the 'CURL_PATH' preference:'%s' "
+                    "WARNING: curl path given in the 'CURL_PATH' preference:'%s' "
                     "either doesn't exist or is not executable! Falling back "
                     "to one set in PATH, or /usr/bin/curl." % curl_path_pref
                 )
@@ -63,7 +63,7 @@ class URLGetter(Processor):
         raise ProcessorError("Unable to locate or execute any curl binary")
 
     def add_curl_common_opts(self, curl_cmd):
-        """Adds request_headers and curl_opts to curl_cmd"""
+        """Add request_headers and curl_opts to curl_cmd"""
         for header, value in self.env.get("request_headers", {}).items():
             curl_cmd.extend(["--header", "%s: %s" % (header, value)])
 
@@ -94,7 +94,7 @@ class URLGetter(Processor):
             header[fieldname] = ""
 
     def parse_curl_error(self, proc_stderr):
-        """Report Curl failure."""
+        """Report curl failure."""
         curl_err = ""
         try:
             curl_err = proc_stderr.rstrip("\n")
@@ -123,7 +123,7 @@ class URLGetter(Processor):
             header["http_result_description"] = line
 
     def parse_headers(self, proc_stdout, header):
-        """Parse headers from Curl."""
+        """Parse headers from curl."""
         for line in proc_stdout.splitlines():
             if line.startswith("HTTP/"):
                 self.parse_http_protocol(line, header)
@@ -145,7 +145,7 @@ class URLGetter(Processor):
                     self.clear_header(header)
 
     def execute_curl(self, curl_cmd):
-        """Executes curl comamnd. Returns stdout, stderr and return code."""
+        """Execute curl comamnd. Return stdout, stderr and return code."""
         proc = subprocess.Popen(
             curl_cmd,
             shell=False,
@@ -160,14 +160,14 @@ class URLGetter(Processor):
         return proc_stdout, proc_stderr, proc.returncode
 
     def download(self, curl_cmd):
-        """Launches curl returns its output and handles failures."""
+        """Launch curl, return its output, and handle failures."""
 
         proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)
 
         if retcode:  # Non-zero exit code from curl => problem with download
             curl_err = self.parse_curl_error(proc_stderr)
             raise ProcessorError(
-                "Curl failure: %s (exit code %s)" % (curl_err, retcode)
+                "curl failure: %s (exit code %s)" % (curl_err, retcode)
             )
 
         return proc_stdout

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -265,6 +265,11 @@ def update_data(a_dict, key, value):
     a_dict[key] = do_variable_substitution(value)
 
 
+def is_executable(exe_path):
+    """Is exe_path executable?"""
+    return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
+
+
 def curl_cmd():
     """Returns a path to a curl binary, priority in the order below.
     Returns None if none found.
@@ -272,10 +277,6 @@ def curl_cmd():
     2. a 'curl' binary that can be found in the PATH environment variable
     3. '/usr/bin/curl'
     """
-
-    def is_executable(exe_path):
-        """Is exe_path executable?"""
-        return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
 
     curl_path_pref = get_pref("CURL_PATH")
     if curl_path_pref:


### PR DESCRIPTION
This PR was split from #446. It should be merged **after** PR #544 (`URLGetter`). Branch `urlgetter-urldownloader` includes code from branch `urlgetter` in order for `URLDownloader` to work. `URLGetter` should be reviewed in #544.

`URLDownloader` was refactored in following way:

- `URLDownloader` is now subclass of `URLGetter`
- Functionality like executing `curl` and parsing headers was moved to `URLGetter`
- xattr code outside of class was moved into the class
- Method `main()` was split into many methods
- Some local variables are now instance variables