### PR TITLE
Use shallow clones/pulls for recipe repos

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -604,7 +604,7 @@ def get_recipe_repo(git_path):
     else:
         log("Attempting git clone...")
         try:
-            log(run_git(["clone", git_path, dest_dir]))
+            log(run_git(["clone", "--depth", "1", git_path, dest_dir]))
             return dest_dir
         except GitError as err:
             log_err(err)
@@ -880,7 +880,7 @@ def repo_update(argv):
         repo_dir = os.path.abspath(os.path.expanduser(repo_dir))
         log("Attempting git pull for %s..." % repo_dir)
         try:
-            log(run_git(["pull"], git_directory=repo_dir))
+            log(run_git(["pull", "--depth", "1"], git_directory=repo_dir))
         except GitError as err:
             log_err(err)
 


### PR DESCRIPTION
I'm starting a thread on autopkg-discuss about this change, but the general idea is to use [shallow clones][1] and pulls for recipe repos to speed up `repo-add` and `repo-update`, as well as reduce disk space usage.

[1]: https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt