### PR TITLE
Versioner changes and unittests

### DIFF
--- a/Code/autopkglib/Versioner.py
+++ b/Code/autopkglib/Versioner.py
@@ -16,9 +16,7 @@
 """See docstring for Versioner class"""
 
 import os.path
-import plistlib
 
-from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
 
 __all__ = ["Versioner"]
@@ -61,20 +59,13 @@ class Versioner(DmgMounter):
             else:
                 # just use the given path
                 input_plist_path = self.env["input_plist_path"]
-            if not os.path.exists(input_plist_path):
-                raise ProcessorError(
-                    f"File '{input_plist_path}' does not exist or could not be read."
-                )
-            try:
-                with open(input_plist_path, "rb") as f:
-                    plist = plistlib.load(f)
-                version_key = self.env.get("plist_version_key")
-                self.env["version"] = plist.get(version_key, "UNKNOWN_VERSION")
-                self.output(
-                    f"Found version {self.env['version']} in file {input_plist_path}"
-                )
-            except Exception as err:
-                raise ProcessorError(err)
+            plist = self.load_plist_from_file(input_plist_path)
+            self.env["version"] = plist.get(
+                self.env["plist_version_key"], "UNKNOWN_VERSION"
+            )
+            self.output(
+                f"Found version {self.env['version']} in file {input_plist_path}"
+            )
 
         finally:
             if dmg:

--- a/Code/autopkglib/Versioner.py
+++ b/Code/autopkglib/Versioner.py
@@ -19,6 +19,8 @@ import os.path
 
 from autopkglib.DmgMounter import DmgMounter
 
+NO_VERSION_MESSAGE = "UNKNOWN_VERSION"
+
 __all__ = ["Versioner"]
 
 
