### PR TITLE
Remove orphaned valid_plist_with_keys() function

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -140,13 +140,6 @@ def valid_recipe_plist_with_keys(recipe_plist, keys_to_verify):
     return False
 
 
-def valid_plist_with_keys(filename, keys_to_verify):
-    """Attempts to read a plist file and ensures the keys in
-    keys_to_verify exist. Returns False on any failure, True otherwise."""
-    recipe_plist = recipe_plist_from_file(filename)
-    return valid_plist_with_keys(recipe_plist, keys_to_verify)
-
-
 def valid_recipe_plist(recipe_plist):
     """Returns True if recipe plist is a valid recipe,
     otherwise returns False"""


### PR DESCRIPTION
This function appears to have been orphaned at some point in the past (probably here: https://github.com/autopkg/autopkg/commit/b754923952d5c3e6eead1e09d5fa4bc7ff193863). A search through the source code reveals that the only reference to the function is in its own return value. If it was ever used again, it would result in a loop. It can be safely removed.

```
% grep -R 'valid_plist_with_keys(' *
Code/autopkg:def valid_plist_with_keys(filename, keys_to_verify):
Code/autopkg:    return valid_plist_with_keys(recipe_plist, keys_to_verify)
```