### PR TITLE
Prefetch filename before download

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -110,8 +110,8 @@ class URLDownloader(URLGetter):
             return xattr.getxattr(self.env["pathname"], attr)
         return None
 
-    def prepare_curl_cmd(self, pathname_temporary):
-        """Assemble curl command and return it."""
+    def prepare_base_curl_cmd(self):
+        """Assemble base curl command and return it."""
         curl_cmd = [
             super(URLDownloader, self).curl_binary(),
             "--silent",
@@ -125,9 +125,15 @@ class URLDownloader(URLGetter):
             "--location",
             "--url",
             self.env["url"],
-            "--output",
-            pathname_temporary,
         ]
+
+        return curl_cmd
+
+    def prepare_download_curl_cmd(self, pathname_temporary):
+        """Assemble file download curl command and return it."""
+
+        curl_cmd = self.prepare_base_curl_cmd()
+        curl_cmd.extend(["--output", pathname_temporary])
 
         super(URLDownloader, self).add_curl_common_opts(curl_cmd)
 
@@ -286,7 +292,7 @@ class URLDownloader(URLGetter):
         pathname_temporary = self.create_temp_file(download_dir)
 
         # Prepare curl command
-        curl_cmd = self.prepare_curl_cmd(pathname_temporary)
+        curl_cmd = self.prepare_download_curl_cmd(pathname_temporary)
 
         # Execute curl command and parse headers
         raw_header = super(URLDownloader, self).download(curl_cmd)

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -171,6 +171,23 @@ class URLDownloader(URLGetter):
         self.env["etag"] = ""
         self.existing_file_size = None
 
+    def prefetch_filename(self):
+        curl_cmd = self.prepare_base_curl_cmd()
+        curl_cmd.extend(["--head"])
+
+        raw_header = super(URLDownloader, self).download(curl_cmd)
+        header = {}
+        super(URLDownloader, self).parse_headers(raw_header, header)
+
+        if "filename=" in header.get("content-disposition", ""):
+            filename = header["content-disposition"].rpartition("filename=")[2]
+        elif header.get("http_redirected", None):
+            filename = header["http_redirected"].rpartition("/")[2]
+        else:
+            return None
+
+        return filename
+
     def get_filename(self):
         """Obtain filename from PKG variable or URL."""
         if "PKG" in self.env:

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -189,9 +189,8 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_base_curl_cmd()
         curl_cmd.extend(["--head"])
 
-        raw_header = super(URLDownloader, self).download(curl_cmd)
-        header = {}
-        super(URLDownloader, self).parse_headers(raw_header, header)
+        raw_headers = super(URLDownloader, self).download(curl_cmd)
+        header = super(URLDownloader, self).parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):
             filename = header["content-disposition"].rpartition("filename=")[2]
@@ -331,10 +330,8 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_download_curl_cmd(pathname_temporary)
 
         # Execute curl command and parse headers
-        raw_header = super(URLDownloader, self).download(curl_cmd)
-        header = {}
-        super(URLDownloader, self).clear_header(header)
-        super(URLDownloader, self).parse_headers(raw_header, header)
+        raw_headers = super(URLDownloader, self).download(curl_cmd)
+        header = super(URLDownloader, self).parse_headers(raw_headers)
 
         if self.download_changed(header):
             self.env["download_changed"] = True

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -72,9 +72,14 @@ class URLGetter(Processor):
 
     def clear_header(self, header):
         """Clear header dictionary"""
+        # Save redirect URL before clear
+        http_redirected = header.get("http_redirected", None)
         header.clear()
         header["http_result_code"] = "000"
         header["http_result_description"] = ""
+
+        # Restore redirect URL
+        header["http_redirected"] = http_redirected
 
     def parse_http_protocol(self, line, header):
         """Parse first HTTP header line"""
@@ -142,6 +147,7 @@ class URLGetter(Processor):
                 ]:
                     # redirect, so more headers are coming.
                     # Throw away the headers we've received so far
+                    header["http_redirected"] = header.get("location", None)
                     self.clear_header(header)
 
     def execute_curl(self, curl_cmd):

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -127,9 +127,11 @@ class URLGetter(Processor):
             header["http_result_code"] = "200"
             header["http_result_description"] = line
 
-    def parse_headers(self, proc_stdout, header):
+    def parse_headers(self, raw_headers):
         """Parse headers from curl."""
-        for line in proc_stdout.splitlines():
+        header = {}
+        self.clear_header(header)
+        for line in raw_headers.splitlines():
             if line.startswith("HTTP/"):
                 self.parse_http_protocol(line, header)
             elif ": " in line:
@@ -149,6 +151,7 @@ class URLGetter(Processor):
                     # Throw away the headers we've received so far
                     header["http_redirected"] = header.get("location", None)
                     self.clear_header(header)
+        return header
 
     def execute_curl(self, curl_cmd):
         """Execute curl comamnd. Return stdout, stderr and return code."""

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -191,10 +191,8 @@ To save the token, paste it to the following prompt."""
         curl_cmd = self.prepare_curl_cmd(method, accept, headers, data, temp_content)
 
         # Execute curl command and parse headers
-        raw_header = self.download(curl_cmd)
-        header = {}
-        super(GitHubSession, self).clear_header(header)
-        super(GitHubSession, self).parse_headers(raw_header, header)
+        raw_headers = self.download(curl_cmd)
+        header = super(GitHubSession, self).parse_headers(raw_headers)
         if header["http_result_code"] != "000":
             self.http_result_code = int(header["http_result_code"])
 


### PR DESCRIPTION
This PR adds new `prefetch_filename` option to `URLDownloader`. When set to `True`, `curl` is called with `--head` option to retrieve only HTTP headers before actual file download. We try to determine filename from HTTP heades in following order:

1. `Content-Disposition` header
2. `Location` header
3. `filename` option (if set)
4. Last part of url right from the slash (default behaviour)

Solves #432 

Also there is tiny bit of refactoring in 3364221
