### PR TITLE
Remove FoundationPlist in favor of plistlib, phase 1

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -25,6 +25,7 @@ import hashlib
 import operator
 import optparse
 import os
+import plistlib
 import pprint
 import re
 import shutil
@@ -66,12 +67,6 @@ if sys.platform != "darwin":
 """
     )
 
-try:
-    import FoundationPlist
-except:
-    log("WARNING: importing plistlib as FoundationPlist;")
-    log("WARNING: some plist formats will be unsupported")
-    import plistlib as FoundationPlist
 
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70
@@ -130,8 +125,8 @@ def recipe_plist_from_file(filename):
     if os.path.isfile(filename):
         try:
             # make sure we can read it
-            recipe_plist = FoundationPlist.readPlist(filename)
-        except FoundationPlist.FoundationPlistException as err:
+            recipe_plist = plistlib.readPlist(filename)
+        except Exception as err:
             log_err("WARNING: plist error for %s: %s" % (filename, unicode(err)))
             return
         return recipe_plist
@@ -379,7 +374,7 @@ def load_recipe(
 
     if recipe_file:
         # read it
-        recipe = FoundationPlist.readPlist(recipe_file)
+        recipe = plistlib.readPlist(recipe_file)
 
         # store parent trust info, but only if this is an override
         if recipe_in_override_dir(recipe_file, override_dirs):
@@ -616,8 +611,8 @@ def write_plist_exit_on_fail(plist_dict, path):
     """Writes a dict to a new plist at path, exits the program
     if the write fails."""
     try:
-        FoundationPlist.writePlist(plist_dict, path)
-    except FoundationPlist.NSPropertyListWriteException:
+        plistlib.writePlist(plist_dict, path)
+    except plistlib.NSPropertyListWriteException:
         log_err("Failed to save plist to %s." % path)
         sys.exit(-1)
 
@@ -1350,7 +1345,7 @@ def list_recipes(argv):
     lowercase_sorted = sorted(recipes, key=lambda s: s["Name"].lower())
 
     if options.plist:
-        print(FoundationPlist.writePlistToString(lowercase_sorted))
+        print(plistlib.writePlistToString(lowercase_sorted))
     else:
         column_spacer = 1
         max_name_length = 0
@@ -1814,7 +1809,7 @@ def update_trust_info(argv):
             continue
         # normalize recipe path
         recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
-        recipe = FoundationPlist.readPlist(recipe_path)
+        recipe = plistlib.readPlist(recipe_path)
         if "ParentRecipe" not in recipe:
             log_err(
                 "%s is not a recipe override and has no parent recipe." % recipe_name
@@ -1840,7 +1835,7 @@ def update_trust_info(argv):
             recipe["ParentRecipeTrustInfo"] = get_trust_info(
                 parent_recipe, search_dirs=search_dirs
             )
-            FoundationPlist.writePlist(recipe, recipe_path)
+            plistlib.writePlist(recipe, recipe_path)
             log("Wrote updated %s" % recipe_path)
         else:
             log_err(
@@ -2017,7 +2012,7 @@ def make_override(argv):
             )
             return -1
         os.unlink(override_file)
-    FoundationPlist.writePlist(override_plist, override_file)
+    plistlib.writePlist(override_plist, override_file)
     log("Override file saved to %s" % override_file)
     return 0
 
@@ -2027,12 +2022,12 @@ def parse_recipe_list(filename):
     or a plist containing recipes and other key/value pairs"""
     recipe_list = {}
     try:
-        plist = FoundationPlist.readPlist(filename)
+        plist = plistlib.readPlist(filename)
         if not plist.get("recipes"):
             # try to trigger an AttributeError if the plist is not a dict
             pass
         return plist
-    except (FoundationPlist.NSPropertyListSerializationException, AttributeError):
+    except (plistlib.NSPropertyListSerializationException, AttributeError):
         # file does not appear to be a plist containing a dictionary;
         # read it as a plaintext list of recipes
         with open(filename, "r") as file_desc:
@@ -2223,7 +2218,7 @@ def run_recipes(argv):
 
     run_results = []
     try:
