### PR TITLE
URLGetter py2 upgrades

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -145,7 +145,7 @@ class SparkleUpdateInfoProvider(URLGetter):
         dictionary of header-name/value mappings."""
 
         curl_cmd = self.prepare_curl_cmd(url, headers)
-        content = super(SparkleUpdateInfoProvider, self).download(curl_cmd)
+        content = super(SparkleUpdateInfoProvider, self).download_with_curl(curl_cmd)
         return content
 
     def get_feed_data(self, url):

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -128,11 +128,7 @@ class SparkleUpdateInfoProvider(URLGetter):
     def prepare_curl_cmd(self, url, headers=None):
         """Assemble curl command and return it."""
 
-        curl_cmd = [
-            super(SparkleUpdateInfoProvider, self).curl_binary(),
-            "--location",
-            "--compressed",
-        ]
+        curl_cmd = super(SparkleUpdateInfoProvider, self).prepare_curl_cmd()
         super(SparkleUpdateInfoProvider, self).add_curl_common_opts(curl_cmd)
         if headers:
             for header, value in headers.items():

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -129,7 +129,7 @@ class SparkleUpdateInfoProvider(URLGetter):
         """Assemble curl command and return it."""
 
         curl_cmd = super(SparkleUpdateInfoProvider, self).prepare_curl_cmd()
-        super(SparkleUpdateInfoProvider, self).add_curl_common_opts(curl_cmd)
+        self.add_curl_common_opts(curl_cmd)
         if headers:
             for header, value in headers.items():
                 curl_cmd.extend(["--header", "%s: %s" % (header, value)])
@@ -141,7 +141,7 @@ class SparkleUpdateInfoProvider(URLGetter):
         dictionary of header-name/value mappings."""
 
         curl_cmd = self.prepare_curl_cmd(url, headers)
-        content = super(SparkleUpdateInfoProvider, self).download_with_curl(curl_cmd)
+        content = self.download_with_curl(curl_cmd)
         return content
 
     def get_feed_data(self, url):

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -79,8 +79,9 @@ class SparkleUpdateInfoProvider(URLGetter):
                 "is usually equivalent to 'release notes' for that "
                 "specific version. Defaults to "
                 "['minimum_os_version']. "
