### PR TITLE
Add debug output to URLDownloader.prefetch_filename()

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -177,9 +177,21 @@ class URLDownloader(URLGetter):
 
         if "filename=" in header.get("content-disposition", ""):
             filename = header["content-disposition"].rpartition("filename=")[2]
+            self.output(
+                f"Filename prefetched from the HTTP Content-Disposition header: {filename}",
+                verbose_level=2,
+            )
         elif header.get("http_redirected", None):
             filename = header["http_redirected"].rpartition("/")[2]
+            self.output(
+                f"Filename prefetched from the HTTP Location header: {filename}",
+                verbose_level=2,
+            )
         else:
+            self.output(
+                "Unable to find filename in the HTTP headers during prefetch",
+                verbose_level=2,
+            )
             return None
 
         return filename


### PR DESCRIPTION
Adds `verbose_level=2` output to `prefetch_filename()` method printing out what filename was found in which header. This should help autopkg users to debug their recipes.

Requested here https://github.com/autopkg/autopkg/issues/432#issuecomment-559154131