### PR TITLE
Handle missing url environment variable

### DIFF
--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -160,7 +160,7 @@ class URLGetter(Processor):
                 self.parse_http_protocol(line, header)
             elif ": " in line:
                 self.parse_http_header(line, header)
-            elif self.env["url"].startswith("ftp://"):
+            elif self.env.get("url", "").startswith("ftp://"):
                 self.parse_ftp_header(line, header)
             elif line == "":
                 # we got an empty line; end of headers (or curl exited)


### PR DESCRIPTION
There may not be a `url` environment variable in all cases, and this change allows parsing headers regardless.