-                "Currently supported keys: %s."
-                % ", ".join(SUPPORTED_ADDITIONAL_PKGINFO_KEYS)
+                "Currently supported keys: {}.".format(
+                    ", ".join(SUPPORTED_ADDITIONAL_PKGINFO_KEYS)
+                )
             ),
         },
         "urlencode_path_component": {
@@ -132,7 +133,7 @@ class SparkleUpdateInfoProvider(URLGetter):
         self.add_curl_common_opts(curl_cmd)
         if headers:
             for header, value in headers.items():
-                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+                curl_cmd.extend(["--header", "{}: {}".format(header, value)])
         curl_cmd.append(url)
         return curl_cmd
 
@@ -174,7 +175,7 @@ class SparkleUpdateInfoProvider(URLGetter):
     def determine_version(self, enclosure, url):
         """Gets version from enclosure"""
 
-        version = enclosure.get("{%s}version" % self.xmlns)
+        version = enclosure.get("{{{}}}version".format(self.xmlns))
 
         if version is None:
             # Sparkle tries to guess a version from the download URL for
@@ -229,15 +230,21 @@ class SparkleUpdateInfoProvider(URLGetter):
                 item["url"] = self.build_url(enclosure)
                 item["version"] = self.determine_version(enclosure, item["url"])
 
-                human_version = enclosure.get("{%s}shortVersionString" % self.xmlns)
+                human_version = enclosure.get(
+                    "{{{}}}shortVersionString".format(self.xmlns)
+                )
                 if human_version is not None:
                     item["human_version"] = human_version
 
-                min_version = item_elem.find("{%s}minimumSystemVersion" % self.xmlns)
+                min_version = item_elem.find(
+                    "{{{}}}minimumSystemVersion".format(self.xmlns)
+                )
                 if min_version is not None:
                     item["minimum_os_version"] = min_version.text
 
-                description_elem = item_elem.find("{%s}releaseNotesLink" % self.xmlns)
+                description_elem = item_elem.find(
+                    "{{{}}}releaseNotesLink".format(self.xmlns)
+                )
                 # Strip possible surrounding whitespace around description_url
                 # element text as we'll be passing this as an argument to a
                 # curl process
@@ -259,8 +266,8 @@ class SparkleUpdateInfoProvider(URLGetter):
             for k in sparkle_pkginfo_keys:
                 if k not in SUPPORTED_ADDITIONAL_PKGINFO_KEYS:
                     self.output(
-                        "Key %s isn't a supported key to copy from the "
-                        "Sparkle feed, ignoring it." % k
+                        "Key {} isn't a supported key to copy from the "
+                        "Sparkle feed, ignoring it.".format(k)
                     )
             # Format description
             if "description" in sparkle_pkginfo_keys:
@@ -279,8 +286,8 @@ class SparkleUpdateInfoProvider(URLGetter):
                     pkginfo["minimum_os_version"] = latest.get("minimum_os_version")
             for copied_key in pkginfo.keys():
                 self.output(
-                    "Copied key %s from Sparkle feed to additional "
-                    "pkginfo." % copied_key
+                    "Copied key {} from Sparkle feed to additional "
+                    "pkginfo.".format(copied_key)
                 )
         return pkginfo
 
@@ -318,18 +325,19 @@ class SparkleUpdateInfoProvider(URLGetter):
         items = self.parse_feed_data(data)
         sorted_items = sorted(items, key=itemgetter("version"), cmp=compare_version)
         latest = sorted_items[-1]
-        self.output("Version retrieved from appcast: %s" % latest["version"])
+        self.output("Version retrieved from appcast: {}".format(latest["version"]))
         if latest.get("human_version"):
             self.output(
-                "User-facing version retrieved from appcast: %s"
-                % latest["human_version"]
+                "User-facing version retrieved from appcast: {}".format(
+                    latest["human_version"]
+                )
             )
 
         pkginfo = self.handle_pkginfo(latest)
 
         self.env["url"] = latest["url"]
         self.env["version"] = latest.get("human_version", latest["version"])
-        self.output("Found URL %s" % self.env["url"])
+        self.output("Found URL {}".format(self.env["url"]))
         self.env["additional_pkginfo"] = pkginfo
 
 

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -189,7 +189,7 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_base_curl_cmd()
         curl_cmd.extend(["--head"])
 
-        raw_headers = super(URLDownloader, self).download(curl_cmd)
+        raw_headers = super(URLDownloader, self).download_with_curl(curl_cmd)
         header = super(URLDownloader, self).parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):
@@ -330,7 +330,7 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_download_curl_cmd(pathname_temporary)
 
         # Execute curl command and parse headers
