### PR TITLE
GitHubReleasesInfoProvider refactoring using URLGetter

### DIFF
--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -99,10 +99,7 @@ class GitHubReleasesInfoProvider(Processor):
         be of the form 'user/repo'"""
         # pylint: disable=no-self-use
         releases = None
-        if "curl_opts" in self.env:
-            curl_opts = self.env["curl_opts"]
-        else:
-            curl_opts = None
+        curl_opts = self.env.get("curl_opts")
         github = autopkglib.github.GitHubSession(self.env["CURL_PATH"], curl_opts)
         releases_uri = "/repos/%s/releases" % repo
         (releases, status) = github.call_api(releases_uri)

--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -63,6 +63,18 @@ class GitHubReleasesInfoProvider(Processor):
                 "release may be posted later."
             ),
         },
+        "curl_opts": {
+            "required": False,
+            "description": (
+                "Optional array of curl options to include with "
+                "the download request."
+            ),
+        },
+        "CURL_PATH": {
+            "required": False,
+            "default": "/usr/bin/curl",
+            "description": "Path to curl binary. Defaults to /usr/bin/curl.",
+        },
     }
     output_variables = {
         "release_notes": {
@@ -87,7 +99,11 @@ class GitHubReleasesInfoProvider(Processor):
         be of the form 'user/repo'"""
         # pylint: disable=no-self-use
         releases = None
