### PR TITLE
Minor adjustments to processor docstrings

### DIFF
--- a/Code/autopkglib/EndOfCheckPhase.py
+++ b/Code/autopkglib/EndOfCheckPhase.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Place-holder processor that autopkg uses to mark the end of the check
-phase"""
+phase."""
 
 from autopkglib import Processor
 
@@ -22,7 +22,8 @@ __all__ = ["EndOfCheckPhase"]
 
 
 class EndOfCheckPhase(Processor):
-    """This processor does nothing at all."""
+    """This processor performs no action, but serves as a marker to signal
+    where AutoPkg should stop when the -c/--check options are used."""
 
     input_variables = {}
     output_variables = {}

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -86,7 +86,7 @@ class SparkleUpdateInfoProvider(URLGetter):
         "urlencode_path_component": {
             "required": False,
             "description": (
-                "Boolean value to specify if the path component"
+                "Boolean value to specify if the path component "
                 "from the sparkle feed needs to be urlencoded. "
                 "Defaults to True."
             ),


### PR DESCRIPTION
This change updates the docstring for EndOfCheckPhase to provide more information about its conventional use for people reading the [wiki page](https://github.com/autopkg/autopkg/wiki/Processor-EndOfCheckPhase). It also adds a missing space to the SparkleUpdateInfoProvider docstring.

No functional changes to code, so I'm not including any log output here.