### PR TITLE
Prefs object

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -18,6 +18,7 @@ related tasks"""
 
 from __future__ import print_function
 
+import copy
 import difflib
 import glob
 import hashlib
@@ -47,6 +48,8 @@ from autopkglib import (
     get_identifier,
     get_pref,
     get_processor,
+    globalPreferences,
+    is_mac,
     log,
     log_err,
     processor_names,
@@ -84,12 +87,16 @@ def print_version(argv):
 def gen_common_parser():
     """Generate a common optparse parser with default options."""
     parser = optparse.OptionParser()
+    parser.add_option("--prefs", dest="file_path")
     return parser
 
 
 def common_parse(parser, argv):
     """Parse an optparse parser with some enhancements and return a tuple."""
     options, arguments = parser.parse_args(argv[2:])
+    if options.file_path:
+        # Attempt to set the global preferences
+        globalPreferences.read_file(options.file_path)
     return (options, arguments)
 
 
@@ -2269,8 +2276,8 @@ def run_recipes(argv):
 
         log("Processing %s..." % recipe_path)
 
-        # Obtain prefs from the defaults domain
-        prefs = get_all_prefs()
+        # Create a local copy of preferences
+        prefs = copy.deepcopy(dict(get_all_prefs()))
         # Add RECIPE_PATH and RECIPE_DIR variables for use by processors
         prefs["RECIPE_PATH"] = os.path.abspath(recipe["RECIPE_PATH"])
         prefs["RECIPE_DIR"] = os.path.dirname(prefs["RECIPE_PATH"])
@@ -2769,7 +2776,7 @@ def main(argv):
     }
 
     # Warn against running as root
-    if os.getuid() == 0:
+    if is_mac() and os.getuid() == 0:
         log_err("\n" + "WARNING! " * 8 + "\n")
         log_err(
             "    Running AutoPkg as root or using `sudo` is not recommended!\n"

--- a/Code/autopkglib/PkgCopier.py
+++ b/Code/autopkglib/PkgCopier.py
@@ -86,7 +86,7 @@ class PkgCopier(Copier):
 
             # do the copy
             pkg_path = self.env.get("pkg_path") or os.path.join(
-                self.env["RECIPE_CACHE_DIR"], os.path.basename(source_pkg)
+                self.env["RECIPE_CACHE_DIR"], os.path.basename(matched_source_path)
             )
             self.copy(matched_source_path, pkg_path, overwrite=True)
             self.env["pkg_path"] = pkg_path

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -47,19 +47,19 @@ class memoize(dict):
         return result
 
 
-@memoize
+# @memoize
 def is_mac():
     """Return True if current OS is macOS."""
     return "Darwin" in platform.platform()
 
 
-@memoize
+# @memoize
 def is_windows():
     """Return True if current OS is Windows."""
     return "Windows" in platform.platform()
 
 
-@memoize
+# @memoize
 def is_linux():
     """Return True if current OS is Linux."""
     return "Linux" in platform.platform()

--- a/Code/tests/e2e_tests.sh
+++ b/Code/tests/e2e_tests.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+echo "**Help:"
+../Code/autopkg help
+echo "**Info:"
+../Code/autopkg info Firefox.munki --prefs tests/preferences.plist
+echo "**List-processors:"
+../Code/autopkg list-processors --prefs tests/preferences.plist
+echo "**Processor-info:"
+../Code/autopkg processor-info URLDownloader --prefs tests/preferences.plist
+echo "**Repo-add:"
+../Code/autopkg repo-add recipes --prefs tests/preferences.plist
+echo "**Repo-delete:"
+../Code/autopkg repo-delete recipes --prefs tests/preferences.plist
+echo "**Repo-list:"
+../Code/autopkg repo-list --prefs tests/preferences.plist
+echo "**Repo-update:"
+../Code/autopkg repo-update all --prefs tests/preferences.plist
+echo "**Audit:"
+../Code/autopkg audit Firefox.munki --prefs tests/preferences.plist
+echo "**List-recipes:"
+../Code/autopkg list-recipes --prefs tests/preferences.plist
+echo "**Make-override:"
+../Code/autopkg make-override Firefox.munki --force --prefs tests/preferences.plist
+echo "**New-recipe:"
+../Code/autopkg new-recipe TestRecipe.check --prefs tests/preferences.plist
+echo "**Search:"
+../Code/autopkg search Firefox --prefs tests/preferences.plist
+echo "**Verify-trust-info:"
+../Code/autopkg verify-trust-info Firefox.munki --prefs tests/preferences.plist
+echo "**Update-trust-info:"
+../Code/autopkg update-trust-info Firefox.munki --prefs tests/preferences.plist
+echo "**Version:"
+../Code/autopkg version
+echo "**Run:"
+../Code/autopkg run -vv Firefox.munki --prefs tests/preferences.plist
+echo "**Run many:"
+../Code/autopkg run -vv Firefox.munki AdobeFlashPlayer.munki MakeCatalogs.munki --prefs tests/preferences.plist
+echo "**Install:"
+../Code/autopkg install Firefox -vv --prefs tests/preferences.plist

--- a/Code/tests/preferences.json
+++ b/Code/tests/preferences.json
@@ -1,0 +1,13 @@
+{
+  "CACHE_DIR": "/Users/Shared/AutoPkg/Cache", 
+  "MUNKI_REPO": "/Users/Shared/munki_repo", 
+  "RECIPE_OVERRIDE_DIRS": "/Users/Shared/AutoPkg/RecipeOverrides", 
+  "RECIPE_REPOS": {}, 
+  "RECIPE_REPO_DIR": "/Users/Shared/AutoPkg/RecipeRepos", 
+  "RECIPE_SEARCH_DIRS": [
+    ".", 
+    "~/Library/AutoPkg/Recipes", 
+    "/Library/AutoPkg/Recipes", 
+    "/Users/Shared/AutoPkg/Recipes"
+  ]
+}

--- a/Code/tests/preferences.plist
+++ b/Code/tests/preferences.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CACHE_DIR</key>
+	<string>/Users/Shared/AutoPkg/Cache</string>
+	<key>MUNKI_REPO</key>
+	<string>/Users/Shared/munki_repo</string>
+	<key>RECIPE_OVERRIDE_DIRS</key>
+	<string>/Users/Shared/AutoPkg/RecipeOverrides</string>
+	<key>RECIPE_REPOS</key>
+	<dict/>
+	<key>RECIPE_REPO_DIR</key>
+	<string>/Users/Shared/AutoPkg/RecipeRepos</string>
+	<key>RECIPE_SEARCH_DIRS</key>
+	<array>
+		<string>.</string>
+		<string>~/Library/AutoPkg/Recipes</string>
+		<string>/Library/AutoPkg/Recipes</string>
+		<string>/Users/Shared/AutoPkg/Recipes</string>
+	</array>
+</dict>
+</plist>

--- a/Code/tests/test_pkgcopier.py
+++ b/Code/tests/test_pkgcopier.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import os
+import plistlib
+import StringIO
+import unittest
+
+import mock
+from autopkglib.PkgCopier import PkgCopier
+
+
+class TestPkgCopier(unittest.TestCase):
+    """Test class for PkgCopier Processor."""
+
+    def setUp(self):
+        self.good_env = {"source_pkg": "source", "pkg_path": "dest"}
+        self.good_glob_dest_env = {"source_pkg": "source*", "pkg_path": "dest"}
+        self.good_glob_env = {"source_pkg": "source*"}
+        self.bad_env = {}
+        self.input_plist = StringIO.StringIO(plistlib.writePlistToString(self.good_env))
+        self.processor = PkgCopier(infile=self.input_plist)
+
+    def tearDown(self):
+        self.input_plist.close()
+
+    @mock.patch("autopkglib.PkgCopier.copy")
+    @mock.patch("glob.glob")
+    def test_no_fail_if_good_env(self, mock_glob, mock_copy):
+        """The processor should not raise any exceptions if run normally."""
+        self.processor.env = self.good_env
+        mock_glob.return_value = ["source"]
+        self.processor.main()
+
+    @mock.patch("autopkglib.PkgCopier.copy")
+    @mock.patch("glob.glob")
+    def test_no_pkgpath_uses_source_name(self, mock_glob, mock_copy):
+        """If pkg_path is not specified, it should use the source name."""
+        self.processor.env = self.good_glob_env
+        self.processor.env["RECIPE_CACHE_DIR"] = "fake_cache_dir"
+        mock_glob.return_value = ["source"]
+        self.processor.main()
+        mock_copy.assert_called_with(
+            "source",
+            os.path.join(self.processor.env["RECIPE_CACHE_DIR"], "source"),
+            overwrite=True,
+        )
+
+    @mock.patch("autopkglib.PkgCopier.copy")
+    @mock.patch("glob.glob")
+    def test_no_pkgpath_uses_dest_name(self, mock_glob, mock_copy):
+        """If pkg_path is specified, it should be used."""
+        self.processor.env = self.good_glob_dest_env
+        mock_glob.return_value = ["source"]
+        self.processor.main()
+        mock_copy.assert_called_with(
+            "source", self.processor.env["pkg_path"], overwrite=True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Summary**
This PR will allow preferences to be stored in an external file (currently it must be either in JSON or Plist format). The common parser will add a `--prefs` argument to each argument parser, which allows passing in a file containing key/value pairs to be read in as preferences. 

If a file is passed in, it will take precedence over any macOS preferences that are present. Additionally, changing any of the preference values (by adding or removing a repo, for example) will write back out to the file, and not macOS preferences.

The preferences are now stored in a global object and referenced throughout the code, rather than collected from macOS each time they are queried.

**OS Versions**
This has been tested to work on Windows and macOS.

**Testing**
I've written a number of unit tests for the new Preferences object functionality: 
```
test_get_identifier_from_recipe_file_returns_identifier (tests.test_autopkglib.TestAutoPkg)
get_identifier_from_recipe-file should return identifier. ... ok
test_get_identifier_from_recipe_file_returns_none (tests.test_autopkglib.TestAutoPkg)
get_identifier_from_recipe-file should return None if no identifier. ... ok
test_get_identifier_returns_identifier (tests.test_autopkglib.TestAutoPkg)
get_identifier should return the identifier. ... ok
test_get_identifier_returns_none (tests.test_autopkglib.TestAutoPkg)
get_identifier should return None if no identifier is found. ... ok
test_get_macos_pref_returns_value (tests.test_autopkglib.TestAutoPkg)
get_macos_pref should return a value. ... ok
test_is_linux_returns_false_on_not_linux (tests.test_autopkglib.TestAutoPkg)
On not-Linux, is_linux() should return False. ... ok
test_is_linux_returns_true_on_linux (tests.test_autopkglib.TestAutoPkg)
On Linux, is_linux() should return True. ... ok
test_is_mac_returns_false_on_not_mac (tests.test_autopkglib.TestAutoPkg)
On not-macOS, is_mac() should return False. ... ok
test_is_mac_returns_true_on_mac (tests.test_autopkglib.TestAutoPkg)
On macOS, is_mac() should return True. ... ok
test_is_windows_returns_false_on_not_windows (tests.test_autopkglib.TestAutoPkg)
On not-Windows, is_windows() should return False. ... ok
test_is_windows_returns_true_on_windows (tests.test_autopkglib.TestAutoPkg)
On Windows, is_windows() should return True. ... ok
test_parse_file_is_empty_by_default (tests.test_autopkglib.TestAutoPkg)
Parsing a non-existant file should return an empty dict. ... ok
test_parse_file_reads_json (tests.test_autopkglib.TestAutoPkg)
Parsing a JSON file should produce a dictionary. ... ok
test_prefs_object_is_empty_by_default (tests.test_autopkglib.TestAutoPkg)
A new Preferences object should be empty. ... ok
test_prefs_object_is_empty_on_nonmac (tests.test_autopkglib.TestAutoPkg)
A new Preferences object on non-macOS should be empty. ... ok
test_read_file_fills_prefs (tests.test_autopkglib.TestAutoPkg)
read_file should populate the prefs object. ... ok
test_set_pref_mac (tests.test_autopkglib.TestAutoPkg)
set_pref should change the prefs object. ... ok
test_set_pref_nonmac (tests.test_autopkglib.TestAutoPkg)
set_pref should change the prefs object. ... ok
test_found_a_dmg_match (tests.test_filefinder.TestFileFinder)
If we find a match inside a DMG, it should be in the env. ... ok
test_found_a_match (tests.test_filefinder.TestFileFinder)
If we find a match, it should be in the env. ... ok
test_no_fail_if_good_env (tests.test_filefinder.TestFileFinder)
The processor should not raise any exceptions if run normally. ... ok
test_raise_if_not_glob (tests.test_filefinder.TestFileFinder)
Raise an exception if glob is not passed to find_method. ... ok

----------------------------------------------------------------------
Ran 22 tests in 0.043s

OK
```

For reasons I'm not yet clear on, the memoization is not being mocked correctly, so it causes some of the unit tests to fail unexpectedly. I've disabled them for now as the very minor performance benefit isn't currently worth the trade-off.

Additionally, I've created a simple bash script that runs through all of the AutoPkg verbs. It doesn't do any reporting or record the exit codes, but it's an easy way to test all things at once and visually identify issues. This is stored in Code/tests/e2e_tests.sh. It also includes two preferences files, one in JSON and one in plist, and it's easy to swap between them to test parsing and preference handling externally.

Using the e2e script, I verified that AutoPkg functionality remains consistent.