-        github = autopkglib.github.GitHubSession()
+        if "curl_opts" in self.env:
+            curl_opts = self.env["curl_opts"]
+        else:
+            curl_opts = None
+        github = autopkglib.github.GitHubSession(self.env["CURL_PATH"], curl_opts)
         releases_uri = "/repos/%s/releases" % repo
         (releases, status) = github.call_api(releases_uri)
         if status != 200:

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python
+#
+# Copyright 2018 Michal Moravec
+# Based on code from Greg Neagle, Timothy Sutton and Per Olofsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for URLGetter class"""
+
+import os.path
+import subprocess
+
+from autopkglib import Processor, ProcessorError, get_pref, log_err
+
+__all__ = ["URLGetter"]
+
+
+class URLGetter(Processor):
+    """Handles curl HTTP operatios. Server only as superclass. Not for direct use."""
+
+    description = __doc__
+
+    def curl_binary(self):
+        """Returns a path to a curl binary, priority in the order below.
+        Returns None if none found.
+        1. env['CURL_PATH']
+        2. app pref 'CURL_PATH'
+        3. a 'curl' binary that can be found in the PATH environment variable
+        4. '/usr/bin/curl'
+        """
+
+        def is_executable(exe_path):
+            """Is exe_path executable?"""
+            return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
+
+        if "CURL_PATH" in self.env and is_executable(self.env["CURL_PATH"]):
+            return self.env["CURL_PATH"]
+
+        curl_path_pref = get_pref("CURL_PATH")
+        if curl_path_pref:
+            if is_executable(curl_path_pref):
+                # take a CURL_PATH pref
+                return curl_path_pref
+            else:
+                log_err(
+                    "WARNING: Curl path given in the 'CURL_PATH' preference:'%s' "
+                    "either doesn't exist or is not executable! Falling back "
+                    "to one set in PATH, or /usr/bin/curl." % curl_path_pref
+                )
+
+        for path_env in os.environ["PATH"].split(":"):
+            curlbin = os.path.join(path_env, "curl")
+            if is_executable(curlbin):
+                # take the first 'curl' in PATH that we find
+                return curlbin
+
+        if is_executable("/usr/bin/curl"):
+            # fall back to /usr/bin/curl
+            return "/usr/bin/curl"
+
+        raise ProcessorError("Unable to execute any curl binary")
+
+    def add_curl_common_opts(self, curl_cmd):
+        """Adds request_headers and curl_opts to curl_cmd"""
+        if "request_headers" in self.env:
+            headers = self.env["request_headers"]
+            for header, value in headers.items():
+                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+        if "curl_opts" in self.env:
+            for item in self.env["curl_opts"]:
+                curl_cmd.extend([item])
+
+    def clear_header(self, header):
+        """Clear header dictionary"""
+        header.clear()
+        header["http_result_code"] = "000"
+        header["http_result_description"] = ""
+
+    def parse_http_protocol(self, line, header):
+        """Parse first HTTP header line"""
+        try:
+            header["http_result_code"] = line.split(None, 2)[1]
+            header["http_result_description"] = line.split(None, 2)[2]
+        except IndexError:
+            pass
+
+    def parse_http_header(self, line, header):
+        """Parse single HTTP header line."""
+        part = line.split(None, 1)
+        fieldname = part[0].rstrip(":").lower()
+        try:
+            header[fieldname] = part[1]
+        except IndexError:
+            header[fieldname] = ""
+
+    def parse_curl_error(self, proc_stderr):
+        """Report Curl failure."""
+        curl_err = ""
+        try:
+            curl_err = proc_stderr.rstrip("\n")
+            curl_err = curl_err.split(None, 2)[2]
+        except IndexError:
+            pass
+
+        return curl_err
+
+    def parse_ftp_header(self, line, header):
+        """Parse single FTP header line."""
+        part = line.split(None, 1)
+        responsecode = part[0]
+        if responsecode == "213":
+            # This is the reply to curl's SIZE command on the file
+            # We can map it to the HTTP content-length header
+            try:
+                header["content-length"] = part[1]
+            except IndexError:
+                pass
+        elif responsecode.startswith("55"):
+            header["http_result_code"] = "404"
+            header["http_result_description"] = line
+        elif responsecode == "150" or responsecode == "125":
+            header["http_result_code"] = "200"
+            header["http_result_description"] = line
+
+    def parse_headers(self, proc_stdout, header):
+        """Parse headers from Curl."""
+        for line in proc_stdout.splitlines():
+            if line.startswith("HTTP/"):
+                self.parse_http_protocol(line, header)
+            elif ": " in line:
+                self.parse_http_header(line, header)
+            elif self.env["url"].startswith("ftp://"):
+                self.parse_ftp_header(line, header)
+            elif line == "":
+                # we got an empty line; end of headers (or curl exited)
+                if header.get("http_result_code") in [
+                    "301",
+                    "302",
+                    "303",
+                    "307",
+                    "308",
+                ]:
+                    # redirect, so more headers are coming.
+                    # Throw away the headers we've received so far
+                    self.clear_header(header)
+
+    def execute_curl(self, curl_cmd):
+        """Executes curl comamnd. Returns stdout, stderr and return code."""
+        proc = subprocess.Popen(
+            curl_cmd,
+            shell=False,
+            bufsize=1,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        proc_stdout, proc_stderr = proc.communicate()
+        retcode = proc.returncode
+
+        return proc_stdout, proc_stderr, retcode
+
+    def download(self, curl_cmd):
+        """Launches curl returns its output and handles failures."""
+
+        proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)
+
+        if retcode:  # Non-zero exit code from curl => problem with download
+            curl_err = self.parse_curl_error(proc_stderr)
+            raise ProcessorError(
+                "Curl failure: %s (exit code %s)" % (curl_err, retcode)
+            )
+
+        return proc_stdout
+
+    def main(self):
+        pass
+
+
+if __name__ == "__main__":
+    PROCESSOR = URLGetter()
+    PROCESSOR.execute_shell()

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -71,13 +71,11 @@ class URLGetter(Processor):
 
     def add_curl_common_opts(self, curl_cmd):
         """Adds request_headers and curl_opts to curl_cmd"""
