### PR TITLE
PkgCopier now uses the correct matched glob name by default

### DIFF
--- a/Code/autopkglib/PkgCopier.py
+++ b/Code/autopkglib/PkgCopier.py
@@ -86,7 +86,7 @@ class PkgCopier(Copier):
 
             # do the copy
             pkg_path = self.env.get("pkg_path") or os.path.join(
-                self.env["RECIPE_CACHE_DIR"], os.path.basename(source_pkg)
+                self.env["RECIPE_CACHE_DIR"], os.path.basename(matched_source_path)
             )
             self.copy(matched_source_path, pkg_path, overwrite=True)
             self.env["pkg_path"] = pkg_path

--- a/Code/tests/test_pkgcopier.py
+++ b/Code/tests/test_pkgcopier.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import os
+import plistlib
+import StringIO
+import unittest
+
+import mock
+from autopkglib.PkgCopier import PkgCopier
+
+
+class TestFileFinder(unittest.TestCase):
+    """Test class for PkgCopier Processor."""
+
+    def setUp(self):
+        self.good_env = {"source_pkg": "source", "pkg_path": "dest"}
+        self.good_glob_dest_env = {"source_pkg": "source*", "pkg_path": "dest"}
+        self.good_glob_env = {"source_pkg": "source*"}
+        self.bad_env = {}
+        self.input_plist = StringIO.StringIO(plistlib.writePlistToString(self.good_env))
+        self.processor = PkgCopier(infile=self.input_plist)
+
+    def tearDown(self):
+        self.input_plist.close()
+
+    @mock.patch("autopkglib.PkgCopier.copy")
+    @mock.patch("glob.glob")
+    def test_no_fail_if_good_env(self, mock_glob, mock_copy):
+        """The processor should not raise any exceptions if run normally."""
+        self.processor.env = self.good_env
+        mock_glob.return_value = ["source"]
+        self.processor.main()
+
+    @mock.patch("autopkglib.PkgCopier.copy")
+    @mock.patch("glob.glob")
+    def test_no_pkgpath_uses_source_name(self, mock_glob, mock_copy):
+        """If pkg_path is not specified, it should use the source name."""
+        self.processor.env = self.good_glob_env
+        self.processor.env["RECIPE_CACHE_DIR"] = "fake_cache_dir"
+        mock_glob.return_value = ["source"]
+        self.processor.main()
+        mock_copy.assert_called_with(
+            "source",
+            os.path.join(self.processor.env["RECIPE_CACHE_DIR"], "source"),
+            overwrite=True,
+        )
+
+    @mock.patch("autopkglib.PkgCopier.copy")
+    @mock.patch("glob.glob")
+    def test_no_pkgpath_uses_dest_name(self, mock_glob, mock_copy):
+        """If pkg_path is specified, it should be used."""
+        self.processor.env = self.good_glob_dest_env
+        mock_glob.return_value = ["source"]
+        self.processor.main()
+        mock_copy.assert_called_with(
+            "source", self.processor.env["pkg_path"], overwrite=True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Code/tests/test_pkgcopier.py
+++ b/Code/tests/test_pkgcopier.py
@@ -9,7 +9,7 @@ import mock
 from autopkglib.PkgCopier import PkgCopier
 
 
-class TestFileFinder(unittest.TestCase):
+class TestPkgCopier(unittest.TestCase):
     """Test class for PkgCopier Processor."""
 
     def setUp(self):


### PR DESCRIPTION
**Summary**
PkgCopier doesn't correctly handle a case where the input `source_pkg` is a glob but no `pkg_path` is specified - it creates a file that is the name of the actual glob, not the glob match - like "*.pkg".

This fixes  #560 .

**Testing**
I edited GoogleEarth.pkg.recipe so that the PkgCopier processor had no `pkg_path` variable:
```
        <dict>
            <key>Processor</key>
            <string>PkgCopier</string>
            <key>Arguments</key>
            <dict>
                <key>source_pkg</key>
                <string>%pathname%/Install Google Earth*.pkg</string>
            </dict>
        </dict>
```

On master, it does something unexpected:
```
PkgCopier
{'Input': {'source_pkg': u'/Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/downloads/GoogleEarth.dmg/Install Google Earth*.pkg'}}
PkgCopier: Mounted disk image /Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/downloads/GoogleEarth.dmg
PkgCopier: Using path '/private/tmp/dmg.OK8qFH/Install Google Earth Free 7.1.8.3036_m.pkg' matched from globbed '/private/tmp/dmg.OK8qFH/Install Google Earth*.pkg'.
PkgCopier: Copied /private/tmp/dmg.OK8qFH/Install Google Earth Free 7.1.8.3036_m.pkg to /Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/Install Google Earth*.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': u'/Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/Install Google Earth*.pkg'},
                                          'summary_text': 'The following packages were copied:'},
            'pkg_path': u'/Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/Install Google Earth*.pkg'}}
Receipt written to /Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/receipts/GoogleEarth-receipt-20190906-125421.plist

The following packages were copied:
    Pkg Path
    --------
    /Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/Install Google Earth*.pkg
```

Fixed:
```
./autopkg run -vv GoogleEarth.pkg
...
PkgCopier
{'Input': {'source_pkg': u'/Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/downloads/GoogleEarth.dmg/Install Google Earth*.pkg'}}
PkgCopier: Mounted disk image /Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/downloads/GoogleEarth.dmg
PkgCopier: Using path '/private/tmp/dmg.4mmqaj/Install Google Earth Free 7.1.8.3036_m.pkg' matched from globbed '/private/tmp/dmg.4mmqaj/Install Google Earth*.pkg'.
PkgCopier: Copied /private/tmp/dmg.4mmqaj/Install Google Earth Free 7.1.8.3036_m.pkg to /Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/Install Google Earth Free 7.1.8.3036_m.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': u'/Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/Install Google Earth Free 7.1.8.3036_m.pkg'},
                                          'summary_text': 'The following packages were copied:'},
            'pkg_path': u'/Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/Install Google Earth Free 7.1.8.3036_m.pkg'}}
Receipt written to /Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/receipts/GoogleEarth-receipt-20190906-125245.plist

The following packages were copied:
    Pkg Path
    --------
    /Users/nmcspadden/Library/AutoPkg/Cache/com.github.autopkg.pkg.google-earth/Install Google Earth Free 7.1.8.3036_m.pkg
```

Unit tests:
```
test_no_fail_if_good_env (tests.test_pkgcopier.TestPkgCopier)
The processor should not raise any exceptions if run normally. ... ok
test_no_pkgpath_uses_dest_name (tests.test_pkgcopier.TestPkgCopier)
If pkg_path is specified, it should be used. ... ok
test_no_pkgpath_uses_source_name (tests.test_pkgcopier.TestPkgCopier)
If pkg_path is not specified, it should use the source name. ... ok
```