### PR TITLE
WIP: Py2 to 3 fixes

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -548,7 +548,11 @@ def run_git(git_options_and_arguments, git_directory=None):
     cmd.extend(git_options_and_arguments)
     try:
         proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=git_directory
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=git_directory,
+            text=True,
         )
         (cmd_out, cmd_err) = proc.communicate()
     except OSError as err:
@@ -559,7 +563,7 @@ def run_git(git_options_and_arguments, git_directory=None):
     if proc.returncode != 0:
         raise GitError(f"ERROR: {cmd_err}")
     else:
-        return cmd_out.decode("UTF-8")
+        return cmd_out
 
 
 def get_recipe_repo(git_path):

--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -185,7 +185,7 @@ class CodeSignatureVerifier(DmgMounter):
         """
         process = ["/usr/sbin/pkgutil", "--check-signature", path]
 
-        proc = subprocess.Popen(process, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(process, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (output, error) = proc.communicate()
 
         # Log everything

--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -163,6 +163,7 @@ class CodeSignatureVerifier(DmgMounter):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            text=True,
         )
         (output, error) = proc.communicate()
 
@@ -185,7 +186,9 @@ class CodeSignatureVerifier(DmgMounter):
         """
         process = ["/usr/sbin/pkgutil", "--check-signature", path]
 
-        proc = subprocess.Popen(process, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            process, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
         (output, error) = proc.communicate()
 
         # Log everything

--- a/Code/autopkglib/DmgCreator.py
+++ b/Code/autopkglib/DmgCreator.py
@@ -143,8 +143,10 @@ class DmgCreator(Processor):
 
         # Call hdiutil.
         try:
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stderr = proc.communicate()[1]
+            proc = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
+            (_, stderr) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 f"hdiutil execution failed with error code {err.errno}: {err.strerror}"

--- a/Code/autopkglib/DmgMounter.py
+++ b/Code/autopkglib/DmgMounter.py
@@ -169,7 +169,7 @@ class DmgMounter(Processor):
                 stderr=subprocess.PIPE,
                 text=True,
             )
-            stderr = proc.communicate()[1]
+            (_, stderr) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 f"hdiutil execution failed with error code {err.errno}: {err.strerror}"

