### PR TITLE
Generate useful output if AutoPkg detects a Python 2 wrapper

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -65,7 +65,7 @@ if sys.platform != "darwin":
     )
 
 # Catch Python 2 wrappers with an early f-string. Message must be on a single line.
-_ = f"""{_} It looks like you're running the autopkg tool with an incompatible version of Python. Please update your script to use autopkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with autopkg 2. """
+_ = f"""{sys.version_info.major} It looks like you're running the autopkg tool with an incompatible version of Python. Please update your script to use autopkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with autopkg 2. """
 
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -65,7 +65,7 @@ if sys.platform != "darwin":
     )
 
 # Catch Python 2 wrappers with an early f-string. Message must be on a single line.
-_ = f"""{_} It looks like you're wrapping an AutoPkg call in an incompatible version of Python. Please update your script to use AutoPkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with AutoPkg 2. """
+_ = f"""{_} It looks like you're running the autopkg tool with an incompatible version of Python. Please update your script to use autopkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with autopkg 2. """
 
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -65,7 +65,7 @@ if sys.platform != "darwin":
     )
 
 # Catch Python 2 wrappers with an early f-string. Message must be on a single line.
-_ = f"""{sys.version_info.major} It looks like you're running the autopkg tool with an incompatible version of Python. Please update your script to use autopkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with autopkg 2. """
+_ = f"""{sys.version_info.major} It looks like you're running the autopkg tool with an incompatible version of Python. Please update your script to use autopkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with autopkg 2. """  # noqa
 
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -64,6 +64,9 @@ if sys.platform != "darwin":
 """
     )
 
+# Catch Python 2 wrappers with an early f-string. Message must be on a single line.
+_ = f"""{_} It looks like you're wrapping an AutoPkg call in an incompatible version of Python. Please update your script to use AutoPkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with AutoPkg 2. """
+
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70
 


### PR DESCRIPTION
Current behavior in AutoPkg 2.0rc1 when a user attempts to run AutoPkg with a version of Python that doesn't support f-strings is the following.

```
% ./autopkg version
2.0.1
% /usr/bin/python ./autopkg version
  File "./autopkg", line 126
    log_err(f"WARNING: plist error for {filename}: {err}")
                                                        ^
SyntaxError: invalid syntax
```

This applies to AutoPkg runner scripts that explicitly call `/usr/bin/python /usr/local/bin/autopkg run`, but more broadly applies to users of AutoPkgr 1.5.1 and earlier (https://github.com/lindegroup/autopkgr/issues/635):

![image](https://user-images.githubusercontent.com/7801391/72835166-15870d80-3c3f-11ea-84dd-93aadbbd58ea.png)

The problem here is that "plist error" implies an actual problem worth troubleshooting, when in reality line 126 just happens to be the first line where an f-string is encountered.

It would be nice to be able to use try/except to catch the SyntaxError here, but that doesn't work because the error occurs at parsing time and not at runtime. However, adding an early f-string with informational output in a string seems to be a good halfway solution for sending people down the correct troubleshooting path.

With this PR, here's the expected output on the command line:

```
% /usr/bin/python ./autopkg version
  File "./autopkg", line 68
    _ = f"""{sys.version_info.major} It looks like you're running the autopkg tool with an incompatible version of Python. Please update your script to use autopkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with autopkg 2. """
                                                                                                                                                                                                                                                                                                                  ^
SyntaxError: invalid syntax
```

And here's what it would look like in AutoPkgr:

![image](https://user-images.githubusercontent.com/7801391/72835921-76fbac00-3c40-11ea-8e13-366e25ab3de6.png)
