### PR TITLE
SparkleUpdateInfoProvider refactoring using URLGetter

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -321,10 +321,7 @@ class SparkleUpdateInfoProvider(URLGetter):
             return
 
         # handle custom xmlns and version attributes
-        if "alternate_xmlns_url" in self.env:
-            self.xmlns = self.env["alternate_xmlns_url"]
-        else:
-            self.xmlns = DEFAULT_XMLNS
+        self.xmlns = self.env.get("alternate_xmlns_url", DEFAULT_XMLNS)
 
         data = self.get_feed_data(self.env.get("appcast_url"))
         items = self.parse_feed_data(data)
@@ -340,10 +337,7 @@ class SparkleUpdateInfoProvider(URLGetter):
         pkginfo = self.handle_pkginfo(latest)
 
         self.env["url"] = latest["url"]
-        if latest.get("human_version"):
-            self.env["version"] = latest["human_version"]
-        else:
-            self.env["version"] = latest["version"]
+        self.env["version"] = latest.get("human_version", latest["version"])
         self.output("Found URL %s" % self.env["url"])
         self.env["additional_pkginfo"] = pkginfo
 

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -142,15 +142,10 @@ class SparkleUpdateInfoProvider(URLGetter):
 
     def fetch_content(self, url, headers=None):
         """Returns content retrieved by curl, given a url and an optional
-        dictionary of header-name/value mappings. Logic here borrowed from
-        URLTextSearcher processor."""
+        dictionary of header-name/value mappings."""
 
         curl_cmd = self.prepare_curl_cmd(url, headers)
-        try:
-            content = super(SparkleUpdateInfoProvider, self).download(curl_cmd)
-        except ProcessorError:
-            raise ProcessorError("Could not retrieve URL: %s" % url)
-
+        content = super(SparkleUpdateInfoProvider, self).download(curl_cmd)
         return content
 
     def get_feed_data(self, url):

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 #
+# Refactoring 2018 Michal Moravec
 # Copyright 2013-2016 Timothy Sutton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,14 +18,14 @@
 """See docstring for SparkleUpdateInfoProvider class"""
 
 import os
-import subprocess
 import urllib
 import urlparse
 from distutils.version import LooseVersion
 from operator import itemgetter
 from xml.etree import ElementTree
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import ProcessorError
+from autopkglib.URLGetter import URLGetter
 
 __all__ = ["SparkleUpdateInfoProvider"]
 
@@ -32,7 +33,7 @@ DEFAULT_XMLNS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
 SUPPORTED_ADDITIONAL_PKGINFO_KEYS = ["description", "minimum_os_version"]
 
 
-class SparkleUpdateInfoProvider(Processor):
+class SparkleUpdateInfoProvider(URLGetter):
     """Provides URL to the highest version number or latest update."""
 
     description = __doc__
@@ -58,6 +59,12 @@ class SparkleUpdateInfoProvider(Processor):
                 "Alternate URL for the XML namespace, if the "
                 "appcast is using an alternate one. Defaults to "
                 "that used for 'vanilla' Sparkle appcasts."
+            ),
+        },
+        "curl_opts": {
+            "required": False,
+            "description": (
+                "Optional array of options to include with the download " "request."
             ),
         },
         "pkginfo_keys_to_copy_from_sparkle_feed": {
@@ -118,27 +125,88 @@ class SparkleUpdateInfoProvider(Processor):
         },
     }
 
+    def prepare_curl_cmd(self, url, headers=None):
+        """Assemble curl command and return it."""
+
+        curl_cmd = [
+            super(SparkleUpdateInfoProvider, self).curl_binary(),
+            "--location",
+            "--compressed",
+        ]
+        super(SparkleUpdateInfoProvider, self).add_curl_common_opts(curl_cmd)
+        if headers:
+            for header, value in headers.items():
+                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+        curl_cmd.append(url)
+        return curl_cmd
+
     def fetch_content(self, url, headers=None):
         """Returns content retrieved by curl, given a url and an optional
         dictionary of header-name/value mappings. Logic here borrowed from
         URLTextSearcher processor."""
 
+        curl_cmd = self.prepare_curl_cmd(url, headers)
         try:
-            cmd = [self.env["CURL_PATH"], "--location", "--compressed"]
-            if headers:
-                for header, value in headers.items():
-                    cmd.extend(["--header", "%s: %s" % (header, value)])
-            cmd.append(url)
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (data, stderr) = proc.communicate()
-            if proc.returncode:
-                raise ProcessorError("Could not retrieve URL %s: %s" % (url, stderr))
-        except OSError:
+            content = super(SparkleUpdateInfoProvider, self).download(curl_cmd)
+        except ProcessorError:
             raise ProcessorError("Could not retrieve URL: %s" % url)
 
-        return data
+        return content
 
     def get_feed_data(self, url):
+        """Downloads raw feed XML"""
+
+        # query string
+        if "appcast_query_pairs" in self.env:
+            queries = self.env["appcast_query_pairs"]
+            new_query = urllib.urlencode([(k, v) for (k, v) in queries.items()])
+            scheme, netloc, path, _, frag = urlparse.urlsplit(url)
+            url = urlparse.urlunsplit((scheme, netloc, path, new_query, frag))
+
+        data = self.fetch_content(url, headers=self.env.get("appcast_request_headers"))
+        return data
+
+    def build_url(self, enclosure):
+        """URL-quote the path component to handle spaces, etc.
+        (Panic apps do this)"""
+
+        url_bits = urlparse.urlsplit(enclosure.get("url"))
+        if self.env.get("urlencode_path_component", True):
+            encoded_path = urllib.quote(url_bits.path)
+        else:
+            encoded_path = url_bits.path
+        built_url = url_bits.scheme + "://" + url_bits.netloc + encoded_path
+        if url_bits.query:
+            built_url += "?" + url_bits.query
+        return built_url
+
+    def determine_version(self, enclosure, url):
+        """Gets version from enclosure"""
+
+        version = enclosure.get("{%s}version" % self.xmlns)
+
+        if version is None:
+            # Sparkle tries to guess a version from the download URL for
+            # rare cases where there is no sparkle:version enclosure
+            # attribute, for the format: AppnameOrAnything_1.2.3.zip
+            # https://github.com/sparkle-project/Sparkle/blob/
+            # 89081ca030c0de218400f7c0f97530df524d687d/Sparkle/
+            # SUAppcastItem.m#L69-L76
+            #
+            # We can even support OmniGroup's alternate appcast format
+            # by cheating and using the '-' as a delimiter to derive
+            # version info
+            filename = os.path.basename(os.path.splitext(url)[0])
+            for delimiter in ["_", "-"]:
+                if delimiter in filename:
+                    version = filename.split(delimiter)[-1]
+                    break
+        # if we still found nothing, fail
+        if version is None:
+            raise ProcessorError("Can't extract version info from item in feed!")
+        return version
+
+    def parse_feed_data(self, data):
         """Returns an array of dicts, one per update item, structured like:
         version: 1234
         human_version: 1.2.3.4 (optional)