-        if "request_headers" in self.env:
-            headers = self.env["request_headers"]
-            for header, value in headers.items():
-                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
-        if "curl_opts" in self.env:
-            for item in self.env["curl_opts"]:
-                curl_cmd.extend([item])
+        for header, value in self.env.get("request_headers", {}).items():
+            curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+
+        for item in self.env.get("curl_opts", []):
+            curl_cmd.extend([item])
 
     def clear_header(self, header):
         """Clear header dictionary"""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -19,7 +19,7 @@
 import os.path
 import subprocess
 
-from autopkglib import Processor, ProcessorError, get_pref, log_err
+from autopkglib import Processor, ProcessorError, get_pref, is_executable, log_err
 
 __all__ = ["URLGetter"]
 
@@ -37,10 +37,6 @@ class URLGetter(Processor):
         3. a 'curl' binary that can be found in the PATH environment variable
         4. '/usr/bin/curl'
         """
-
-        def is_executable(exe_path):
-            """Is exe_path executable?"""
-            return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
 
         if "CURL_PATH" in self.env and is_executable(self.env["CURL_PATH"]):
             return self.env["CURL_PATH"]

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -48,7 +48,6 @@ class URLGetter(Processor):
         curl_path_pref = get_pref("CURL_PATH")
         if curl_path_pref:
             if is_executable(curl_path_pref):
-                # take a CURL_PATH pref
                 return curl_path_pref
             else:
                 log_err(
@@ -60,11 +59,9 @@ class URLGetter(Processor):
         for path_env in os.environ["PATH"].split(":"):
             curlbin = os.path.join(path_env, "curl")
             if is_executable(curlbin):
-                # take the first 'curl' in PATH that we find
                 return curlbin
 
         if is_executable("/usr/bin/curl"):
-            # fall back to /usr/bin/curl
             return "/usr/bin/curl"
 
         raise ProcessorError("Unable to execute any curl binary")

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -64,7 +64,7 @@ class URLGetter(Processor):
         if is_executable("/usr/bin/curl"):
             return "/usr/bin/curl"
 
-        raise ProcessorError("Unable to execute any curl binary")
+        raise ProcessorError("Unable to locate or execute any curl binary")
 
     def add_curl_common_opts(self, curl_cmd):
         """Adds request_headers and curl_opts to curl_cmd"""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -163,9 +163,8 @@ class URLGetter(Processor):
         )
 
         proc_stdout, proc_stderr = proc.communicate()
-        retcode = proc.returncode
 
-        return proc_stdout, proc_stderr, retcode
+        return proc_stdout, proc_stderr, proc.returncode
 
     def download(self, curl_cmd):
         """Launches curl returns its output and handles failures."""

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -25,13 +25,13 @@ __all__ = ["URLGetter"]
 
 
 class URLGetter(Processor):
-    """Handles curl HTTP operatios. Server only as superclass. Not for direct use."""
+    """Handles curl HTTP operations. Serves only as superclass. Not for direct use."""
 
     description = __doc__
 
     def curl_binary(self):
-        """Returns a path to a curl binary, priority in the order below.
-        Returns None if none found.
+        """Return a path to a curl binary, priority in the order below.
+        Return None if none found.
         1. env['CURL_PATH']
         2. app pref 'CURL_PATH'
         3. a 'curl' binary that can be found in the PATH environment variable
@@ -47,7 +47,7 @@ class URLGetter(Processor):
                 return curl_path_pref
             else:
                 log_err(
-                    "WARNING: Curl path given in the 'CURL_PATH' preference:'%s' "
+                    "WARNING: curl path given in the 'CURL_PATH' preference:'%s' "
                     "either doesn't exist or is not executable! Falling back "
                     "to one set in PATH, or /usr/bin/curl." % curl_path_pref
                 )
@@ -63,7 +63,7 @@ class URLGetter(Processor):
         raise ProcessorError("Unable to locate or execute any curl binary")
 
     def add_curl_common_opts(self, curl_cmd):
-        """Adds request_headers and curl_opts to curl_cmd"""
+        """Add request_headers and curl_opts to curl_cmd"""
         for header, value in self.env.get("request_headers", {}).items():
             curl_cmd.extend(["--header", "%s: %s" % (header, value)])
 
@@ -94,7 +94,7 @@ class URLGetter(Processor):
             header[fieldname] = ""
 
     def parse_curl_error(self, proc_stderr):
-        """Report Curl failure."""
+        """Report curl failure."""
         curl_err = ""
         try:
             curl_err = proc_stderr.rstrip("\n")
@@ -123,7 +123,7 @@ class URLGetter(Processor):
             header["http_result_description"] = line
 
     def parse_headers(self, proc_stdout, header):
-        """Parse headers from Curl."""
+        """Parse headers from curl."""
         for line in proc_stdout.splitlines():
             if line.startswith("HTTP/"):
                 self.parse_http_protocol(line, header)
@@ -145,7 +145,7 @@ class URLGetter(Processor):
                     self.clear_header(header)
 
     def execute_curl(self, curl_cmd):
-        """Executes curl comamnd. Returns stdout, stderr and return code."""
+        """Execute curl comamnd. Return stdout, stderr and return code."""
         proc = subprocess.Popen(
             curl_cmd,
             shell=False,
@@ -160,14 +160,14 @@ class URLGetter(Processor):
         return proc_stdout, proc_stderr, proc.returncode
 
     def download(self, curl_cmd):
-        """Launches curl returns its output and handles failures."""
+        """Launch curl, return its output, and handle failures."""
 
         proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)
 
         if retcode:  # Non-zero exit code from curl => problem with download
             curl_err = self.parse_curl_error(proc_stderr)
             raise ProcessorError(
-                "Curl failure: %s (exit code %s)" % (curl_err, retcode)
+                "curl failure: %s (exit code %s)" % (curl_err, retcode)
             )
 
         return proc_stdout

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -265,6 +265,11 @@ def update_data(a_dict, key, value):
     a_dict[key] = do_variable_substitution(value)
 
 
+def is_executable(exe_path):
+    """Is exe_path executable?"""
+    return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
+
+
 def curl_cmd():
     """Returns a path to a curl binary, priority in the order below.
     Returns None if none found.