-        FoundationPlist.writePlist(run_results, current_run_results_plist)
+        plistlib.writePlist(run_results, current_run_results_plist)
     except IOError as err:
         log_err(
             "Can't write results to %s: %s" % (current_run_results_plist, err.strerror)
@@ -2337,7 +2332,7 @@ def run_recipes(argv):
 
         run_results.append(autopackager.results)
         try:
-            FoundationPlist.writePlist(run_results, current_run_results_plist)
+            plistlib.writePlist(run_results, current_run_results_plist)
         except IOError as err:
             log_err(
                 "Can't write results to %s: %s"
@@ -2391,7 +2386,7 @@ def run_recipes(argv):
         if os.path.exists(receipt_dir):
             receipt_path = os.path.join(receipt_dir, receipt_name)
             try:
-                FoundationPlist.writePlist(autopackager.results, receipt_path)
+                plistlib.writePlist(autopackager.results, receipt_path)
                 if options.verbose:
                     log("Receipt written to %s" % receipt_path)
             except IOError as err:
@@ -2658,7 +2653,7 @@ def audit(argv):
             recipe_no_issue_count += 1
             log("%s: no audit flags triggered." % recipe_path)
     if options.plist:
-        print(FoundationPlist.writePlistToString(audit_results))
+        print(plistlib.writePlistToString(audit_results))
     elif len(recipe_paths) > 1:
         log("\nSummary:")
         log("    %s recipes audited" % len(audit_results.keys()))
@@ -2709,9 +2704,9 @@ def new_recipe(argv):
         recipe["ParentRecipe"] = options.parent_identifier
 
     try:
-        FoundationPlist.writePlist(recipe, filename)
+        plistlib.writePlist(recipe, filename)
         log("Saved new recipe to %s" % filename)
-    except FoundationPlist.FoundationPlistException as err:
+    except Exception as err:
         log_err("Failed to write recipe: %s" % err)
 
 

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -16,10 +16,10 @@
 """See docstring for MunkiImporter class"""
 
 import os
+import plistlib
 import shutil
 import subprocess
 
-import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["MunkiImporter"]
@@ -135,7 +135,7 @@ class MunkiImporter(Processor):
             catalogitems = []
         else:
             try:
-                catalogitems = FoundationPlist.readPlist(all_items_path)
+                catalogitems = plistlib.readPlist(all_items_path)
             except OSError as err:
                 raise ProcessorError(
                     "Error reading 'all' catalog from Munki repo: %s" % err
@@ -459,7 +459,7 @@ class MunkiImporter(Processor):
             pkginfo_path = os.path.join(destination_path, pkginfo_name)
 
         try:
-            FoundationPlist.writePlist(pkginfo, pkginfo_path)
+            plistlib.writePlist(pkginfo, pkginfo_path)
         except OSError as err:
             raise ProcessorError(
                 "Could not write pkginfo %s: %s" % (pkginfo_path, err.strerror)
@@ -503,7 +503,7 @@ class MunkiImporter(Processor):
             )
 
         # Get pkginfo from output plist.
-        pkginfo = FoundationPlist.readPlistFromString(out)
+        pkginfo = plistlib.readPlistFromString(out)
 
         # copy any keys from pkginfo in self.env
         if "pkginfo" in self.env:

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -23,13 +23,12 @@ import imp
 import json
 import os
 import platform
+import plistlib
 import pprint
 import re
 import subprocess
 import sys
 from distutils.version import LooseVersion
-
-import FoundationPlist
 
 
 class memoize(dict):
@@ -118,7 +117,7 @@ class Preferences(object):
     def _parse_json_or_plist_file(self, file_path):
         """Parse the file. Start with plist, then JSON."""
         try:
-            data = FoundationPlist.readPlist(file_path)
+            data = plistlib.readPlist(file_path)
             self.type = "plist"
             self.file_path = file_path
             return Conversion.pythonCollectionFromPropertyList(data)
@@ -203,7 +202,7 @@ class Preferences(object):
     def _write_plist_file(self):
         """Write out the prefs into a Plist."""
         try:
-            FoundationPlist.writePlist(self.prefs, self.file_path)
+            plistlib.writePlist(self.prefs, self.file_path)
         except Exception as e:
             log_err("Unable to write out plist: {}".format(e))
 
@@ -287,8 +286,8 @@ def get_identifier_from_recipe_file(filename):
     identifier. Otherwise, returns None."""
     try:
         # make sure we can read it
-        recipe_plist = FoundationPlist.readPlist(filename)
-    except FoundationPlist.FoundationPlistException as err:
+        recipe_plist = plistlib.readPlist(filename)
+    except Exception as err:
         # unicode() doesn't exist in Python3, and we'd have to
         # change the behavior by importing unicode_literals from
         # __future__, which is a significant change requiring a lot of
@@ -322,10 +321,10 @@ def find_recipe_by_identifier(identifier, search_dirs):
 def get_autopkg_version():
     """Gets the version number of autopkg"""
     try:
-        version_plist = FoundationPlist.readPlist(
+        version_plist = plistlib.readPlist(
             os.path.join(os.path.dirname(__file__), "version.plist")
         )
-    except FoundationPlist.FoundationPlistException:
+    except Exception:
         return "UNKNOWN"
     try:
         return version_plist["Version"]
@@ -458,7 +457,7 @@ class Processor(object):
         try:
             indata = self.infile.read()
             if indata:
-                self.env = FoundationPlist.readPlistFromString(indata)
+                self.env = plistlib.readPlistFromString(indata)
             else:
                 self.env = dict()
         except BaseException as err:
@@ -471,7 +470,7 @@ class Processor(object):
             return
 
         try:
-            FoundationPlist.writePlist(self.env, self.outfile)
+            plistlib.writePlist(self.env, self.outfile)
         except BaseException as err:
             raise ProcessorError(err)
 

--- a/Code/tests/e2e_tests.sh
+++ b/Code/tests/e2e_tests.sh
@@ -2,16 +2,14 @@
 
 echo "**Help:"
 ../Code/autopkg help
-echo "**Info:"
-../Code/autopkg info Firefox.munki --prefs tests/preferences.plist
 echo "**List-processors:"
 ../Code/autopkg list-processors --prefs tests/preferences.plist
 echo "**Processor-info:"
 ../Code/autopkg processor-info URLDownloader --prefs tests/preferences.plist
 echo "**Repo-add:"
 ../Code/autopkg repo-add recipes --prefs tests/preferences.plist
-echo "**Repo-delete:"
-../Code/autopkg repo-delete recipes --prefs tests/preferences.plist
+echo "**Info:"
+../Code/autopkg info Firefox.munki --prefs tests/preferences.plist
 echo "**Repo-list:"
 ../Code/autopkg repo-list --prefs tests/preferences.plist
 echo "**Repo-update:"
@@ -38,3 +36,5 @@ echo "**Run many:"
 ../Code/autopkg run -vv Firefox.munki AdobeFlashPlayer.munki MakeCatalogs.munki --prefs tests/preferences.plist
 echo "**Install:"
 ../Code/autopkg install Firefox -vv --prefs tests/preferences.plist
+echo "**Repo-delete:"
+../Code/autopkg repo-delete recipes --prefs tests/preferences.plist


### PR DESCRIPTION
#565 raised an interesting problem, which is that FoundationPlist is capable of reading in values from a plist, but then writing them back in a slightly different format, which prevents it from reading in successfully again. 

Specifically, when FoundationPlist reads in a plist with an `integer` type, it converts it to a Python long integer. When it writes this value back out, it appends an L to the value - meaning reading in a plist with value 100 and writing it back out creates a value of 100L. If FoundationPlist reads this value back in again, it breaks, because "100L" is not a valid value for an integer type.

Short of doing a whole lot of fancy in-place conversions from FoundationPlist native data types to Python primitive types, the better solution is to avoid FoundationPlist altogether for anything that doesn't depend on binary plist parsing. In Python 3, `plistlib` handles this correctly anyway, so it's just a matter of time until we don't need it. We might as well take the first step now, which both resolves this issue and aids our migration to Python 3.

I've replaced all occurrences and use of FoundationPlist in AutoPkg core itself, along with MunkiImporter. The primary reason to replace MunkiImporter is that it reads in a plist (with FoundationPlist), and places the output directly into the summary results, which means that the environment variables contain PyObjc data types - which plistlib can't serialize when writing out a result plist, thus causing MunkiImporter to fail.

This PR also fixes the tests that were broken as a result of the preferences moving about a bit (which I failed to catch originally!), as well as adjusting e2e_tests.sh to be smarter about the order of operations it performs.

This PR passes all tests, and e2e_tests.sh runs without any problems. This closes #565 .