### PR TITLE
Fix merge bugs in py2-to-3

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -123,7 +123,7 @@ class SparkleUpdateInfoProvider(URLGetter):
     def prepare_curl_cmd(self, url, headers=None):
         """Assemble curl command and return it."""
 
-        curl_cmd = super(SparkleUpdateInfoProvider, self).prepare_curl_cmd()
+        curl_cmd = super().prepare_curl_cmd()
         self.add_curl_common_opts(curl_cmd)
         if headers:
             for header, value in headers.items():

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -183,8 +183,8 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_base_curl_cmd()
         curl_cmd.extend(["--head"])
 
-        raw_headers = super().download_with_curl(curl_cmd)
-        header = super().parse_headers(raw_headers)
+        raw_headers = self.download_with_curl(curl_cmd)
+        header = self.parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):
             filename = header["content-disposition"].rpartition("filename=")[2]

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -183,7 +183,7 @@ class URLDownloader(URLGetter):
         curl_cmd = self.prepare_base_curl_cmd()
         curl_cmd.extend(["--head"])
 
-        raw_headers = super().download(curl_cmd)
+        raw_headers = super().download_with_curl(curl_cmd)
         header = super().parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -75,8 +75,7 @@ class URLGetter(Processor):
 
     def add_curl_common_opts(self, curl_cmd):
         """Add request_headers and curl_opts to curl_cmd"""
-        for header, value in self.env.get("request_headers", {}).items():
-            curl_cmd.extend(["--header", f"{header}: {value}"])
+        self.add_curl_headers(curl_cmd, self.env.get("request_headers"))
 
         for item in self.env.get("curl_opts", []):
             curl_cmd.extend([item])
@@ -197,7 +196,7 @@ class URLGetter(Processor):
         curl_cmd = self.prepare_curl_cmd()
         self.add_curl_headers(curl_cmd, headers)
         curl_cmd.append(url)
-        output = self.download_with_curl(curl_cmd)
+        output = self.download_with_curl(curl_cmd, text_mode)
 
         return output
 

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -163,13 +163,13 @@ class URLGetter(Processor):
                     self.clear_header(header)
         return header
 
-    def execute_curl(self, curl_cmd, text_mode=True):
+    def execute_curl(self, curl_cmd, text=True):
         """Execute curl comamnd. Return stdout, stderr and return code."""
         proc = subprocess.Popen(
             curl_cmd,
             shell=False,
             bufsize=1,
-            text=text_mode,
+            text=text,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -196,7 +196,7 @@ class URLGetter(Processor):
         curl_cmd = self.prepare_curl_cmd()
         self.add_curl_headers(curl_cmd, headers)
         curl_cmd.append(url)
-        output = self.download_with_curl(curl_cmd, text_mode)
+        output = self.download_with_curl(curl_cmd, text)
 
         return output
 


### PR DESCRIPTION
When I rebased this branch containg same changes (#584) as in #583 (in master) onto current `py2-to-3` which was merged with master I found out there are few lines wrong.

This was missed in the testing because new `prefetch_filename` feature is not used anywhere  yet and `text_mode` which should be `text` has default value we use most of the times.

Additionally there are few syntax updates for py3 only code.