@@ -153,20 +221,6 @@ class SparkleUpdateInfoProvider(Processor):
         metadata we're never going to use. If it's a URL, this must be handled
         by whoever calls this function."""
 
-        # handle custom xmlns and version attributes
-        if "alternate_xmlns_url" in self.env:
-            xmlns = self.env["alternate_xmlns_url"]
-        else:
-            xmlns = DEFAULT_XMLNS
-
-        # query string
-        if "appcast_query_pairs" in self.env:
-            queries = self.env["appcast_query_pairs"]
-            new_query = urllib.urlencode([(k, v) for (k, v) in queries.items()])
-            scheme, netloc, path, _, frag = urlparse.urlsplit(url)
-            url = urlparse.urlunsplit((scheme, netloc, path, new_query, frag))
-
-        data = self.fetch_content(url, headers=self.env.get("appcast_request_headers"))
         try:
             xmldata = ElementTree.fromstring(data)
         except:
@@ -181,98 +235,34 @@ class SparkleUpdateInfoProvider(Processor):
             enclosure = item_elem.find("enclosure")
             if enclosure is not None:
                 item = {}
-                # URL-quote the path component to handle spaces, etc.
-                # (Panic apps do this)
-                url_bits = urlparse.urlsplit(enclosure.get("url"))
-                if self.env.get("urlencode_path_component", True):
-                    encoded_path = urllib.quote(url_bits.path)
-                else:
-                    encoded_path = url_bits.path
-                built_url = url_bits.scheme + "://" + url_bits.netloc + encoded_path
-                if url_bits.query:
-                    built_url += "?" + url_bits.query
-                item["url"] = built_url
+                item["url"] = self.build_url(enclosure)
+                item["version"] = self.determine_version(enclosure, item["url"])
 
-                item["version"] = enclosure.get("{%s}version" % xmlns)
-                if item["version"] is None:
-                    # Sparkle tries to guess a version from the download URL for
-                    # rare cases where there is no sparkle:version enclosure
-                    # attribute, for the format: AppnameOrAnything_1.2.3.zip
-                    # https://github.com/sparkle-project/Sparkle/blob/
-                    # 89081ca030c0de218400f7c0f97530df524d687d/Sparkle/
-                    # SUAppcastItem.m#L69-L76
-                    #
-                    # We can even support OmniGroup's alternate appcast format
-                    # by cheating and using the '-' as a delimiter to derive
-                    # version info
-                    filename = os.path.basename(os.path.splitext(item["url"])[0])
-                    for delimiter in ["_", "-"]:
-                        if delimiter in filename:
-                            item["version"] = filename.split(delimiter)[-1]
-                            break
-                # if we still found nothing, fail
-                if item["version"] is None:
-                    raise ProcessorError(
-                        "Can't extract version info from item in feed!"
-                    )
-
-                human_version = enclosure.get("{%s}shortVersionString" % xmlns)
+                human_version = enclosure.get("{%s}shortVersionString" % self.xmlns)
                 if human_version is not None:
                     item["human_version"] = human_version
-                min_version = item_elem.find("{%s}minimumSystemVersion" % xmlns)
+
+                min_version = item_elem.find("{%s}minimumSystemVersion" % self.xmlns)
                 if min_version is not None:
                     item["minimum_os_version"] = min_version.text
-                description_elem = item_elem.find("{%s}releaseNotesLink" % xmlns)
+
+                description_elem = item_elem.find("{%s}releaseNotesLink" % self.xmlns)
                 # Strip possible surrounding whitespace around description_url
                 # element text as we'll be passing this as an argument to a
                 # curl process
                 if description_elem is not None:
                     item["description_url"] = description_elem.text.strip()
+
                 if item_elem.find("description") is not None:
                     item["description_data"] = item_elem.find("description").text
                 versions.append(item)
 
         return versions
 
-    def main(self):
-        """Get URL for latest version in update feed"""
-
-        def compare_version(this, that):
-            """Compare loose versions"""
-            # cmp() doesn't exist in Python3, so this uses the suggested
-            # solutions from What's New In Python 3.0:
-            # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
-            # This will be refactored in Python 3.
-            this_comparison = LooseVersion(this) > LooseVersion(that)
-            that_comparison = LooseVersion(this) < LooseVersion(that)
-            return this_comparison - that_comparison
-
-        if "PKG" in self.env:
-            self.output("Local PKG provided, no downloaded needed.")
-            self.output(
-                "WARNING: Skipping this processor means output "
-                "variables 'version', 'additional_pkginfo' will "
-                "not contain useful info. If these are needed "
-                "in other recipe steps, this may give unexpected "
-                "results."
-            )
-            self.env["url"] = self.env.get("PKG")
-            self.env["additional_pkginfo"] = {}
-            self.env["version"] = "NotSetBySparkleUpdateInfoProvider"
-            return
-
-        items = self.get_feed_data(self.env.get("appcast_url"))
-        sorted_items = sorted(items, key=itemgetter("version"), cmp=compare_version)
-        latest = sorted_items[-1]
-        self.output("Version retrieved from appcast: %s" % latest["version"])
-        if latest.get("human_version"):
-            self.output(
-                "User-facing version retrieved from appcast: %s"
-                % latest["human_version"]
-            )
+    def handle_pkginfo(self, latest):
+        """Handles any keys we may have defined"""
 
         pkginfo = {}
-        # Handle any keys we may have defined
         sparkle_pkginfo_keys = self.env.get("pkginfo_keys_to_copy_from_sparkle_feed")
         if sparkle_pkginfo_keys:
             for k in sparkle_pkginfo_keys:
@@ -301,6 +291,53 @@ class SparkleUpdateInfoProvider(Processor):
                     "Copied key %s from Sparkle feed to additional "
                     "pkginfo." % copied_key
                 )
+        return pkginfo
+
+    def main(self):
+        """Get URL for latest version in update feed"""
+
+        def compare_version(this, that):
+            """Compare loose versions"""
+            # cmp() doesn't exist in Python3, so this uses the suggested
+            # solutions from What's New In Python 3.0:
+            # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
+            # This will be refactored in Python 3.
+            this_comparison = LooseVersion(this) > LooseVersion(that)
+            that_comparison = LooseVersion(this) < LooseVersion(that)
+            return this_comparison - that_comparison
+
+        if "PKG" in self.env:
+            self.output("Local PKG provided, no downloaded needed.")
+            self.output(
+                "WARNING: Skipping this processor means output "
+                "variables 'version', 'additional_pkginfo' will "
+                "not contain useful info. If these are needed "
+                "in other recipe steps, this may give unexpected "
+                "results."
+            )
+            self.env["url"] = self.env.get("PKG")
+            self.env["additional_pkginfo"] = {}
+            self.env["version"] = "NotSetBySparkleUpdateInfoProvider"
+            return
+
+        # handle custom xmlns and version attributes
+        if "alternate_xmlns_url" in self.env:
+            self.xmlns = self.env["alternate_xmlns_url"]
+        else:
+            self.xmlns = DEFAULT_XMLNS
+
+        data = self.get_feed_data(self.env.get("appcast_url"))
+        items = self.parse_feed_data(data)
+        sorted_items = sorted(items, key=itemgetter("version"), cmp=compare_version)
+        latest = sorted_items[-1]
+        self.output("Version retrieved from appcast: %s" % latest["version"])
+        if latest.get("human_version"):
+            self.output(
+                "User-facing version retrieved from appcast: %s"
+                % latest["human_version"]
+            )
+
+        pkginfo = self.handle_pkginfo(latest)
 
         self.env["url"] = latest["url"]
         if latest.get("human_version"):

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python
+#
+# Copyright 2018 Michal Moravec
+# Based on code from Greg Neagle, Timothy Sutton and Per Olofsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for URLGetter class"""
+
+import os.path
+import subprocess
+
+from autopkglib import Processor, ProcessorError, get_pref, log_err
+
+__all__ = ["URLGetter"]
+
+
+class URLGetter(Processor):
+    """Handles curl HTTP operatios. Server only as superclass. Not for direct use."""
+
+    description = __doc__
+
+    def curl_binary(self):
+        """Returns a path to a curl binary, priority in the order below.
+        Returns None if none found.
+        1. env['CURL_PATH']
+        2. app pref 'CURL_PATH'
+        3. a 'curl' binary that can be found in the PATH environment variable
+        4. '/usr/bin/curl'
+        """
+
+        def is_executable(exe_path):
+            """Is exe_path executable?"""
+            return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
+
+        if "CURL_PATH" in self.env and is_executable(self.env["CURL_PATH"]):
+            return self.env["CURL_PATH"]
+
+        curl_path_pref = get_pref("CURL_PATH")
+        if curl_path_pref:
+            if is_executable(curl_path_pref):
+                # take a CURL_PATH pref
+                return curl_path_pref
+            else:
+                log_err(
+                    "WARNING: Curl path given in the 'CURL_PATH' preference:'%s' "
+                    "either doesn't exist or is not executable! Falling back "
+                    "to one set in PATH, or /usr/bin/curl." % curl_path_pref
+                )
+
+        for path_env in os.environ["PATH"].split(":"):
+            curlbin = os.path.join(path_env, "curl")
+            if is_executable(curlbin):
+                # take the first 'curl' in PATH that we find
+                return curlbin
+
+        if is_executable("/usr/bin/curl"):
+            # fall back to /usr/bin/curl
+            return "/usr/bin/curl"
+
+        raise ProcessorError("Unable to execute any curl binary")
+
+    def add_curl_common_opts(self, curl_cmd):
+        """Adds request_headers and curl_opts to curl_cmd"""
+        if "request_headers" in self.env:
+            headers = self.env["request_headers"]
+            for header, value in headers.items():
+                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+        if "curl_opts" in self.env:
+            for item in self.env["curl_opts"]:
+                curl_cmd.extend([item])
+
+    def clear_header(self, header):
+        """Clear header dictionary"""
+        header.clear()
+        header["http_result_code"] = "000"
+        header["http_result_description"] = ""
+
+    def parse_http_protocol(self, line, header):
+        """Parse first HTTP header line"""
+        try:
+            header["http_result_code"] = line.split(None, 2)[1]
+            header["http_result_description"] = line.split(None, 2)[2]
+        except IndexError:
+            pass
+
+    def parse_http_header(self, line, header):
+        """Parse single HTTP header line."""
+        part = line.split(None, 1)
+        fieldname = part[0].rstrip(":").lower()
+        try:
+            header[fieldname] = part[1]
+        except IndexError:
+            header[fieldname] = ""
+
+    def parse_curl_error(self, proc_stderr):
+        """Report Curl failure."""
+        curl_err = ""
+        try:
+            curl_err = proc_stderr.rstrip("\n")
+            curl_err = curl_err.split(None, 2)[2]
+        except IndexError:
+            pass
+
+        return curl_err
+
+    def parse_ftp_header(self, line, header):
+        """Parse single FTP header line."""
+        part = line.split(None, 1)
+        responsecode = part[0]
+        if responsecode == "213":
+            # This is the reply to curl's SIZE command on the file
+            # We can map it to the HTTP content-length header
+            try:
+                header["content-length"] = part[1]
+            except IndexError:
+                pass
+        elif responsecode.startswith("55"):
+            header["http_result_code"] = "404"
+            header["http_result_description"] = line
+        elif responsecode == "150" or responsecode == "125":
+            header["http_result_code"] = "200"
+            header["http_result_description"] = line
+
+    def parse_headers(self, proc_stdout, header):
+        """Parse headers from Curl."""
+        for line in proc_stdout.splitlines():
+            if line.startswith("HTTP/"):
+                self.parse_http_protocol(line, header)
+            elif ": " in line:
+                self.parse_http_header(line, header)
+            elif self.env["url"].startswith("ftp://"):
+                self.parse_ftp_header(line, header)
+            elif line == "":
+                # we got an empty line; end of headers (or curl exited)
+                if header.get("http_result_code") in [
+                    "301",
+                    "302",
+                    "303",
+                    "307",
+                    "308",
+                ]:
+                    # redirect, so more headers are coming.
+                    # Throw away the headers we've received so far
+                    self.clear_header(header)
+
+    def execute_curl(self, curl_cmd):
+        """Executes curl comamnd. Returns stdout, stderr and return code."""
+        proc = subprocess.Popen(
+            curl_cmd,
+            shell=False,
+            bufsize=1,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        proc_stdout, proc_stderr = proc.communicate()
+        retcode = proc.returncode
+
+        return proc_stdout, proc_stderr, retcode
+
+    def download(self, curl_cmd):
+        """Launches curl returns its output and handles failures."""
+
+        proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)
+
+        if retcode:  # Non-zero exit code from curl => problem with download
+            curl_err = self.parse_curl_error(proc_stderr)
+            raise ProcessorError(
+                "Curl failure: %s (exit code %s)" % (curl_err, retcode)
+            )
+
+        return proc_stdout
+
+    def main(self):
+        pass
+
+
+if __name__ == "__main__":
+    PROCESSOR = URLGetter()
+    PROCESSOR.execute_shell()

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -71,13 +71,11 @@ class URLGetter(Processor):
 
     def add_curl_common_opts(self, curl_cmd):
         """Adds request_headers and curl_opts to curl_cmd"""
