### PR TITLE
URLGetter py3 upgrades

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,3 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+known_third_party = autopkglib,certifi,xattr

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -123,7 +123,7 @@ class SparkleUpdateInfoProvider(URLGetter):
     def prepare_curl_cmd(self, url, headers=None):
         """Assemble curl command and return it."""
 
-        curl_cmd = super(SparkleUpdateInfoProvider, self).prepare_curl_cmd()
+        curl_cmd = super().prepare_curl_cmd()
         self.add_curl_common_opts(curl_cmd)
         if headers:
             for header, value in headers.items():

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -183,8 +183,8 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_base_curl_cmd()
         curl_cmd.extend(["--head"])
 
-        raw_headers = super().download_with_curl(curl_cmd)
-        header = super().parse_headers(raw_headers)
+        raw_headers = self.download_with_curl(curl_cmd)
+        header = self.parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):
             filename = header["content-disposition"].rpartition("filename=")[2]

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -183,7 +183,7 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_base_curl_cmd()
         curl_cmd.extend(["--head"])
 
-        raw_headers = super().download(curl_cmd)
+        raw_headers = super().download_with_curl(curl_cmd)
         header = super().parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -75,8 +75,7 @@ class URLGetter(Processor):
 
     def add_curl_common_opts(self, curl_cmd):
         """Add request_headers and curl_opts to curl_cmd"""
-        for header, value in self.env.get("request_headers", {}).items():
-            curl_cmd.extend(["--header", f"{header}: {value}"])
+        self.add_curl_headers(curl_cmd, self.env.get("request_headers"))
 
         for item in self.env.get("curl_opts", []):
             curl_cmd.extend([item])
@@ -197,7 +196,7 @@ class URLGetter(Processor):
         curl_cmd = self.prepare_curl_cmd()
         self.add_curl_headers(curl_cmd, headers)
         curl_cmd.append(url)
-        output = self.download_with_curl(curl_cmd)
+        output = self.download_with_curl(curl_cmd, text_mode)
 
         return output
 

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -163,13 +163,13 @@ class URLGetter(Processor):
                     self.clear_header(header)
         return header
 
-    def execute_curl(self, curl_cmd, text_mode=True):
+    def execute_curl(self, curl_cmd, text=True):
         """Execute curl comamnd. Return stdout, stderr and return code."""
         proc = subprocess.Popen(
             curl_cmd,
             shell=False,
             bufsize=1,
-            text=text_mode,
+            text=text,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -196,7 +196,7 @@ class URLGetter(Processor):
         curl_cmd = self.prepare_curl_cmd()
         self.add_curl_headers(curl_cmd, headers)
         curl_cmd.append(url)
-        output = self.download_with_curl(curl_cmd, text_mode)
+        output = self.download_with_curl(curl_cmd, text)
 
         return output
 


### PR DESCRIPTION
Commits mostly cherry-picked from #583  with conflicts resolved from. However i removed some of @nmcspadden changes in `URLGetter` See 0213609 

Changes to the URLGetter and its subclasses to enable autopkg/recipes py23 compatibiilty upgrade with use of URLGetter.

- Oriignal `download()` method was renamed to `download_with_curl()` so we can use **download** for simpler uses. 2168798
- `URLGetter` now has `prepare_curl_cmd()` with *default* `curl` command 9c4c958. This is used by new `download()` method and subclasses. d008151
- We now use inherited methods instead of calling `super()` everywhere. f7901ed
- New simple `download()` method 0213609 for use cases where we don't want to specify `curl` command. It takes http headers too 2f3dd78. We use `text` argument in python3 code to control format of the method output (string/bytes) 
f8f16e0