-        raw_headers = super(URLDownloader, self).download(curl_cmd)
+        raw_headers = super(URLDownloader, self).download_with_curl(curl_cmd)
         header = super(URLDownloader, self).parse_headers(raw_headers)
 
         if self.download_changed(header):

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -126,7 +126,7 @@ class URLDownloader(URLGetter):
     def prepare_base_curl_cmd(self):
         """Assemble base curl command and return it."""
         curl_cmd = [
-            super(URLDownloader, self).curl_binary(),
+            self.curl_binary(),
             "--silent",
             "--show-error",
             "--no-buffer",
@@ -148,7 +148,7 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_base_curl_cmd()
         curl_cmd.extend(["--output", pathname_temporary])
 
-        super(URLDownloader, self).add_curl_common_opts(curl_cmd)
+        self.add_curl_common_opts(curl_cmd)
 
         # if file already exists and the size is 0, discard it and download again
         if (
@@ -189,8 +189,8 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_base_curl_cmd()
         curl_cmd.extend(["--head"])
 
-        raw_headers = super(URLDownloader, self).download_with_curl(curl_cmd)
-        header = super(URLDownloader, self).parse_headers(raw_headers)
+        raw_headers = self.download_with_curl(curl_cmd)
+        header = self.parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):
             filename = header["content-disposition"].rpartition("filename=")[2]
@@ -330,8 +330,8 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_download_curl_cmd(pathname_temporary)
 
         # Execute curl command and parse headers
-        raw_headers = super(URLDownloader, self).download_with_curl(curl_cmd)
-        header = super(URLDownloader, self).parse_headers(raw_headers)
+        raw_headers = self.download_with_curl(curl_cmd)
+        header = self.parse_headers(raw_headers)
 
         if self.download_changed(header):
             self.env["download_changed"] = True

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -164,9 +164,11 @@ class URLDownloader(URLGetter):
             etag = self.getxattr(self.xattr_etag)
             last_modified = self.getxattr(self.xattr_last_modified)
             if etag:
-                curl_cmd.extend(["--header", "If-None-Match: %s" % etag])
+                curl_cmd.extend(["--header", "If-None-Match: {}".format(etag)])
             if last_modified:
-                curl_cmd.extend(["--header", "If-Modified-Since: %s" % last_modified])
+                curl_cmd.extend(
+                    ["--header", "If-Modified-Since: {}".format(last_modified)]
+                )
 
         return curl_cmd
 
@@ -177,8 +179,8 @@ class URLDownloader(URLGetter):
             del self.env["url_downloader_summary_result"]
 
         # XATTR names for Etag and Last-Modified headers
-        self.xattr_etag = "%s.etag" % BUNDLE_ID
-        self.xattr_last_modified = "%s.last-modified" % BUNDLE_ID
+        self.xattr_etag = "{}.etag".format(BUNDLE_ID)
+        self.xattr_last_modified = "{}.last-modified".format(BUNDLE_ID)
 
         self.env["last_modified"] = ""
         self.env["etag"] = ""
@@ -206,7 +208,7 @@ class URLDownloader(URLGetter):
         if "PKG" in self.env:
             self.env["pathname"] = os.path.expanduser(self.env["PKG"])
             self.env["download_changed"] = True
-            self.output("Given %s, no download needed." % self.env["pathname"])
+            self.output("Given {}, no download needed.".format(self.env["pathname"]))
             return None
 
         if self.env.get("prefetch_filename", False):
@@ -232,7 +234,7 @@ class URLDownloader(URLGetter):
                 os.makedirs(download_dir)
             except OSError as err:
                 raise ProcessorError(
-                    "Can't create %s: %s" % (download_dir, err.strerror)
+                    "Can't create {}: {}".format(download_dir, err.strerror)
                 )
         return download_dir
 
@@ -262,21 +264,21 @@ class URLDownloader(URLGetter):
                 self.env["download_changed"] = False
                 self.output(
                     "File size returned by webserver matches that "
-                    "of the cached file: %s bytes" % size_header
+                    "of the cached file: {} bytes".format(size_header)
                 )
                 self.output(
                     "WARNING: Matching a download by filesize is a "
                     "fallback mechanism that does not guarantee "
                     "that a build is unchanged."
                 )
-                self.output("Using existing %s" % self.env["pathname"])
+                self.output("Using existing {}".format(self.env["pathname"]))
                 return False
 
         if header["http_result_code"] == "304":
             # resource not modified
             self.env["download_changed"] = False
             self.output("Item at URL is unchanged.")
-            self.output("Using existing %s" % self.env["pathname"])
+            self.output("Using existing {}".format(self.env["pathname"]))
             return False
 
         return True
@@ -289,7 +291,7 @@ class URLDownloader(URLGetter):
             os.rename(pathname_temporary, self.env["pathname"])
         except OSError:
             raise ProcessorError(
-                "Can't move %s to %s" % (pathname_temporary, self.env["pathname"])
+                "Can't move {} to {}".format(pathname_temporary, self.env["pathname"])
             )
 
     def store_headers(self, header):
@@ -302,14 +304,16 @@ class URLDownloader(URLGetter):
                 header.get("last-modified"),
             )
             self.output(
-                "Storing new Last-Modified header: %s" % header.get("last-modified")
+                "Storing new Last-Modified header: {}".format(
+                    header.get("last-modified")
+                )
             )
 
         self.env["etag"] = ""
         if header.get("etag"):
             self.env["etag"] = header.get("etag")
             xattr.setxattr(self.env["pathname"], self.xattr_etag, header.get("etag"))
-            self.output("Storing new ETag header: %s" % header.get("etag"))
+            self.output("Storing new ETag header: {}".format(header.get("etag")))
 
     def main(self):
         if not is_mac():
@@ -347,7 +351,7 @@ class URLDownloader(URLGetter):
         self.store_headers(header)
 
         # Generate output messages and variables