@@ -272,10 +277,6 @@ def curl_cmd():
     2. a 'curl' binary that can be found in the PATH environment variable
     3. '/usr/bin/curl'
     """
-
-    def is_executable(exe_path):
-        """Is exe_path executable?"""
-        return os.path.exists(exe_path) and os.access(exe_path, os.X_OK)
 
     curl_path_pref = get_pref("CURL_PATH")
     if curl_path_pref:

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -61,7 +61,7 @@ class GitHubSession(URLGetter):
         if it exists."""
 
         if not os.path.exists(TOKEN_LOCATION):
-            log(
+            print(
                 """Create a new token in your GitHub settings page:
 
     https://github.com/settings/tokens

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -138,7 +138,7 @@ To save the token, paste it to the following prompt."""
         return curl_cmd
 
     def download(self, curl_cmd):
-        """Downloads file using curl and returns raw headers."""
+        """Download file using curl and return raw headers."""
 
         p_stdout, p_stderr, retcode = super(GitHubSession, self).execute_curl(curl_cmd)
 


### PR DESCRIPTION
This PR was split from #446. It should be merged **after** PR #544 (`URLGetter`) and #548 (`GitHubSession`). Branch `urlgetter-githubreleasesinfoprovider` includes code from branch `urlgetter` and `urlgetter-githubsession` in order for `GitHubReleasesInfoProvider` to work. `URLGetter` should be reviewed in #544. Changes to GitHubSession should be reviewed in #548.

`GitHubReleasesInfoProvider` was refactored in following way:

- Added support for `curl_opts` and `CURL_PATH` environment variables. If set they are passed to `GitHubSession`.