### PR TITLE
WIP: Subprocess run

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -527,23 +527,16 @@ def run_git(git_options_and_arguments, git_directory=None):
     cmd = [gitcmd]
     cmd.extend(git_options_and_arguments)
     try:
-        proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=git_directory,
-            text=True,
-        )
-        (cmd_out, cmd_err) = proc.communicate()
+        proc = subprocess.run(cmd, cwd=git_directory, capture_output=True, text=True)
     except OSError as err:
         raise GitError(
             f"ERROR: git execution failed with error code {err.errno}: "
             f"{err.strerror}"
         )
     if proc.returncode != 0:
-        raise GitError(f"ERROR: {cmd_err}")
+        raise GitError(f"ERROR: {proc.stderr}")
     else:
-        return cmd_out
+        return proc.stdout
 
 
 def get_recipe_repo(git_path):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -527,16 +527,17 @@ def run_git(git_options_and_arguments, git_directory=None):
     cmd = [gitcmd]
     cmd.extend(git_options_and_arguments)
     try:
-        proc = subprocess.run(cmd, cwd=git_directory, capture_output=True, text=True)
+        proc = subprocess.run(
+            cmd, capture_output=True, check=True, cwd=git_directory, text=True
+        )
+    except subprocess.CalledProcessError as err:
+        raise GitError(f"ERROR: {err.stderr}")
     except OSError as err:
         raise GitError(
             f"ERROR: git execution failed with error code {err.errno}: "
             f"{err.strerror}"
         )
-    if proc.returncode != 0:
-        raise GitError(f"ERROR: {proc.stderr}")
-    else:
-        return proc.stdout
+    return proc.stdout
 
 
 def get_recipe_repo(git_path):

--- a/Code/autopkglib/DmgCreator.py
+++ b/Code/autopkglib/DmgCreator.py
@@ -143,16 +143,15 @@ class DmgCreator(Processor):
 
         # Call hdiutil.
         try:
-            proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            (_, stderr) = proc.communicate()
+            proc = subprocess.run(cmd, capture_output=True, text=True)
         except OSError as err:
             raise ProcessorError(
                 f"hdiutil execution failed with error code {err.errno}: {err.strerror}"
             )
         if proc.returncode != 0:
-            raise ProcessorError(f"creation of {self.env['dmg_path']} failed: {stderr}")
+            raise ProcessorError(
+                f"creation of {self.env['dmg_path']} failed: {proc.stderr}"
+            )
 
         self.output(
             f"Created dmg from {self.env['dmg_root']} at {self.env['dmg_path']}"

--- a/Code/autopkglib/DmgCreator.py
+++ b/Code/autopkglib/DmgCreator.py
@@ -16,7 +16,6 @@
 """See docstring for DmgCreator class"""
 
 import os
-import subprocess
 
 from autopkglib import Processor, ProcessorError
 
@@ -142,16 +141,7 @@ class DmgCreator(Processor):
         cmd.extend(["-srcfolder", self.env["dmg_root"], self.env["dmg_path"]])
 
         # Call hdiutil.
-        try:
-            proc = subprocess.run(cmd, capture_output=True, text=True)
-        except OSError as err:
-            raise ProcessorError(
-                f"hdiutil execution failed with error code {err.errno}: {err.strerror}"
-            )
-        if proc.returncode != 0:
-            raise ProcessorError(
-                f"creation of {self.env['dmg_path']} failed: {proc.stderr}"
-            )
+        self.cmdexec(cmd, exception_text=f"creation of {self.env['dmg_path']} failed")
 
         self.output(
             f"Created dmg from {self.env['dmg_root']} at {self.env['dmg_path']}"

--- a/Code/autopkglib/DmgMounter.py
+++ b/Code/autopkglib/DmgMounter.py
@@ -73,20 +73,17 @@ class DmgMounter(Processor):
         """Returns true if dmg has a Software License Agreement.
         These dmgs normally cannot be attached without user intervention"""
         has_sla = False
-        proc = subprocess.Popen(
+        proc = subprocess.run(
             ["/usr/bin/hdiutil", "imageinfo", dmgpath, "-plist"],
-            bufsize=-1,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
         )
-        (stdout, stderr) = proc.communicate()
-        if stderr:
+        if proc.stderr:
             # some error with hdiutil. Print it, but try to continue anyway.
             # (APFS disk images generate extranous output to stderr)
-            self.output(f"hdiutil imageinfo error {stderr} with image {dmgpath}.")
+            self.output(f"hdiutil imageinfo error {proc.stderr} with image {dmgpath}.")
 
-        (pliststr, stdout) = self.get_first_plist(stdout)
+        (pliststr, stdout) = self.get_first_plist(proc.stdout)
         if pliststr:
             try:
                 plist = plistlib.loads(pliststr.encode())
@@ -110,7 +107,7 @@ class DmgMounter(Processor):
 
         # Call hdiutil.
         try:
-            proc = subprocess.Popen(
+            proc = subprocess.run(
                 (
                     "/usr/bin/hdiutil",
                     "attach",
@@ -120,21 +117,19 @@ class DmgMounter(Processor):
                     "-nobrowse",
                     pathname,
                 ),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                stdin=subprocess.PIPE,
+                input=stdin,
+                capture_output=True,
                 text=True,
             )
-            (stdout, stderr) = proc.communicate(stdin)
         except OSError as err:
             raise ProcessorError(
                 f"hdiutil execution failed with error code {err.errno}: {err.strerror}"
             )
         if proc.returncode != 0:
-            raise ProcessorError(f"mounting {pathname} failed: {stderr}")
+            raise ProcessorError(f"mounting {pathname} failed: {proc.stderr}")
 
         # Read output plist.
-        (pliststr, stdout) = self.get_first_plist(stdout)
+        (pliststr, stdout) = self.get_first_plist(proc.stdout)
         try:
             output = plistlib.loads(pliststr.encode())
         except Exception:
@@ -162,19 +157,17 @@ class DmgMounter(Processor):
 
         # Call hdiutil.
         try:
-            proc = subprocess.Popen(
+            proc = subprocess.run(
                 ("/usr/bin/hdiutil", "detach", self.mounts[pathname]),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 text=True,
             )
-            (_, stderr) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 f"hdiutil execution failed with error code {err.errno}: {err.strerror}"
             )
         if proc.returncode != 0:
-            raise ProcessorError(f"unmounting {pathname} failed: {stderr}")
+            raise ProcessorError(f"unmounting {pathname} failed: {proc.stderr}")
 
         # Delete mount from mount list.
         del self.mounts[pathname]

--- a/Code/autopkglib/FlatPkgPacker.py
+++ b/Code/autopkglib/FlatPkgPacker.py
@@ -15,9 +15,7 @@
 # limitations under the License.
 """See docstring for FlatPkgPacker class"""
 
-import subprocess
-
-from autopkglib import Processor, ProcessorError
+from autopkglib import Processor
 
 __all__ = ["FlatPkgPacker"]
 
@@ -45,12 +43,8 @@ class FlatPkgPacker(Processor):
 
     def flatten(self, source_dir, dest_pkg):
         """Flattens a previously expanded flat package"""
-        try:
-            subprocess.check_call(
-                ["/usr/sbin/pkgutil", "--flatten", source_dir, dest_pkg]
-            )
-        except subprocess.CalledProcessError as err:
-            raise ProcessorError(f"{err} flattening {source_dir}")
+        cmd = ["/usr/sbin/pkgutil", "--flatten", source_dir, dest_pkg]
+        self.cmdexec(cmd, exception_text=f"flattening {source_dir} failed")
 
     def main(self):
         source_dir = self.env.get("source_flatpkg_dir")

--- a/Code/autopkglib/FlatPkgUnpacker.py
+++ b/Code/autopkglib/FlatPkgUnpacker.py
@@ -111,17 +111,14 @@ class FlatPkgUnpacker(DmgMounter):
             ]
             if self.env.get("skip_payload"):
                 xarcmd.extend(["--exclude", "Payload"])
-            proc = subprocess.Popen(
-                xarcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            (_, stderr) = proc.communicate()
+            proc = subprocess.run(xarcmd, capture_output=True, text=True)
         except OSError as err:
             raise ProcessorError(
                 f"xar execution failed with error code {err.errno}: {err.strerror}"
             )
         if proc.returncode != 0:
             raise ProcessorError(
-                f"extraction of {self.env['flat_pkg_path']} with xar failed: {stderr}"
+                f"extraction of {self.env['flat_pkg_path']} with xar failed: {proc.stderr}"
             )
 
     def pkgutil_expand(self):
@@ -142,10 +139,7 @@ class FlatPkgUnpacker(DmgMounter):
                 self.source_path,
                 self.env["destination_path"],
             ]
-            proc = subprocess.Popen(
-                pkgutilcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            (_, stderr) = proc.communicate()
+            proc = subprocess.run(pkgutilcmd, capture_output=True, text=True)
         except OSError as err:
             raise ProcessorError(
                 f"pkgutil execution failed with error code {err.errno}: {err.strerror}"
@@ -153,7 +147,7 @@ class FlatPkgUnpacker(DmgMounter):
         if proc.returncode != 0:
             raise ProcessorError(
                 f"extraction of {self.env['flat_pkg_path']} with pkgutil failed: "
-                f"{stderr}"
+                f"{proc.stderr}"
             )
 
     def main(self):

--- a/Code/autopkglib/MunkiCatalogBuilder.py
+++ b/Code/autopkglib/MunkiCatalogBuilder.py
@@ -15,9 +15,7 @@
 # limitations under the License.
 """See docstring for MunkiCatalogBuilder class"""
 
-import subprocess
-
-from autopkglib import Processor, ProcessorError
+from autopkglib import Processor
 
 __all__ = ["MunkiCatalogBuilder"]
 
@@ -39,25 +37,17 @@ class MunkiCatalogBuilder(Processor):
 
     def main(self):
         # MunkiImporter or other processor must set
-        # env["munki_repo_changed"] = True in order for makecatalogs
-        # to run
+        # env["munki_repo_changed"] = True in order for makecatalogs to run
         if not self.env.get("munki_repo_changed"):
             self.output("Skipping makecatalogs because repo is unchanged.")
             return
 
         # Generate arguments for makecatalogs.
-        args = ["/usr/local/munki/makecatalogs", self.env["MUNKI_REPO"]]
+        cmd = ["/usr/local/munki/makecatalogs", self.env["MUNKI_REPO"]]
 
         # Call makecatalogs.
-        try:
-            proc = subprocess.run(args, capture_output=True, text=True)
-        except OSError as err:
-            raise ProcessorError(
-                f"makecatalog execution failed with error code {err.errno}: "
-                f"{err.strerror}"
-            )
-        if proc.returncode != 0:
-            raise ProcessorError(f"makecatalogs failed: {proc.stderr}")
+        self.cmdexec(cmd, exception_text="makecatalogs failed")
+
         self.output("Munki catalogs rebuilt!")
 
 

--- a/Code/autopkglib/MunkiCatalogBuilder.py
+++ b/Code/autopkglib/MunkiCatalogBuilder.py
@@ -50,17 +50,14 @@ class MunkiCatalogBuilder(Processor):
 
         # Call makecatalogs.
         try:
-            proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            (_, err_out) = proc.communicate()
+            proc = subprocess.run(args, capture_output=True, text=True)
         except OSError as err:
             raise ProcessorError(
                 f"makecatalog execution failed with error code {err.errno}: "
                 f"{err.strerror}"
             )
         if proc.returncode != 0:
-            raise ProcessorError(f"makecatalogs failed: {err_out}")
+            raise ProcessorError(f"makecatalogs failed: {proc.stderr}")
         self.output("Munki catalogs rebuilt!")
 
 

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -476,26 +476,23 @@ class MunkiImporter(Processor):
 
         # Call makepkginfo.
         try:
-            proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=False
-            )
-            (out, err_out) = proc.communicate()
+            proc = subprocess.run(args, capture_output=True, text=False)
         except OSError as err:
             raise ProcessorError(
                 f"makepkginfo execution failed with error code {err.errno}: "
                 f"{err.strerror}"
             )
-        if err_out:
-            for err_line in err_out.decode().splitlines():
+        if proc.stderr:
+            for err_line in proc.stderr.decode().splitlines():
                 self.output(err_line)
         if proc.returncode != 0:
             raise ProcessorError(
                 f"creating pkginfo for {self.env['pkg_path']} failed: "
-                f"{err_out.decode()}"
+                f"{proc.stderr.decode()}"
             )
 
         # Get pkginfo from output plist.
-        pkginfo = plistlib.loads(out)
+        pkginfo = plistlib.loads(proc.stdout)
 
         # copy any keys from pkginfo in self.env
         if "pkginfo" in self.env:

--- a/Code/autopkglib/MunkiInfoCreator.py
+++ b/Code/autopkglib/MunkiInfoCreator.py
@@ -79,10 +79,7 @@ class MunkiInfoCreator(Processor):
 
             # Call makepkginfo.
             try:
-                proc = subprocess.Popen(
-                    args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=False
-                )
-                (stdout, stderr) = proc.communicate()
+                proc = subprocess.run(args, capture_output=True, text=False)
             except OSError as err:
                 raise ProcessorError(
                     f"makepkginfo execution failed with error code {err.errno}: "
@@ -90,7 +87,7 @@ class MunkiInfoCreator(Processor):
                 )
             if proc.returncode != 0:
                 raise ProcessorError(
-                    f"creating pkginfo for {self.env['pkg_path']} failed: {stderr.decode()}"
+                    f"creating pkginfo for {self.env['pkg_path']} failed: {proc.stderr.decode()}"
                 )
 
         # makepkginfo cleanup.
@@ -99,7 +96,7 @@ class MunkiInfoCreator(Processor):
                 shutil.rmtree(temp_path)
 
         # Read output plist.
-        output = plistlib.loads(stdout)
+        output = plistlib.loads(proc.stdout)
 
         # Set version and name.
         if "version" in self.env:

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -74,20 +74,17 @@ class MunkiInstallsItemsCreator(Processor):
 
         # Call makepkginfo.
         try:
-            proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=False
-            )
-            (out, err) = proc.communicate()
+            proc = subprocess.run(args, capture_output=True, text=False)
         except OSError as err:
             raise ProcessorError(
                 f"makepkginfo execution failed with error code {err.errno}: "
                 f"{err.strerror}"
             )
         if proc.returncode != 0:
-            raise ProcessorError(f"creating pkginfo failed: {err.decode()}")
+            raise ProcessorError(f"creating pkginfo failed: {proc.stderr.decode()}")
 
         # Get pkginfo from output plist.
-        pkginfo = plistlib.loads(out)
+        pkginfo = plistlib.loads(proc.stdout)
         installs_array = pkginfo.get("installs", [])
 
         if faux_root:

--- a/Code/autopkglib/PkgCreator.py
+++ b/Code/autopkglib/PkgCreator.py
@@ -18,7 +18,6 @@
 import os.path
 import plistlib
 import socket
-import subprocess
 import xml.etree.ElementTree as ET
 
 from autopkglib import Processor, ProcessorError
@@ -89,25 +88,17 @@ class PkgCreator(Processor):
 
     def xar_expand(self, source_path):
         """Uses xar to expand an archive"""
-        try:
-            xarcmd = [
-                "/usr/bin/xar",
-                "-x",
-                "-C",
-                self.env.get("RECIPE_CACHE_DIR"),
-                "-f",
-                source_path,
-                "PackageInfo",
-            ]
-            proc = subprocess.run(xarcmd, capture_output=True, text=True)
-        except OSError as err:
-            raise ProcessorError(
-                f"xar execution failed with error code {err.errno}: {err.strerror}"
-            )
-        if proc.returncode != 0:
-            raise ProcessorError(
-                f"extraction of {source_path} with xar failed: {proc.stderr}"
-            )
+
+        cmd = [
+            "/usr/bin/xar",
+            "-x",
+            "-C",
+            self.env.get("RECIPE_CACHE_DIR"),
+            "-f",
+            source_path,
+            "PackageInfo",
+        ]
+        self.cmdexec(cmd, exception_text=f"extraction of {source_path} with xar failed")
 
     def pkg_already_exists(self, pkg_path, identifier, version):
         """Check for an existing flat package in the output dir and compare its

--- a/Code/autopkglib/PkgCreator.py
+++ b/Code/autopkglib/PkgCreator.py
@@ -99,17 +99,14 @@ class PkgCreator(Processor):
                 source_path,
                 "PackageInfo",
             ]
-            proc = subprocess.Popen(
-                xarcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            (_, stderr) = proc.communicate()
+            proc = subprocess.run(xarcmd, capture_output=True, text=True)
         except OSError as err:
             raise ProcessorError(
                 f"xar execution failed with error code {err.errno}: {err.strerror}"
             )
         if proc.returncode != 0:
             raise ProcessorError(
-                f"extraction of {source_path} with xar failed: {stderr}"
+                f"extraction of {source_path} with xar failed: {proc.stderr}"
             )
 
     def pkg_already_exists(self, pkg_path, identifier, version):

--- a/Code/autopkglib/PkgExtractor.py
+++ b/Code/autopkglib/PkgExtractor.py
@@ -18,7 +18,6 @@
 import os
 import plistlib
 import shutil
-import subprocess
 
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
@@ -70,18 +69,8 @@ class PkgExtractor(DmgMounter):
             raise ProcessorError(f"Failed to create extract_path: {err}")
 
         # Unpack payload.
-        try:
-            proc = subprocess.run(
-                ("/usr/bin/ditto", "-x", "-z", archive_path, extract_path),
-                capture_output=True,
-                text=True,
-            )
-        except OSError as err:
-            raise ProcessorError(
-                f"ditto execution failed with error code {err.errno}: {err.strerror}"
-            )
-        if proc.returncode != 0:
-            raise ProcessorError(f"Unpacking payload failed: {proc.stderr}")
+        cmd = ["/usr/bin/ditto", "-x", "-z", archive_path, extract_path]
+        self.cmdexec(cmd, exception_text="Unpacking payload failed")
 
     def main(self):
         # Check if we're trying to read something inside a dmg.

--- a/Code/autopkglib/PkgExtractor.py
+++ b/Code/autopkglib/PkgExtractor.py
@@ -71,19 +71,17 @@ class PkgExtractor(DmgMounter):
 
         # Unpack payload.
         try:
-            proc = subprocess.Popen(
+            proc = subprocess.run(
                 ("/usr/bin/ditto", "-x", "-z", archive_path, extract_path),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 text=True,
             )
-            (_, stderr) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 f"ditto execution failed with error code {err.errno}: {err.strerror}"
             )
         if proc.returncode != 0:
-            raise ProcessorError(f"Unpacking payload failed: {stderr}")
+            raise ProcessorError(f"Unpacking payload failed: {proc.stderr}")
 
     def main(self):
         # Check if we're trying to read something inside a dmg.

--- a/Code/autopkglib/PkgPayloadUnpacker.py
+++ b/Code/autopkglib/PkgPayloadUnpacker.py
@@ -17,7 +17,6 @@
 
 import os
 import shutil
-import subprocess
 
 from autopkglib import Processor, ProcessorError
 
@@ -68,24 +67,18 @@ class PkgPayloadUnpacker(Processor):
                 except OSError as err:
                     raise ProcessorError(f"Can't remove {path}: {err.strerror}")
 
-        try:
-            dittocmd = [
-                "/usr/bin/ditto",
-                "-x",
-                "-z",
-                self.env["pkg_payload_path"],
-                self.env["destination_path"],
-            ]
-            proc = subprocess.run(dittocmd, capture_output=True, text=True)
-        except OSError as err:
-            raise ProcessorError(
-                f"ditto execution failed with error code {err.errno}: {err.strerror}"
-            )
-        if proc.returncode != 0:
-            raise ProcessorError(
-                f"extraction of {self.env['pkg_payload_path']} with ditto failed: "
-                f"{proc.stderr}"
-            )
+        cmd = [
+            "/usr/bin/ditto",
+            "-x",
+            "-z",
+            self.env["pkg_payload_path"],
+            self.env["destination_path"],
+        ]
+        self.cmdexec(
+            cmd,
+            exception_text=f"extraction of {self.env['pkg_payload_path']} with ditto failed",
+        )
+
         self.output(
             f"Unpacked {self.env['pkg_payload_path']} to {self.env['destination_path']}"
         )

--- a/Code/autopkglib/PkgPayloadUnpacker.py
+++ b/Code/autopkglib/PkgPayloadUnpacker.py
@@ -76,10 +76,7 @@ class PkgPayloadUnpacker(Processor):
                 self.env["pkg_payload_path"],
                 self.env["destination_path"],
             ]
-            proc = subprocess.Popen(
-                dittocmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            (_, err_out) = proc.communicate()
+            proc = subprocess.run(dittocmd, capture_output=True, text=True)
         except OSError as err:
             raise ProcessorError(
                 f"ditto execution failed with error code {err.errno}: {err.strerror}"
@@ -87,7 +84,7 @@ class PkgPayloadUnpacker(Processor):
         if proc.returncode != 0:
             raise ProcessorError(
                 f"extraction of {self.env['pkg_payload_path']} with ditto failed: "
-                f"{err_out}"
+                f"{proc.stderr}"
             )
         self.output(
             f"Unpacked {self.env['pkg_payload_path']} to {self.env['destination_path']}"

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -17,6 +17,7 @@
 """See docstring for URLGetter class"""
 
 import os.path
+import subprocess
 
 from autopkglib import Processor, ProcessorError, find_binary
 
@@ -178,7 +179,7 @@ class URLGetter(Processor):
         """Launch curl and return its output."""
         self.output(f"Curl command: {curl_cmd}", verbose_level=4)
         cmd_result = self.cmdexec(
-            curl_cmd, bufsize=1, exception_text="curl failure", text=text
+            curl_cmd, exception_text="curl failure", text=text, bufsize=1
         )
         return cmd_result["stdout"]
 

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -17,7 +17,6 @@
 """See docstring for URLGetter class"""
 
 import os.path
-import subprocess
 
 from autopkglib import Processor, ProcessorError, find_binary
 
@@ -176,13 +175,12 @@ class URLGetter(Processor):
         return result.stdout, result.stderr, result.returncode
 
     def download_with_curl(self, curl_cmd, text=True):
-        """Launch curl, return its output, and handle failures."""
-        proc_stdout, proc_stderr, retcode = self.execute_curl(curl_cmd, text)
+        """Launch curl and return its output."""
         self.output(f"Curl command: {curl_cmd}", verbose_level=4)
-        if retcode:  # Non-zero exit code from curl => problem with download
-            curl_err = self.parse_curl_error(proc_stderr)
-            raise ProcessorError(f"curl failure: {curl_err} (exit code {retcode})")
-        return proc_stdout
+        cmd_result = self.cmdexec(
+            curl_cmd, bufsize=1, exception_text="curl failure", text=text
+        )
+        return cmd_result["stdout"]
 
     def download(self, url, headers=None, text=False):
         """Download content with default curl options."""

--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -144,10 +144,7 @@ class Unarchiver(Processor):
 
         # Call command.
         try:
-            proc = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            (_, stderr) = proc.communicate()
+            proc = subprocess.run(cmd, capture_output=True, text=True)
         except OSError as err:
             raise ProcessorError(
                 f"{os.path.basename(cmd[0])} execution failed with error code "
@@ -156,7 +153,7 @@ class Unarchiver(Processor):
         if proc.returncode != 0:
             raise ProcessorError(
                 f"Unarchiving {archive_path} with {os.path.basename(cmd[0])} failed: "
-                f"{stderr}"
+                f"{proc.stderr}"
             )
 
         self.output(f"Unarchived {archive_path} to {destination_path}")

--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -17,7 +17,6 @@
 
 import os
 import shutil
-import subprocess
 
 from autopkglib import Processor, ProcessorError
 
@@ -143,18 +142,10 @@ class Unarchiver(Processor):
                 cmd.append("-j")
 
         # Call command.
-        try:
-            proc = subprocess.run(cmd, capture_output=True, text=True)
-        except OSError as err:
-            raise ProcessorError(
-                f"{os.path.basename(cmd[0])} execution failed with error code "
-                f"{err.errno}: {err.strerror}"
-            )
-        if proc.returncode != 0:
-            raise ProcessorError(
-                f"Unarchiving {archive_path} with {os.path.basename(cmd[0])} failed: "
-                f"{proc.stderr}"
-            )
+        self.cmdexec(
+            cmd,
+            exception_text=f"Unarchiving {archive_path} with {os.path.basename(cmd[0])} failed",
+        )
 
         self.output(f"Unarchived {archive_path} to {destination_path}")
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -594,9 +594,7 @@ class Processor:
         self.main()
         return self.env
 
-    def cmdexec(
-        self, cmd, bufsize=-1, check=True, exception_text="", input=None, text=True
-    ):
+    def cmdexec(self, cmd, exception_text="", check=True, text=True, **kwargs):
         """Execute a command and return a dictionary with keys stdout, stderr
         and returncode
 
@@ -607,12 +605,7 @@ class Processor:
 
         try:
             proc = subprocess.run(
-                cmd,
-                bufsize=bufsize,
-                capture_output=True,
-                check=check,
-                input=input,
-                text=text,
+                cmd, capture_output=True, check=check, text=text, **kwargs,
             )
         except subprocess.CalledProcessError as err:
             if text:

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -598,19 +598,16 @@ class Processor:
         """Execute a command and return output."""
 
         try:
-            proc = subprocess.Popen(
-                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
-            (stdout, stderr) = proc.communicate()
+            proc = subprocess.run(command, capture_output=True)
         except OSError as err:
             raise ProcessorError(
                 f"{command[0]} execution failed with error code "
                 f"{err.errno}: {err.strerror}"
             )
         if proc.returncode != 0:
-            raise ProcessorError(f"{description} failed: {stderr}")
+            raise ProcessorError(f"{description} failed: {proc.stderr}")
 
-        return stdout
+        return proc.stdout
 
     def execute_shell(self):
         """Execute as a standalone binary on the commandline."""

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -135,7 +135,7 @@ To save the token, paste it to the following prompt."""
     def download_with_curl(self, curl_cmd):
         """Download file using curl and return raw headers."""
 
-        cmd_result = self.cmdexec(curl_cmd, bufsize=1, check=False)
+        cmd_result = self.cmdexec(curl_cmd, check=False, bufsize=1)
 
         # Non-zero exit code from curl => problem with download
         if cmd_result["returncode"]:

--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -88,11 +88,11 @@ class Packager:
 
         def cmd_output(cmd):
             """Outputs a stdout, stderr tuple from command output using a subprocess."""
-            p = subprocess.run(cmd, capture_output=True, text=False)
-            if p.stderr:
+            proc = subprocess.run(cmd, capture_output=True, text=False)
+            if proc.stderr:
                 self.log.debug(f"WARNING: errors from command '{', '.join(cmd)}':")
-                self.log.debug(p.stderr.decode())
-            return (p.stdout, p.stderr)
+                self.log.debug(proc.stderr.decode())
+            return (proc.stdout, proc.stderr)
 
         def get_mounts():
             """Returns a list of mounted volume paths as reported by diskutil."""
@@ -271,7 +271,7 @@ class Packager:
         os.chmod(self.tmp_pkgroot, 0o1775)
         os.chown(self.tmp_pkgroot, 0, 80)
         try:
-            p = subprocess.run(
+            proc = subprocess.run(
                 ("/usr/bin/ditto", self.request["pkgroot"], self.tmp_pkgroot),
                 capture_output=True,
                 text=True,
@@ -280,10 +280,10 @@ class Packager:
             raise PackagerError(
                 f"ditto execution failed with error code {e.errno}: {e.strerror}"
             )
-        if p.returncode != 0:
+        if proc.returncode != 0:
             raise PackagerError(
                 f"Couldn't copy pkgroot from {self.request['pkgroot']} to "
-                f"{self.tmp_pkgroot}: {' '.join(str(p.stderr).split())}"
+                f"{self.tmp_pkgroot}: {' '.join(str(proc.stderr).split())}"
             )
 
         self.log.info(f"Package root copied to {self.tmp_pkgroot}")
@@ -380,7 +380,7 @@ class Packager:
         turn off package relocation"""
         self.component_plist = os.path.join(self.tmproot, "component.plist")
         try:
-            p = subprocess.run(
+            proc = subprocess.run(
                 (
                     "/usr/bin/pkgbuild",
                     "--analyze",
@@ -395,10 +395,10 @@ class Packager:
             raise PackagerError(
                 f"pkgbuild execution failed with error code {e.errno}: {e.strerror}"
             )
-        if p.returncode != 0:
+        if proc.returncode != 0:
             raise PackagerError(
-                f"pkgbuild failed with exit code {p.returncode}: "
-                f"{' '.join(str(p.stderr).split())}"
+                f"pkgbuild failed with exit code {proc.returncode}: "
+                f"{' '.join(str(proc.stderr).split())}"
             )
         try:
             with open(self.component_plist, "rb") as f:
@@ -472,15 +472,15 @@ class Packager:
             # Execute pkgbuild.
             self.log.info("Sending package build command")
             try:
-                p = subprocess.run(cmd, capture_output=True, text=True)
+                proc = subprocess.run(cmd, capture_output=True, text=True)
             except OSError as e:
                 raise PackagerError(
                     f"pkgbuild execution failed with error code {e.errno}: {e.strerror}"
                 )
-            if p.returncode != 0:
+            if proc.returncode != 0:
                 raise PackagerError(
-                    f"pkgbuild failed with exit code {p.returncode}: "
-                    f"{' '.join(str(p.stderr).split())}"
+                    f"pkgbuild failed with exit code {proc.returncode}: "
+                    f"{' '.join(str(proc.stderr).split())}"
                 )
             self.log.info("Changing name and owner")
             # Change to final name and owner.


### PR DESCRIPTION
Use new (since Python 3.5) `subprocess.run()` in most cases. Smaller code footprint. Unification of `stdout`, `stderr` and `proc` variable names.