-        self.output("Downloaded %s" % self.env["pathname"])
+        self.output("Downloaded {}".format(self.env["pathname"]))
         self.env["url_downloader_summary_result"] = {
             "summary_text": "The following new items were downloaded:",
             "data": {"download_path": self.env["pathname"]},

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -190,7 +190,7 @@ class URLGetter(Processor):
 
         return proc_stdout
 
-    def download(self, url, headers=None):
+    def download(self, url, headers=None, text=False):
         """Download content with default curl options"""
 
         curl_cmd = self.prepare_curl_cmd()

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -47,9 +47,9 @@ class URLGetter(Processor):
                 return curl_path_pref
             else:
                 log_err(
-                    "WARNING: curl path given in the 'CURL_PATH' preference:'%s' "
+                    "WARNING: curl path given in the 'CURL_PATH' preference:'{}' "
                     "either doesn't exist or is not executable! Falling back "
-                    "to one set in PATH, or /usr/bin/curl." % curl_path_pref
+                    "to one set in PATH, or /usr/bin/curl.".format(curl_path_pref)
                 )
 
         for path_env in os.environ["PATH"].split(":"):
@@ -70,7 +70,7 @@ class URLGetter(Processor):
         """Add headers to curl_cmd"""
         if headers:
             for header, value in headers.items():
-                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+                curl_cmd.extend(["--header", "{}: {}".format(header, value)])
 
     def add_curl_common_opts(self, curl_cmd):
         """Add request_headers and curl_opts to curl_cmd"""
@@ -185,7 +185,7 @@ class URLGetter(Processor):
         if retcode:  # Non-zero exit code from curl => problem with download
             curl_err = self.parse_curl_error(proc_stderr)
             raise ProcessorError(
-                "curl failure: %s (exit code %s)" % (curl_err, retcode)
+                "curl failure: {} (exit code {})".format(curl_err, retcode)
             )
 
         return proc_stdout

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -66,10 +66,15 @@ class URLGetter(Processor):
         """Assemble basic curl command and return it."""
         return [self.curl_binary(), "--compressed", "--location"]
 
+    def add_curl_headers(self, curl_cmd, headers):
+        """Add headers to curl_cmd"""
+        if headers:
+            for header, value in headers.items():
+                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+
     def add_curl_common_opts(self, curl_cmd):
         """Add request_headers and curl_opts to curl_cmd"""
-        for header, value in self.env.get("request_headers", {}).items():
-            curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+        self.add_curl_headers(curl_cmd, self.env.get("request_headers"))
 
         for item in self.env.get("curl_opts", []):
             curl_cmd.extend([item])
@@ -185,10 +190,11 @@ class URLGetter(Processor):
 
         return proc_stdout
 
-    def download(self, url):
+    def download(self, url, headers=None):
         """Download content with default curl options"""
 
         curl_cmd = self.prepare_curl_cmd()
+        self.add_curl_headers(curl_cmd, headers)
         curl_cmd.append(url)
         output = self.download_with_curl(curl_cmd)
 

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -62,6 +62,10 @@ class URLGetter(Processor):
 
         raise ProcessorError("Unable to locate or execute any curl binary")
 
+    def prepare_curl_cmd(self):
+        """Assemble basic curl command and return it."""
+        return [self.curl_binary(), "--compressed", "--location"]
+
     def add_curl_common_opts(self, curl_cmd):
         """Add request_headers and curl_opts to curl_cmd"""
         for header, value in self.env.get("request_headers", {}).items():

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -168,7 +168,7 @@ class URLGetter(Processor):
 
         return proc_stdout, proc_stderr, proc.returncode
 
-    def download(self, curl_cmd):
+    def download_with_curl(self, curl_cmd):
         """Launch curl, return its output, and handle failures."""
 
         proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd)

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -185,6 +185,15 @@ class URLGetter(Processor):
 
         return proc_stdout
 
+    def download(self, url):
+        """Download content with default curl options"""
+
+        curl_cmd = self.prepare_curl_cmd()
+        curl_cmd.append(url)
+        output = self.download_with_curl(curl_cmd)
+
+        return output
+
     def main(self):
         pass
 

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -90,7 +90,7 @@ class URLTextSearcher(URLGetter):
         """Assemble curl command and return it."""
 
         curl_cmd = super(URLTextSearcher, self).prepare_curl_cmd()
-        super(URLTextSearcher, self).add_curl_common_opts(curl_cmd)
+        self.add_curl_common_opts(curl_cmd)
         curl_cmd.append(self.env["url"])
         return curl_cmd
 
@@ -116,7 +116,7 @@ class URLTextSearcher(URLGetter):
         curl_cmd = self.prepare_curl_cmd()
 
         # Execute curl command and search in content
