### PR TITLE
Use only FoundationPlist for macOS, convert Foundation types to Python primitives

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -68,7 +68,7 @@ if sys.platform != "darwin":
 
 try:
     import FoundationPlist
-except:
+except ImportError:
     log("WARNING: importing plistlib as FoundationPlist;")
     log("WARNING: some plist formats will be unsupported")
     import plistlib as FoundationPlist

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -29,7 +29,12 @@ import subprocess
 import sys
 from distutils.version import LooseVersion
 
-import FoundationPlist
+try:
+    import FoundationPlist
+except ImportError:
+    print(unicode("WARNING: importing plistlib as FoundationPlist;").encode("UTF-8"))
+    print(unicode("WARNING: some plist formats will be unsupported").encode("UTF-8"))
+    import plistlib as FoundationPlist
 
 
 class memoize(dict):

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -78,7 +78,6 @@ try:
         kCFPreferencesCurrentUser,
         kCFPreferencesCurrentHost,
     )
-    from PyObjCTools import Conversion
 except:
     print(
         "WARNING: Failed 'from Foundation import NSArray, NSDictionary' in " + __name__
@@ -121,7 +120,7 @@ class Preferences(object):
             data = FoundationPlist.readPlist(file_path)
             self.type = "plist"
             self.file_path = file_path
-            return Conversion.pythonCollectionFromPropertyList(data)
+            return data
         except Exception:
             pass
         try:
@@ -141,8 +140,6 @@ class Preferences(object):
         # This a workaround for 10.6, where PyObjC doesn't seem to
         # support as many common operations such as list concatenation
         # between Python and ObjC objects.
-        if isinstance(value, NSArray) or isinstance(value, NSDictionary):
-            value = Conversion.pythonCollectionFromPropertyList(value)
         return value
 
     def _get_macos_prefs(self):


### PR DESCRIPTION
#565 introduced an unexpected problem where CFPreferencesCopyAppValue via objc is converting integers to Longs, which Python represents by appending an "L" onto the string representation of an int.

You can replicate this by writing an integer via defaults:
```
defaults write com.github.autopkg FOO -integer 100
```
Then using Python to retrieve it:
```
>>> from CoreFoundation import CFPreferencesCopyAppValue
>>> BUNDLE_ID = "com.github.autopkg"
>>> testint = CFPreferencesCopyAppValue("FOO", BUNDLE_ID)
>>> type(testint)
<class 'objc._pythonify.OC_PythonLong'>
>>> testint
100L
```

In order to solve this, we have to actively convert each of the preferences we slurp in from CFPreferences from the custom objc bridged type to a Python primitive type.