--- a/Code/autopkglib/DmgMounter.py
+++ b/Code/autopkglib/DmgMounter.py
@@ -50,8 +50,8 @@ class DmgMounter(Processor):
         Returns a tuple - the first plist (if any) and the remaining
         string after the plist"""
 
-        plist_header = b"<?xml version"
-        plist_footer = b"</plist>"
+        plist_header = "<?xml version"
+        plist_footer = "</plist>"
         plist_start_index = text_string.find(plist_header)
         if plist_start_index == -1:
             # not found
@@ -78,6 +78,7 @@ class DmgMounter(Processor):
             bufsize=-1,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            text=True,
         )
         (stdout, stderr) = proc.communicate()
         if stderr:
@@ -89,7 +90,7 @@ class DmgMounter(Processor):
         (pliststr, stdout) = self.get_first_plist(stdout)
         if pliststr:
             try:
-                plist = plistlib.loads(pliststr)
+                plist = plistlib.loads(pliststr.encode())
                 properties = plist.get("Properties")
                 if properties:
                     has_sla = properties.get("Software License Agreement", False)
@@ -123,6 +124,7 @@ class DmgMounter(Processor):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 stdin=subprocess.PIPE,
+                text=True,
             )
             (stdout, stderr) = proc.communicate(stdin)
         except OSError as err:
@@ -135,7 +137,7 @@ class DmgMounter(Processor):
         # Read output plist.
         (pliststr, stdout) = self.get_first_plist(stdout)
         try:
-            output = plistlib.loads(pliststr)
+            output = plistlib.loads(pliststr.encode())
         except Exception:
             raise ProcessorError(
                 f"mounting {pathname} failed: unexpected output from hdiutil"
@@ -165,6 +167,7 @@ class DmgMounter(Processor):
                 ("/usr/bin/hdiutil", "detach", self.mounts[pathname]),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                text=True,
             )
             stderr = proc.communicate()[1]
         except OSError as err:

--- a/Code/autopkglib/FlatPkgUnpacker.py
+++ b/Code/autopkglib/FlatPkgUnpacker.py
@@ -112,7 +112,7 @@ class FlatPkgUnpacker(DmgMounter):
             if self.env.get("skip_payload"):
                 xarcmd.extend(["--exclude", "Payload"])
             proc = subprocess.Popen(
-                xarcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                xarcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
             (_, stderr) = proc.communicate()
         except OSError as err:
@@ -143,7 +143,7 @@ class FlatPkgUnpacker(DmgMounter):
                 self.env["destination_path"],
             ]
             proc = subprocess.Popen(
-                pkgutilcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                pkgutilcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
             (_, stderr) = proc.communicate()
         except OSError as err:

--- a/Code/autopkglib/MunkiCatalogBuilder.py
+++ b/Code/autopkglib/MunkiCatalogBuilder.py
@@ -51,7 +51,7 @@ class MunkiCatalogBuilder(Processor):
         # Call makecatalogs.
         try:
             proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
             (_, err_out) = proc.communicate()
         except OSError as err:

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -483,7 +483,7 @@ class MunkiImporter(Processor):
         # Call makepkginfo.
         try:
             proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=False
             )
             (out, err_out) = proc.communicate()
         except OSError as err:
@@ -492,11 +492,11 @@ class MunkiImporter(Processor):
                 f"{err.strerror}"
             )
         if err_out:
-            for err_line in err_out.splitlines():
+            for err_line in err_out.decode().splitlines():
                 self.output(err_line)
         if proc.returncode != 0:
             raise ProcessorError(
-                f"creating pkginfo for {self.env['pkg_path']} failed: {err_out}"
+                f"creating pkginfo for {self.env['pkg_path']} failed: {err_out.decode()}"
             )
 
         # Get pkginfo from output plist.

--- a/Code/autopkglib/MunkiInfoCreator.py
+++ b/Code/autopkglib/MunkiInfoCreator.py
@@ -80,7 +80,7 @@ class MunkiInfoCreator(Processor):
             # Call makepkginfo.
             try:
                 proc = subprocess.Popen(
-                    args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                    args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=False
                 )
                 (stdout, stderr) = proc.communicate()
             except OSError as err:
@@ -90,7 +90,7 @@ class MunkiInfoCreator(Processor):
                 )
             if proc.returncode != 0:
                 raise ProcessorError(
-                    f"creating pkginfo for {self.env['pkg_path']} failed: {stderr}"
+                    f"creating pkginfo for {self.env['pkg_path']} failed: {stderr.decode()}"
                 )
 
         # makepkginfo cleanup.

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -75,7 +75,7 @@ class MunkiInstallsItemsCreator(Processor):
         # Call makepkginfo.
         try:
             proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=False
             )
             (out, err) = proc.communicate()
         except OSError as err:
@@ -84,7 +84,7 @@ class MunkiInstallsItemsCreator(Processor):
                 f"{err.strerror}"
             )
         if proc.returncode != 0:
-            raise ProcessorError(f"creating pkginfo failed: {err}")
+            raise ProcessorError(f"creating pkginfo failed: {err.decode()}")
 
         # Get pkginfo from output plist.
         pkginfo = plistlib.loads(out)

--- a/Code/autopkglib/PkgCreator.py
+++ b/Code/autopkglib/PkgCreator.py
@@ -100,7 +100,7 @@ class PkgCreator(Processor):
                 "PackageInfo",
             ]
             proc = subprocess.Popen(
-                xarcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                xarcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
             (_, stderr) = proc.communicate()
         except OSError as err:

--- a/Code/autopkglib/PkgExtractor.py
+++ b/Code/autopkglib/PkgExtractor.py
@@ -75,6 +75,7 @@ class PkgExtractor(DmgMounter):
                 ("/usr/bin/ditto", "-x", "-z", archive_path, extract_path),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                text=True,
             )
             (_, stderr) = proc.communicate()
         except OSError as err:

--- a/Code/autopkglib/PkgPayloadUnpacker.py
+++ b/Code/autopkglib/PkgPayloadUnpacker.py
@@ -77,7 +77,7 @@ class PkgPayloadUnpacker(Processor):
                 self.env["destination_path"],
             ]
             proc = subprocess.Popen(
-                dittocmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                dittocmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
             (_, err_out) = proc.communicate()
         except OSError as err:

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -19,7 +19,6 @@
 
 import os
 from distutils.version import LooseVersion
-from operator import itemgetter
 from urllib.parse import quote, urlencode, urlsplit, urlunsplit
 from xml.etree import ElementTree
 
@@ -282,16 +281,6 @@ class SparkleUpdateInfoProvider(URLGetter):
     def main(self):
         """Get URL for latest version in update feed"""
 
-        def compare_version(this, that):
-            """Compare loose versions"""
-            # cmp() doesn't exist in Python3, so this uses the suggested
-            # solutions from What's New In Python 3.0:
-            # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
-            # This will be refactored in Python 3.
-            this_comparison = LooseVersion(this) > LooseVersion(that)
-            that_comparison = LooseVersion(this) < LooseVersion(that)
-            return this_comparison - that_comparison
-
         if "PKG" in self.env:
             self.output("Local PKG provided, no downloaded needed.")
             self.output(
@@ -311,7 +300,8 @@ class SparkleUpdateInfoProvider(URLGetter):
 
         data = self.get_feed_data(self.env.get("appcast_url"))
         items = self.parse_feed_data(data)
-        sorted_items = sorted(items, key=itemgetter("version"), cmp=compare_version)
+
+        sorted_items = sorted(items, key=lambda a: LooseVersion(a["version"]))
         latest = sorted_items[-1]
         self.output(f"Version retrieved from appcast: {latest['version']}")
         if latest.get("human_version"):

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -170,7 +170,7 @@ class SparkleUpdateInfoProvider(URLGetter):
     def determine_version(self, enclosure, url):
         """Gets version from enclosure"""
 
-        version = enclosure.get(f"{self.xmlns}version")
+        version = enclosure.get(f"{{{self.xmlns}}}version")
 
         if version is None:
             # Sparkle tries to guess a version from the download URL for
@@ -225,15 +225,14 @@ class SparkleUpdateInfoProvider(URLGetter):
                 item["url"] = self.build_url(enclosure)
                 item["version"] = self.determine_version(enclosure, item["url"])
 
-                human_version = enclosure.get(f"{self.xmlns}shortVersionString")
+                human_version = enclosure.get(f"{{{self.xmlns}}}shortVersionString")
                 if human_version is not None:
                     item["human_version"] = human_version
-
-                min_version = item_elem.find(f"{self.xmlns}minimumSystemVersion")
+                min_version = item_elem.find(f"{{{self.xmlns}}}minimumSystemVersion")
                 if min_version is not None:
                     item["minimum_os_version"] = min_version.text
 
-                description_elem = item_elem.find(f"{self.xmlns}releaseNotesLink")
+                description_elem = item_elem.find(f"{{{self.xmlns}}}releaseNotesLink")
                 # Strip possible surrounding whitespace around description_url
                 # element text as we'll be passing this as an argument to a
                 # curl process

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -18,11 +18,9 @@
 """See docstring for SparkleUpdateInfoProvider class"""
 
 import os
-import urllib.error
-import urllib.parse as urlparse
-import urllib.request
 from distutils.version import LooseVersion
 from operator import itemgetter
+from urllib.parse import quote, urlencode, urlsplit, urlunsplit
 from xml.etree import ElementTree
 
 from autopkglib import ProcessorError
@@ -148,9 +146,9 @@ class SparkleUpdateInfoProvider(URLGetter):
         # query string
         if "appcast_query_pairs" in self.env:
             queries = self.env["appcast_query_pairs"]
-            new_query = urllib.urlencode([(k, v) for (k, v) in queries.items()])
-            scheme, netloc, path, _, frag = urlparse.urlsplit(url)
-            url = urlparse.urlunsplit((scheme, netloc, path, new_query, frag))
+            new_query = urlencode([(k, v) for (k, v) in queries.items()])
+            scheme, netloc, path, _, frag = urlsplit(url)
+            url = urlunsplit((scheme, netloc, path, new_query, frag))
 
         data = self.fetch_content(url, headers=self.env.get("appcast_request_headers"))
         return data
@@ -159,9 +157,9 @@ class SparkleUpdateInfoProvider(URLGetter):
         """URL-quote the path component to handle spaces, etc.
         (Panic apps do this)"""
 
-        url_bits = urlparse.urlsplit(enclosure.get("url"))
+        url_bits = urlsplit(enclosure.get("url"))
         if self.env.get("urlencode_path_component", True):
-            encoded_path = urllib.quote(url_bits.path)
+            encoded_path = quote(url_bits.path)
         else:
             encoded_path = url_bits.path
         built_url = url_bits.scheme + "://" + url_bits.netloc + encoded_path

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -115,7 +115,7 @@ class URLDownloader(URLGetter):
     def getxattr(self, attr):
         """Get a named xattr from a file. Return None if not present"""
         if attr in xattr.listxattr(self.env["pathname"]):
-            return xattr.getxattr(self.env["pathname"], attr)
+            return xattr.getxattr(self.env["pathname"], attr).decode()
         return None
 
     def prepare_base_curl_cmd(self):

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -125,7 +125,6 @@ class URLDownloader(URLGetter):
             "--silent",
             "--show-error",
             "--no-buffer",
-            "--fail",
             "--dump-header",
             "-",
             "--speed-time",
@@ -141,7 +140,7 @@ class URLDownloader(URLGetter):
         """Assemble file download curl command and return it."""
 
         curl_cmd = self.prepare_base_curl_cmd()
-        curl_cmd.extend(["--output", pathname_temporary])
+        curl_cmd.extend(["--fail", "--output", pathname_temporary])
 
         super().add_curl_common_opts(curl_cmd)
 

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -292,7 +292,7 @@ class URLDownloader(URLGetter):
             xattr.setxattr(
                 self.env["pathname"],
                 self.xattr_last_modified,
-                header.get("last-modified"),
+                header.get("last-modified").encode(),
             )
             self.output(
                 f"Storing new Last-Modified header: {header.get('last-modified')}"
@@ -301,7 +301,9 @@ class URLDownloader(URLGetter):
         self.env["etag"] = ""
         if header.get("etag"):
             self.env["etag"] = header.get("etag")
-            xattr.setxattr(self.env["pathname"], self.xattr_etag, header.get("etag"))
+            xattr.setxattr(
+                self.env["pathname"], self.xattr_etag, header.get("etag").encode()
+            )
             self.output(f"Storing new ETag header: {header.get('etag')}")
 
     def main(self):

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -160,6 +160,7 @@ class URLGetter(Processor):
             curl_cmd,
             shell=False,
             bufsize=1,
+            text=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -154,13 +154,13 @@ class URLGetter(Processor):
                     self.clear_header(header)
         return header
 
-    def execute_curl(self, curl_cmd):
+    def execute_curl(self, curl_cmd, text_mode=True):
         """Execute curl comamnd. Return stdout, stderr and return code."""
         proc = subprocess.Popen(
             curl_cmd,
             shell=False,
             bufsize=1,
-            text=True,
+            text=text_mode,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -170,16 +170,14 @@ class URLGetter(Processor):
 
         return proc_stdout, proc_stderr, proc.returncode
 
-    def download(self, curl_cmd):
+    def download(self, curl_cmd, text_mode=True):
         """Launch curl, return its output, and handle failures."""
 
-        proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)
+        proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd, text_mode)
 
         if retcode:  # Non-zero exit code from curl => problem with download
             curl_err = self.parse_curl_error(proc_stderr)
-            raise ProcessorError(
-                f"curl failure: {curl_err} (exit code {retcode})"
-            )
+            raise ProcessorError(f"curl failure: {curl_err} (exit code {retcode})")
 
         return proc_stdout
 

--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -144,7 +144,9 @@ class Unarchiver(Processor):
 
         # Call command.
         try:
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
             (_, stderr) = proc.communicate()
         except OSError as err:
             raise ProcessorError(

--- a/Code/autopkgserver/autopkginstalld
+++ b/Code/autopkgserver/autopkginstalld
@@ -113,7 +113,7 @@ class RunHandler(socketserver.StreamRequestHandler):
                 plist = plistlib.loads(plist_string)
             except BaseException:
                 self.log.error("Malformed request")
-                self.request.send("ERROR:Malformed request\n")
+                self.request.send("ERROR:Malformed request\n".encode())
                 return
             self.log.debug("Parsed request plist")
 
@@ -125,10 +125,10 @@ class RunHandler(socketserver.StreamRequestHandler):
                 try:
                     installer = Installer(self.log, self.request, plist)
                     installer.install()
-                    self.request.send("OK:DONE\n")
+                    self.request.send("OK:DONE\n".encode())
                 except InstallerError as err:
                     self.log.error(f"Installing failed: {err}")
-                    self.request.send(str(err) + "\n")
+                    self.request.send(f"{err}\n".encode())
             elif "mount_point" in plist:
                 self.log.info(
                     "Dispatching ItemCopier worker to process request for "
@@ -137,17 +137,17 @@ class RunHandler(socketserver.StreamRequestHandler):
                 try:
                     copier = ItemCopier(self.log, self.request, plist)
                     copier.copy()
-                    self.request.send("OK:DONE\n")
+                    self.request.send("OK:DONE\n".encode())
                 except ItemCopierError as err:
                     self.log.error(f"Copying failed: {err}")
-                    self.request.send(str(err) + "\n")
+                    self.request.send(f"{err}\n".encode())
             else:
                 self.log.error("Unsupported request format")
-                self.request.send("ERROR:Unsupported request format")
+                self.request.send("ERROR:Unsupported request format".encode())
 
         except BaseException as err:
             self.log.error(f"Caught exception: {repr(err)}")
-            self.request.send(f"ERROR:Caught exception: {repr(err)}")
+            self.request.send(f"ERROR:Caught exception: {repr(err)}".encode())
 
 
 class AutoPkgInstallDaemonError(Exception):

--- a/Code/autopkgserver/autopkgserver
+++ b/Code/autopkgserver/autopkgserver
@@ -355,8 +355,9 @@ def main(argv):
 
     # Get socket file descriptors from launchd.
     import launch2
+
     try:
-        sockets = launch2.launch_activate_socket(b"AutoPkgServer")
+        sockets = launch2.launch_activate_socket("AutoPkgServer")
     except launch2.LaunchDError as err:
         print(f"launchd check-in failed: {err}", file=sys.stderr)
         time.sleep(10)

--- a/Code/autopkgserver/installer.py
+++ b/Code/autopkgserver/installer.py
@@ -65,7 +65,7 @@ class Installer:
                 output = proc.stdout.readline()
                 if not output and (proc.poll() is not None):
                     break
-                self.socket.send(f"STATUS:{output.encode('UTF-8')}")
+                self.socket.send(f"STATUS:{output}".encode())
                 self.log.info(output.rstrip())
 
             if proc.returncode != 0:

--- a/Code/autopkgserver/installer.py
+++ b/Code/autopkgserver/installer.py
@@ -59,9 +59,10 @@ class Installer:
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
+                text=True,
             )
             while True:
-                output = proc.stdout.readline().decode("UTF-8")
+                output = proc.stdout.readline()
                 if not output and (proc.poll() is not None):
                     break
                 self.socket.send(f"STATUS:{output.encode('UTF-8')}")

--- a/Code/autopkgserver/itemcopier.py
+++ b/Code/autopkgserver/itemcopier.py
@@ -138,8 +138,7 @@ class ItemCopier:
             # all tests passed, OK to copy
             self.log.info(f"Copying {source_itemname} to {full_destpath}")
             self.socket.send(
-                f"STATUS:Copying {source_itemname.encode('UTF-8')} to "
-                f"{full_destpath.encode('UTF-8')}\n"
+                f"STATUS:Copying {source_itemname} to {full_destpath}\n".encode()
             )
             retcode = subprocess.call(
                 ["/bin/cp", "-pR", source_itempath, full_destpath]

--- a/Code/autopkgserver/launch2.py
+++ b/Code/autopkgserver/launch2.py
@@ -41,7 +41,7 @@ def launch_activate_socket(name):
     try:
         fds = POINTER(c_int)()
         cnt = c_size_t(0)
-        err = libc.launch_activate_socket(name, byref(fds), byref(cnt))
+        err = libc.launch_activate_socket(name.encode(), byref(fds), byref(cnt))
         if err:
             raise LaunchDError(
                 f"Failed to retrieve sockets from launchd: {os.strerror(err)}"

--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -88,11 +88,13 @@ class Packager:
 
         def cmd_output(cmd):
             """Outputs a stdout, stderr tuple from command output using a Popen"""
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=False
+            )
             out, err = p.communicate()
             if err:
                 self.log.debug(f"WARNING: errors from command '{', '.join(cmd)}':")
-                self.log.debug(err)
+                self.log.debug(err.decode())
             return (out, err)
 
         def get_mounts():
@@ -276,8 +278,9 @@ class Packager:
                 ("/usr/bin/ditto", self.request["pkgroot"], self.tmp_pkgroot),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                text=True,
             )
-            out, err = p.communicate()
+            (_, err) = p.communicate()
         except OSError as e:
             raise PackagerError(
                 f"ditto execution failed with error code {e.errno}: {e.strerror}"
@@ -394,8 +397,9 @@ class Packager:
                 ),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                text=True,
             )
-            (out, err) = p.communicate()
+            (_, err) = p.communicate()
         except OSError as e:
             raise PackagerError(
                 f"pkgbuild execution failed with error code {e.errno}: {e.strerror}"
@@ -478,9 +482,9 @@ class Packager:
             self.log.info("Sending package build command")
             try:
                 p = subprocess.Popen(
-                    cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                    cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
                 )
-                (out, err) = p.communicate()
+                (_, err) = p.communicate()
             except OSError as e:
                 raise PackagerError(
                     f"pkgbuild execution failed with error code {e.errno}: {e.strerror}"


### PR DESCRIPTION
Fixes to get `URLGetter` code working after py2-to-3 conversion. Currently WIP.

- Popen in `URLGetter` is set to text mode by default 5e3c35c. This is handy when expecting **text* output from subprocess we want to parse/searchh. I made text mode configurable 7c05276 because sometimes we might need bytes output. Popen in `CodeSignatureVerifier` set to text mode only 845337e
- URLDownloader str/bytes fixes beac4a5, 1a1777f
- Fixed SparkleUpdateInfoProvider urllib code 3614ee4
- Fixed SparkleUpdateInfoProvider missing curly brackets bug introduced in py2-to-3 branch
- SparkleUpdateInfoProvider  Sort function converted to Python3 e314375 **Plese take a look** at lambda function solution. It works for me but I don't use lambda very often.
- DmgMounter str/bytes fixes f55d3a0
- URLDownloader calls `curl` with `--fail` only when downlading something. No need for `--fail` when prefetching filname b01d69a

**Update: 17.11.**:

- dbb5acd sets text or binary mode for all Popen calls. **Please take a look**
- beac4a5 and 1a1777f fix autopkgserver socket encoding issues 