-        content = super(URLTextSearcher, self).download_with_curl(curl_cmd)
+        content = self.download_with_curl(curl_cmd)
         groupmatch, groupdict = self.re_search(content)
 
         # favor a named group over a normal group match

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -104,7 +104,7 @@ class URLTextSearcher(URLGetter):
         match = re_pattern.search(content)
 
         if not match:
-            raise ProcessorError("No match found on URL: %s" % self.env["url"])
+            raise ProcessorError("No match found on URL: {}".format(self.env["url"]))
 
         # return the last matched group with the dict of named groups
         return (match.group(match.lastindex or 0), match.groupdict())
@@ -126,7 +126,7 @@ class URLTextSearcher(URLGetter):
         self.output_variables = {}
         for key in groupdict.keys():
             self.env[key] = groupdict[key]
-            self.output("Found matching text (%s): %s" % (key, self.env[key]))
+            self.output("Found matching text ({}): {}".format(key, self.env[key]))
             self.output_variables[key] = {
                 "description": "Matched regular expression group"
             }

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -88,11 +88,8 @@ class URLTextSearcher(URLGetter):
 
     def prepare_curl_cmd(self):
         """Assemble curl command and return it."""
-        curl_cmd = [
-            super(URLTextSearcher, self).curl_binary(),
-            "--location",
-            "--compressed",
-        ]
+
+        curl_cmd = super(URLTextSearcher, self).prepare_curl_cmd()
         super(URLTextSearcher, self).add_curl_common_opts(curl_cmd)
         curl_cmd.append(self.env["url"])
         return curl_cmd

--- a/Code/autopkglib/URLTextSearcher.py
+++ b/Code/autopkglib/URLTextSearcher.py
@@ -119,7 +119,7 @@ class URLTextSearcher(URLGetter):
         curl_cmd = self.prepare_curl_cmd()
 
         # Execute curl command and search in content
-        content = super(URLTextSearcher, self).download(curl_cmd)
+        content = super(URLTextSearcher, self).download_with_curl(curl_cmd)
         groupmatch, groupdict = self.re_search(content)
 
         # favor a named group over a normal group match

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -100,7 +100,7 @@ To save the token, paste it to the following prompt."""
     def prepare_curl_cmd(self, method, accept, headers, data, temp_content):
         """Assemble curl command and return it."""
         curl_cmd = [
-            super(GitHubSession, self).curl_binary(),
+            self.curl_binary(),
             "--location",
             "--silent",
             "--show-error",
@@ -119,7 +119,7 @@ To save the token, paste it to the following prompt."""
                 ["--header", "%s: %s" % ("Authorization", "token %s" % self.token)]
             )
 
-        super(GitHubSession, self).add_curl_common_opts(curl_cmd)
+        self.add_curl_common_opts(curl_cmd)
 
         # Additional headers if defined
         if headers:
@@ -140,10 +140,10 @@ To save the token, paste it to the following prompt."""
     def download_with_curl(self, curl_cmd):
         """Download file using curl and return raw headers."""
 
-        p_stdout, p_stderr, retcode = super(GitHubSession, self).execute_curl(curl_cmd)
+        p_stdout, p_stderr, retcode = self.execute_curl(curl_cmd)
 
         if retcode:  # Non-zero exit code from curl => problem with download
-            curl_err = super(GitHubSession, self).parse_curl_error(p_stderr)
+            curl_err = self.parse_curl_error(p_stderr)
             log_err(
                 "Curl failure: Could not retrieve URL %s: %s"
                 % (self.env["url"], curl_err)
@@ -192,7 +192,7 @@ To save the token, paste it to the following prompt."""
 
         # Execute curl command and parse headers
         raw_headers = self.download_with_curl(curl_cmd)
-        header = super(GitHubSession, self).parse_headers(raw_headers)
+        header = self.parse_headers(raw_headers)
         if header["http_result_code"] != "000":
             self.http_result_code = int(header["http_result_code"])
 

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -137,7 +137,7 @@ To save the token, paste it to the following prompt."""
 
         return curl_cmd
 
-    def download(self, curl_cmd):
+    def download_with_curl(self, curl_cmd):
         """Download file using curl and return raw headers."""
 
         p_stdout, p_stderr, retcode = super(GitHubSession, self).execute_curl(curl_cmd)
@@ -191,7 +191,7 @@ To save the token, paste it to the following prompt."""
         curl_cmd = self.prepare_curl_cmd(method, accept, headers, data, temp_content)
 
         # Execute curl command and parse headers