@@ -61,7 +63,7 @@ class Versioner(DmgMounter):
                 input_plist_path = self.env["input_plist_path"]
             plist = self.load_plist_from_file(input_plist_path)
             self.env["version"] = plist.get(
-                self.env["plist_version_key"], "UNKNOWN_VERSION"
+                self.env["plist_version_key"], NO_VERSION_MESSAGE
             )
             self.output(
                 f"Found version {self.env['version']} in file {input_plist_path}"

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -626,6 +626,18 @@ class Processor:
         else:
             sys.exit(0)
 
+    def load_plist_from_file(plist_path, exception_text="Unable to load plist"):
+        """Load plist from file and return content as dictionary"""
+        if not os.path.exists(plist_path):
+            raise ProcessorError(
+                f"File '{plist_path}' does not exist or could not be read."
+            )
+        try:
+            with open(plist_path, "rb") as f:
+                return plistlib.load(f)
+        except Exception as err:
+            raise ProcessorError(f"{exception_text}: {err}")
+
 
 # AutoPackager class defintion
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -628,10 +628,6 @@ class Processor:
 
     def load_plist_from_file(plist_path, exception_text="Unable to load plist"):
         """Load plist from file and return content as dictionary"""
-        if not os.path.exists(plist_path):
-            raise ProcessorError(
-                f"File '{plist_path}' does not exist or could not be read."
-            )
         try:
             with open(plist_path, "rb") as f:
                 return plistlib.load(f)

--- a/Code/tests/test_versioner.py
+++ b/Code/tests/test_versioner.py
@@ -1,0 +1,99 @@
+#!/usr/local/autopkg/python
+
+import plistlib
+import unittest
+from textwrap import dedent
+from unittest.mock import patch
+
+from autopkglib.Versioner import NO_VERSION_MESSAGE, Versioner
+
+
+class TestVersioner(unittest.TestCase):
+    """Test class for Versioner Processor."""
+
+    version_default_key = "CFBundleShortVersionString"
+    version_default = "1.2.3"
+    version_custom_key = "com.someapp.customversion"
+    version_custom = "3.2.1"
+
+    info_plist = dedent(
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleShortVersionString</key>
+            <string>{version_default}</string>
+            <key>{version_custom_key}</key>
+            <string>{version_custom}</string>
+        </dict>
+        </plist>
+    """
+    ).encode()
+
+    no_version_plist = dedent(
+        """<?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        </dict>
+        </plist>
+    """
+    ).encode()
+
+    def setUp(self):
+        self.good_env = {
+            "input_plist_path": "dummy_path",
+            "plist_version_key": self.version_default_key,
+        }
+        self.bad_env = {}
+        self.input_plist = plistlib.dumps(self.good_env)
+        self.processor = Versioner(infile=self.input_plist)
+        self.processor.env = self.good_env
+
+    def tearDown(self):
+        pass
+
+    @patch("autopkglib.Versioner.load_plist_from_file")
+    @patch("autopkglib.Versioner.parsePathForDMG")
+    def run_direct_plist(self, plist, mock_dmg, mock_plist):
+        mock_dmg.return_value = (self.processor.env["input_plist_path"], "", "")
+        mock_plist.return_value = plistlib.loads(plist)
+        self.processor.main()
+
+    @patch("autopkglib.Versioner.unmount")
+    @patch("autopkglib.Versioner.mount")
+    @patch("autopkglib.Versioner.load_plist_from_file")
+    @patch("autopkglib.Versioner.parsePathForDMG")
+    def run_dmg_plist(self, mock_dmg, mock_plist, mock_mount, mock_unmount):
+        mock_dmg.return_value = ("path_to_dmg", ".dmg/", "path_to_plist")
+        mock_plist.return_value = plistlib.loads(self.info_plist)
+        mock_mount.return_value = "dmg_mount_point"
+        self.processor.main()
+
+    def test_no_fail_if_good_env(self):
+        """The processor should not raise any exceptions if run normally."""
+        self.run_direct_plist(self.info_plist)
+
+    def test_find_cfbundle_short_version(self):
+        """The processor should find version in default CFBundleShortVersionString."""
+        self.run_direct_plist(self.info_plist)
+        self.assertEqual(self.processor.env["version"], self.version_default)
+
+    def test_find_custom_version(self):
+        """The processor should find version under key specified by plist_version_key."""
+        self.processor.env["plist_version_key"] = self.version_custom_key
+        self.run_direct_plist(self.info_plist)
+        self.assertEqual(self.processor.env["version"], self.version_custom)
+
+    def test_no_version_found(self):
+        """The processor should not find version if plist misses it."""
+        self.run_direct_plist(self.no_version_plist)
+        self.assertEqual(self.processor.env["version"], NO_VERSION_MESSAGE)
+
+    def test_no_fail_if_dmg(self):
+        """The processor should not raise any exceptions when plist is in the dmg image."""
+        self.run_dmg_plist()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Code/tests/test_versioner.py
+++ b/Code/tests/test_versioner.py
@@ -53,46 +53,50 @@ class TestVersioner(unittest.TestCase):
     def tearDown(self):
         pass
 
-    @patch("autopkglib.Versioner.load_plist_from_file")
-    @patch("autopkglib.Versioner.parsePathForDMG")
     def run_direct_plist(self, plist, mock_dmg, mock_plist):
+        """Find version in specified plist file."""
         mock_dmg.return_value = (self.processor.env["input_plist_path"], "", "")
         mock_plist.return_value = plistlib.loads(plist)
         self.processor.main()
+
+    @patch("autopkglib.Versioner.load_plist_from_file")
+    @patch("autopkglib.Versioner.parsePathForDMG")
+    def test_no_fail_if_good_env(self, mock_dmg, mock_plist):
+        """The processor should not raise any exceptions if run normally."""
+        self.run_direct_plist(self.info_plist, mock_dmg, mock_plist)
+
+    @patch("autopkglib.Versioner.load_plist_from_file")
+    @patch("autopkglib.Versioner.parsePathForDMG")
+    def test_find_cfbundle_short_version(self, mock_dmg, mock_plist):
+        """The processor should find version in default CFBundleShortVersionString."""
+        self.run_direct_plist(self.info_plist, mock_dmg, mock_plist)
+        self.assertEqual(self.processor.env["version"], self.version_default)
+
+    @patch("autopkglib.Versioner.load_plist_from_file")
+    @patch("autopkglib.Versioner.parsePathForDMG")
+    def test_find_custom_version(self, mock_dmg, mock_plist):
+        """The processor should find version under key specified by plist_version_key."""
+        self.processor.env["plist_version_key"] = self.version_custom_key
+        self.run_direct_plist(self.info_plist, mock_dmg, mock_plist)
+        self.assertEqual(self.processor.env["version"], self.version_custom)
+
+    @patch("autopkglib.Versioner.load_plist_from_file")
+    @patch("autopkglib.Versioner.parsePathForDMG")
+    def test_no_version_found(self, mock_dmg, mock_plist):
+        """The processor should not find version if plist misses it."""
+        self.run_direct_plist(self.no_version_plist, mock_dmg, mock_plist)
+        self.assertEqual(self.processor.env["version"], NO_VERSION_MESSAGE)
 
     @patch("autopkglib.Versioner.unmount")
     @patch("autopkglib.Versioner.mount")
     @patch("autopkglib.Versioner.load_plist_from_file")
     @patch("autopkglib.Versioner.parsePathForDMG")
-    def run_dmg_plist(self, mock_dmg, mock_plist, mock_mount, mock_unmount):
+    def test_no_fail_if_dmg(self, mock_dmg, mock_plist, mock_mount, mock_unmount):
+        """The processor should not raise any exceptions when plist is in the dmg image."""
         mock_dmg.return_value = ("path_to_dmg", ".dmg/", "path_to_plist")
         mock_plist.return_value = plistlib.loads(self.info_plist)
         mock_mount.return_value = "dmg_mount_point"
         self.processor.main()
-
-    def test_no_fail_if_good_env(self):
-        """The processor should not raise any exceptions if run normally."""
-        self.run_direct_plist(self.info_plist)
-
-    def test_find_cfbundle_short_version(self):
-        """The processor should find version in default CFBundleShortVersionString."""
-        self.run_direct_plist(self.info_plist)
-        self.assertEqual(self.processor.env["version"], self.version_default)
-
-    def test_find_custom_version(self):
-        """The processor should find version under key specified by plist_version_key."""
-        self.processor.env["plist_version_key"] = self.version_custom_key
-        self.run_direct_plist(self.info_plist)
-        self.assertEqual(self.processor.env["version"], self.version_custom)
-
-    def test_no_version_found(self):
-        """The processor should not find version if plist misses it."""
-        self.run_direct_plist(self.no_version_plist)
-        self.assertEqual(self.processor.env["version"], NO_VERSION_MESSAGE)
-
-    def test_no_fail_if_dmg(self):
-        """The processor should not raise any exceptions when plist is in the dmg image."""
-        self.run_dmg_plist()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Code for loading plists was moved into base `Processor. self.load_plist_from_file()` method (da3a354 and 428831a) This method could be used in other processors. Ouput:
    - If path to plist does not exist or is inaccessible: `File '{plist_path}' does not exist or could not be read.`
    - if plistlib fails to load plist: `"{exception_text}: {err}"` where default exception_text is `Unable to load plist`
- There is new Versioner module constant `NO_VERSION_MESSAGE` which is used in both Versioner class and unittests. (8687925)
- Unittest class `TestVersioner` (69d36ca)

Unittest output:

```
test_find_cfbundle_short_version (tests.test_versioner.TestVersioner)
The processor should find version in default CFBundleShortVersionString. ... ok
--
test_find_custom_version (tests.test_versioner.TestVersioner)
The processor should find version under key specified by plist_version_key. ... ok
--
test_no_fail_if_dmg (tests.test_versioner.TestVersioner)
The processor should not raise any exceptions when plist is in the dmg image. ... ok
--
test_no_fail_if_good_env (tests.test_versioner.TestVersioner)
The processor should not raise any exceptions if run normally. ... ok
--
test_no_version_found (tests.test_versioner.TestVersioner)
The processor should not find version if plist misses it. ... ok
```