-        if "request_headers" in self.env:
-            headers = self.env["request_headers"]
-            for header, value in headers.items():
-                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
-        if "curl_opts" in self.env:
-            for item in self.env["curl_opts"]:
-                curl_cmd.extend([item])
+        for header, value in self.env.get("request_headers", {}).items():
+            curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+
+        for item in self.env.get("curl_opts", []):
+            curl_cmd.extend([item])
 
     def clear_header(self, header):
         """Clear header dictionary"""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -19,7 +19,7 @@
 import os.path
 import subprocess
 
-from autopkglib import Processor, ProcessorError, get_pref, log_err
+from autopkglib import Processor, ProcessorError, get_pref, is_executable, log_err
 
 __all__ = ["URLGetter"]
 
@@ -37,10 +37,6 @@ class URLGetter(Processor):
         3. a 'curl' binary that can be found in the PATH environment variable
         4. '/usr/bin/curl'
         """
-
-        def is_executable(exe_path):
-            """Is exe_path executable?"""
-            return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
 
         if "CURL_PATH" in self.env and is_executable(self.env["CURL_PATH"]):
             return self.env["CURL_PATH"]

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -48,7 +48,6 @@ class URLGetter(Processor):
         curl_path_pref = get_pref("CURL_PATH")
         if curl_path_pref:
             if is_executable(curl_path_pref):
-                # take a CURL_PATH pref
                 return curl_path_pref
             else:
                 log_err(
@@ -60,11 +59,9 @@ class URLGetter(Processor):
         for path_env in os.environ["PATH"].split(":"):
             curlbin = os.path.join(path_env, "curl")
             if is_executable(curlbin):
-                # take the first 'curl' in PATH that we find
                 return curlbin
 
         if is_executable("/usr/bin/curl"):
-            # fall back to /usr/bin/curl
             return "/usr/bin/curl"
 
         raise ProcessorError("Unable to execute any curl binary")

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -64,7 +64,7 @@ class URLGetter(Processor):
         if is_executable("/usr/bin/curl"):
             return "/usr/bin/curl"
 
-        raise ProcessorError("Unable to execute any curl binary")
+        raise ProcessorError("Unable to locate or execute any curl binary")
 
     def add_curl_common_opts(self, curl_cmd):
         """Adds request_headers and curl_opts to curl_cmd"""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -163,9 +163,8 @@ class URLGetter(Processor):
         )
 
         proc_stdout, proc_stderr = proc.communicate()
-        retcode = proc.returncode
 
-        return proc_stdout, proc_stderr, retcode
+        return proc_stdout, proc_stderr, proc.returncode
 
     def download(self, curl_cmd):
         """Launches curl returns its output and handles failures."""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -25,13 +25,13 @@ __all__ = ["URLGetter"]
 
 
 class URLGetter(Processor):
-    """Handles curl HTTP operatios. Server only as superclass. Not for direct use."""
+    """Handles curl HTTP operations. Serves only as superclass. Not for direct use."""
 
     description = __doc__
 
     def curl_binary(self):
-        """Returns a path to a curl binary, priority in the order below.
-        Returns None if none found.
+        """Return a path to a curl binary, priority in the order below.
+        Return None if none found.
         1. env['CURL_PATH']
         2. app pref 'CURL_PATH'
         3. a 'curl' binary that can be found in the PATH environment variable
@@ -47,7 +47,7 @@ class URLGetter(Processor):
                 return curl_path_pref
             else:
                 log_err(
-                    "WARNING: Curl path given in the 'CURL_PATH' preference:'%s' "
+                    "WARNING: curl path given in the 'CURL_PATH' preference:'%s' "
                     "either doesn't exist or is not executable! Falling back "
                     "to one set in PATH, or /usr/bin/curl." % curl_path_pref
                 )
@@ -63,7 +63,7 @@ class URLGetter(Processor):
         raise ProcessorError("Unable to locate or execute any curl binary")
 
     def add_curl_common_opts(self, curl_cmd):
-        """Adds request_headers and curl_opts to curl_cmd"""
+        """Add request_headers and curl_opts to curl_cmd"""
         for header, value in self.env.get("request_headers", {}).items():
             curl_cmd.extend(["--header", "%s: %s" % (header, value)])
 
@@ -94,7 +94,7 @@ class URLGetter(Processor):
             header[fieldname] = ""
 
     def parse_curl_error(self, proc_stderr):
-        """Report Curl failure."""
+        """Report curl failure."""
         curl_err = ""
         try:
             curl_err = proc_stderr.rstrip("\n")
@@ -123,7 +123,7 @@ class URLGetter(Processor):
             header["http_result_description"] = line
 
     def parse_headers(self, proc_stdout, header):
-        """Parse headers from Curl."""
+        """Parse headers from curl."""
         for line in proc_stdout.splitlines():
             if line.startswith("HTTP/"):
                 self.parse_http_protocol(line, header)
@@ -145,7 +145,7 @@ class URLGetter(Processor):
                     self.clear_header(header)
 
     def execute_curl(self, curl_cmd):
-        """Executes curl comamnd. Returns stdout, stderr and return code."""
+        """Execute curl comamnd. Return stdout, stderr and return code."""
         proc = subprocess.Popen(
             curl_cmd,
             shell=False,
@@ -160,14 +160,14 @@ class URLGetter(Processor):
         return proc_stdout, proc_stderr, proc.returncode
 
     def download(self, curl_cmd):
-        """Launches curl returns its output and handles failures."""
+        """Launch curl, return its output, and handle failures."""
 
         proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)
 
         if retcode:  # Non-zero exit code from curl => problem with download
             curl_err = self.parse_curl_error(proc_stderr)
             raise ProcessorError(
-                "Curl failure: %s (exit code %s)" % (curl_err, retcode)
+                "curl failure: %s (exit code %s)" % (curl_err, retcode)
             )
 
         return proc_stdout

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -265,6 +265,11 @@ def update_data(a_dict, key, value):
     a_dict[key] = do_variable_substitution(value)
 
 
+def is_executable(exe_path):
+    """Is exe_path executable?"""
+    return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
+
+
 def curl_cmd():
     """Returns a path to a curl binary, priority in the order below.
     Returns None if none found.
@@ -272,10 +277,6 @@ def curl_cmd():
     2. a 'curl' binary that can be found in the PATH environment variable
     3. '/usr/bin/curl'
     """
-
-    def is_executable(exe_path):
-        """Is exe_path executable?"""
-        return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
 
     curl_path_pref = get_pref("CURL_PATH")
     if curl_path_pref:


### PR DESCRIPTION
This PR was split from #446. It should be merged **after** PR #544 (`URLGetter`). Branch `urlgetter-sparkleupdateinfoprovider` includes code from branch `urlgetter` in order for `SparkleUpdateInfoProvider` to work. `URLGetter` should be reviewed in #544.

`URLTextSearcher` was refactored in following way:

- `SparkleUpdateInfoProvider` is now subclass of `URLGetter`
- Functionality like executing `curl` was moved to `URLGetter`
- Some of the code from `get_feed_data()` was split into methods `build_url()`, `determine_version()`, `parse_feed_data`.
- Some of the code from `main()` was split into methods `handle_pkginfo()`
- Some local variables are now instance variables
- `SparkleUpdateInfoProvider` now supports `curl_opts` variable