-        raw_headers = self.download(curl_cmd)
+        raw_headers = self.download_with_curl(curl_cmd)
         header = super(GitHubSession, self).parse_headers(raw_headers)
         if header["http_result_code"] != "000":
             self.http_result_code = int(header["http_result_code"])

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -49,7 +49,9 @@ class GitHubSession(URLGetter):
                     self.token = tokenf.read()
             except IOError as err:
                 log_err(
-                    "Couldn't read token file at %s! Error: %s" % (TOKEN_LOCATION, err)
+                    "Couldn't read token file at {}! Error: {}".format(
+                        TOKEN_LOCATION, err
+                    )
                 )
                 self.token = None
         else:
@@ -71,15 +73,16 @@ To save the token, paste it to the following prompt."""
 
             token = raw_input("Token: ")
             if token:
-                log("""Writing token file %s.""" % TOKEN_LOCATION)
+                log("""Writing token file {}.""".format(TOKEN_LOCATION))
                 try:
                     with open(TOKEN_LOCATION, "w") as tokenf:
                         tokenf.write(token)
                     os.chmod(TOKEN_LOCATION, 0o600)
                 except IOError as err:
                     log_err(
-                        "Couldn't write token file at %s! Error: %s"
-                        % (TOKEN_LOCATION, err)
+                        "Couldn't write token file at {}! Error: {}".format(
+                            TOKEN_LOCATION, err
+                        )
                     )
             else:
                 log("Skipping token file creation.")
@@ -89,7 +92,9 @@ To save the token, paste it to the following prompt."""
                     token = tokenf.read()
             except IOError as err:
                 log_err(
-                    "Couldn't read token file at %s! Error: %s" % (TOKEN_LOCATION, err)
+                    "Couldn't read token file at {}! Error: {}".format(
+                        TOKEN_LOCATION, err
+                    )
                 )
 
             # TODO: validate token given we found one but haven't checked its
@@ -110,13 +115,16 @@ To save the token, paste it to the following prompt."""
         ]
 
         curl_cmd.extend(["-X", method])
-        curl_cmd.extend(["--header", "%s: %s" % ("User-Agent", "AutoPkg")])
-        curl_cmd.extend(["--header", "%s: %s" % ("Accept", accept)])
+        curl_cmd.extend(["--header", "{}: {}".format("User-Agent", "AutoPkg")])
+        curl_cmd.extend(["--header", "{}: {}".format("Accept", accept)])
 
         # Pass the GitHub token as a header
         if self.token:
             curl_cmd.extend(
-                ["--header", "%s: %s" % ("Authorization", "token %s" % self.token)]
+                [
+                    "--header",
+                    "{}: {}".format("Authorization", "token {}".format(self.token)),
+                ]
             )
 
         self.add_curl_common_opts(curl_cmd)
@@ -124,7 +132,7 @@ To save the token, paste it to the following prompt."""
         # Additional headers if defined
         if headers:
             for header, value in headers.items():
-                curl_cmd.extend(["--header", "%s: %s" % (header, value)])
+                curl_cmd.extend(["--header", "{}: {}".format(header, value)])
 
         # Set the data header if defined
         if data:
@@ -145,8 +153,9 @@ To save the token, paste it to the following prompt."""
         if retcode:  # Non-zero exit code from curl => problem with download
             curl_err = self.parse_curl_error(p_stderr)
             log_err(
-                "Curl failure: Could not retrieve URL %s: %s"
-                % (self.env["url"], curl_err)
+                "Curl failure: Could not retrieve URL {}: {}".format(
+                    self.env["url"], curl_err
+                )
             )
 
             if retcode == 22:


### PR DESCRIPTION
Changes to the `URLGetter` and its subclasses to enable `autopkg/recipes` py23 compatibiilty upgrade with use of `URLGetter`.

Similiar changes future ported to py2-to-3 branch in PR #584

Changes:

- Oriignal `download()` method was renamed to `download_with_curl()` so we can use **download** for simpler uses. b1e449b
- `URLGetter` now has `prepare_curl_cmd()` with *default* `curl` command e45ce95. This is used by new `download()` method and subclasses. 71296de
- We now use inherited methods instead of calling `super()` everywhere. 3a17705
- New simple `download()` method 32267dc for use cases where we don't want to specify `curl` command. It takes http headers too 7b47aa1. We don't use `text` argument in python2 code but it's there for recipe compatibility with python3 version.
