### PR TITLE
Add support for recipes in yaml format

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -131,21 +131,21 @@ def valid_recipe_dict_with_keys(recipe_dict, keys_to_verify):
     return False
 
 
-def valid_recipe_dict(recipe_plist):
+def valid_recipe_dict(recipe_dict):
     """Returns True if recipe dict is a valid recipe,
     otherwise returns False"""
     return (
-        valid_recipe_dict_with_keys(recipe_plist, ["Input", "Process"])
-        or valid_recipe_dict_with_keys(recipe_plist, ["Input", "Recipe"])
-        or valid_recipe_dict_with_keys(recipe_plist, ["Input", "ParentRecipe"])
+        valid_recipe_dict_with_keys(recipe_dict, ["Input", "Process"])
+        or valid_recipe_dict_with_keys(recipe_dict, ["Input", "Recipe"])
+        or valid_recipe_dict_with_keys(recipe_dict, ["Input", "ParentRecipe"])
     )
 
 
 def valid_recipe_file(filename):
     """Returns True if filename contains a valid recipe,
     otherwise returns False"""
-    recipe_plist = recipe_from_file(filename)
-    return valid_recipe_dict(recipe_plist)
+    recipe_dict = recipe_from_file(filename)
+    return valid_recipe_dict(recipe_dict)
 
 
 def valid_override_plist(recipe_plist):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -51,7 +51,7 @@ from autopkglib import (
     log,
     log_err,
     processor_names,
-    recipe_plist_from_file,
+    recipe_from_file,
     set_pref,
     version_equal_or_greater,
 )
@@ -131,7 +131,7 @@ def valid_recipe_plist_with_keys(recipe_plist, keys_to_verify):
 def valid_plist_with_keys(filename, keys_to_verify):
     """Attempts to read a plist file and ensures the keys in
     keys_to_verify exist. Returns False on any failure, True otherwise."""
-    recipe_plist = recipe_plist_from_file(filename)
+    recipe_plist = recipe_from_file(filename)
     return valid_plist_with_keys(recipe_plist, keys_to_verify)
 
 
@@ -148,7 +148,7 @@ def valid_recipe_plist(recipe_plist):
 def valid_recipe_file(filename):
     """Returns True if filename contains a valid recipe,
     otherwise returns False"""
-    recipe_plist = recipe_plist_from_file(filename)
+    recipe_plist = recipe_from_file(filename)
     return valid_recipe_plist(recipe_plist)
 
 
@@ -163,7 +163,7 @@ def valid_override_plist(recipe_plist):
 def valid_override_file(filename):
     """Returns True if filename contains a valid override,
     otherwise returns False"""
-    override_plist = recipe_plist_from_file(filename)
+    override_plist = recipe_from_file(filename)
     return valid_override_plist(override_plist)
 
 
@@ -357,7 +357,7 @@ def load_recipe(
 
     if recipe_file:
         # read it
-        recipe = recipe_plist_from_file(recipe_file)
+        recipe = recipe_from_file(recipe_file)
 
         # store parent trust info, but only if this is an override
         if recipe_in_override_dir(recipe_file, override_dirs):
@@ -1206,7 +1206,7 @@ def get_recipe_list(
         )
 
         for match in matches:
-            recipe = recipe_plist_from_file(match)
+            recipe = recipe_from_file(match)
             if valid_recipe_plist(recipe):
                 recipe_name = os.path.basename(match)
 
@@ -1230,7 +1230,7 @@ def get_recipe_list(
         for filename in os.listdir(normalized_dir):
             if filename.endswith(".recipe"):
                 pathname = os.path.join(normalized_dir, filename)
-                override = recipe_plist_from_file(pathname)
+                override = recipe_from_file(pathname)
 
                 if valid_override_plist(override):
                     # override points to a valid recipe
@@ -1792,7 +1792,7 @@ def update_trust_info(argv):
             continue
         # normalize recipe path
         recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
-        recipe = recipe_plist_from_file(recipe_path)
+        recipe = recipe_from_file(recipe_path)
         if "ParentRecipe" not in recipe:
             log_err(f"{recipe_name} is not a recipe override and has no parent recipe.")
             log_err(f"Path: {recipe_path}")

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -343,7 +343,7 @@ def load_recipe(
     search_github=True,
 ):
     """Loads a recipe, first locating it by name.
-    If we find one, we load it and return the plist object (which
+    If we find one, we load it and return the plist or yaml object (which
     should be functionally equivelent to a dictionary). If an override file is
     used, it prefers finding the original recipe by identifier rather than
     name, so that if recipe names shift with updated recipe repos, the
@@ -1997,7 +1997,7 @@ def make_override(argv):
     if os.path.exists(override_file):
         if not options.force:
             log_err(
-                f"An override plist already exists at {override_file}, "
+                f"A recipe override already exists at {override_file}, "
                 "will not overwrite it. Use --force to overwrite "
                 "anyway."
             )

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -357,8 +357,7 @@ def load_recipe(
 
     if recipe_file:
         # read it
-        with open(recipe_file, "rb") as f:
-            recipe = plistlib.load(f)
+        recipe = recipe_plist_from_file(recipe_file)
 
         # store parent trust info, but only if this is an override
         if recipe_in_override_dir(recipe_file, override_dirs):
@@ -1793,8 +1792,7 @@ def update_trust_info(argv):
             continue
         # normalize recipe path
         recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
-        with open(recipe_path, "rb") as f:
-            recipe = plistlib.load(f)
+        recipe = recipe_plist_from_file(recipe_path)
         if "ParentRecipe" not in recipe:
             log_err(f"{recipe_name} is not a recipe override and has no parent recipe.")
             log_err(f"Path: {recipe_path}")

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -51,6 +51,7 @@ from autopkglib import (
     log,
     log_err,
     processor_names,
+    recipe_plist_from_file,
     set_pref,
     version_equal_or_greater,
 )
@@ -113,19 +114,6 @@ def has_check_phase(recipe):
 def builds_a_package(recipe):
     """Does this recipe build any packages?"""
     return recipe_has_step_processor(recipe, "PkgCreator")
-
-
-def recipe_plist_from_file(filename):
-    """Create a recipe plist from a file. Handle exceptions and log"""
-    if os.path.isfile(filename):
-        try:
-            # make sure we can read it
-            with open(filename, "rb") as f:
-                recipe_plist = plistlib.load(f)
-        except Exception as err:
-            log_err(f"WARNING: plist error for {filename}: {err}")
-            return
-        return recipe_plist
 
 
 def valid_recipe_plist_with_keys(recipe_plist, keys_to_verify):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1957,8 +1957,8 @@ def make_override(argv):
         )
         return 1
 
-    override_name = (
-        options.name or os.path.splitext(os.path.basename(recipe["RECIPE_PATH"]))[0]
+    override_name = options.name or remove_recipe_extension(
+        os.path.basename(recipe["RECIPE_PATH"])
     )
 
     reversed_name = ".".join(reversed(override_name.split(".")))
@@ -1986,8 +1986,8 @@ def make_override(argv):
             log_err(f"Could not create {override_dir}: {err}")
             return -1
 
-    override_name = (
-        options.name or os.path.splitext(os.path.basename(recipe["RECIPE_PATH"]))[0]
+    override_name = options.name or remove_recipe_extension(
+        os.path.basename(recipe["RECIPE_PATH"])
     )
 
     override_file = os.path.join(override_dir, f"{override_name}.recipe")

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1213,27 +1213,29 @@ def get_recipe_list(
             continue
 
         # find all top-level recipes and recipes one level down
-        matches = glob.glob(os.path.join(normalized_dir, "*.recipe")) + glob.glob(
-            os.path.join(normalized_dir, "*/*.recipe")
+        patterns = [os.path.join(normalized_dir, f"*{ext}") for ext in RECIPE_EXTS]
+        patterns.extend(
+            [os.path.join(normalized_dir, f"*/*{ext}") for ext in RECIPE_EXTS]
         )
+        for pattern in patterns:
+            matches = glob.glob(pattern)
+            for match in matches:
+                recipe = recipe_from_file(match)
+                if valid_recipe_plist(recipe):
+                    recipe_name = os.path.basename(match)
 
-        for match in matches:
-            recipe = recipe_from_file(match)
-            if valid_recipe_plist(recipe):
-                recipe_name = os.path.basename(match)
+                    recipe["Name"] = remove_recipe_extension(recipe_name)
+                    recipe["Path"] = match
 
-                recipe["Name"] = os.path.splitext(recipe_name)[0]
-                recipe["Path"] = match
+                    # If a top level "Identifier" key is not discovered,
+                    # this will copy an IDENTIFIER key in the "Input"
+                    # entry to the top level of the recipe dictionary.
+                    if "Identifier" not in recipe:
+                        identifier = get_identifier(recipe)
+                        if identifier:
+                            recipe["Identifier"] = identifier
 
-                # If a top level "Identifier" key is not discovered,
-                # this will copy an IDENTIFIER key in the "Input"
-                # entry to the top level of the recipe dictionary.
-                if "Identifier" not in recipe:
-                    identifier = get_identifier(recipe)
-                    if identifier:
-                        recipe["Identifier"] = identifier
-
-                recipes.append(recipe)
+                    recipes.append(recipe)
 
     for directory in override_dirs:
         normalized_dir = os.path.abspath(os.path.expanduser(directory))

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -35,6 +35,7 @@ from urllib.parse import quote, urlparse
 
 import autopkglib.github
 from autopkglib import (
+    RECIPE_EXTS,
     AutoPackager,
     AutoPackagerError,
     PreferenceError,
@@ -67,9 +68,6 @@ if sys.platform != "darwin":
 
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70
-
-# Supported recipe extensions
-RECIPE_EXTS = (".recipe", ".recipe.plist", ".recipe.yaml")
 
 
 def print_version(argv):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -170,14 +170,21 @@ def valid_override_file(filename):
     return valid_override_plist(override_plist)
 
 
+def remove_recipe_extension(name):
+    """Removes supported recipe extensions from a filename or path.
+    If the filename or path does not end with any known recipe extension,
+    the name is returned as is."""
+    for ext in RECIPE_EXTS:
+        if name.endswith(ext):
+            return name[: -len(ext)]
+    return name
+
+
 def find_recipe_by_name(name, search_dirs):
     """Search search_dirs for a recipe by file/directory naming rules"""
     # drop extension from the end of the name because we're
     # going to add it back on...
-    for ext in RECIPE_EXTS:
-        if name.endswith(ext):
-            name = name[: -len(ext)]
-            break  # stop after first extension match
+    name = remove_recipe_extension(name)
 
     # search by "Name", using file/directory hierarchy rules
     for directory in search_dirs:
@@ -1147,9 +1154,8 @@ def list_processors(argv):
 
 def make_suggestions_for(search_name):
     """Suggest existing recipes with names similar to search name."""
-    # trim '.recipe' from the end if it exists
-    if os.path.splitext(search_name)[1].lower() == ".recipe":
-        search_name = os.path.splitext(search_name)[0]
+    # trim extension from the end if it exists
+    search_name = remove_recipe_extension(search_name)
     (search_name_base, search_name_ext) = os.path.splitext(search_name.lower())
     recipe_names = [os.path.splitext(item["Name"]) for item in get_recipe_list()]
     recipe_names = list(set(recipe_names))

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -119,12 +119,12 @@ def builds_a_package(recipe):
     return recipe_has_step_processor(recipe, "PkgCreator")
 
 
-def valid_recipe_plist_with_keys(recipe_plist, keys_to_verify):
-    """Attempts to read a plist and ensures the keys in
-    keys_to_verify exist. Returns False on any failure, True otherwise."""
-    if recipe_plist:
+def valid_recipe_dict_with_keys(recipe_dict, keys_to_verify):
+    """Ensures the keys in keys_to_verify exist in the recipe
+    dict. Returns False on any failure, True otherwise."""
+    if recipe_dict:
         for key in keys_to_verify:
-            if key not in recipe_plist:
+            if key not in recipe_dict:
                 return False
         # if we get here, we found all the keys
         return True
@@ -135,9 +135,9 @@ def valid_recipe_dict(recipe_plist):
     """Returns True if recipe dict is a valid recipe,
     otherwise returns False"""
     return (
-        valid_recipe_plist_with_keys(recipe_plist, ["Input", "Process"])
-        or valid_recipe_plist_with_keys(recipe_plist, ["Input", "Recipe"])
-        or valid_recipe_plist_with_keys(recipe_plist, ["Input", "ParentRecipe"])
+        valid_recipe_dict_with_keys(recipe_plist, ["Input", "Process"])
+        or valid_recipe_dict_with_keys(recipe_plist, ["Input", "Recipe"])
+        or valid_recipe_dict_with_keys(recipe_plist, ["Input", "ParentRecipe"])
     )
 
 
@@ -151,9 +151,9 @@ def valid_recipe_file(filename):
 def valid_override_plist(recipe_plist):
     """Returns True if the recipe is a valid override,
     otherwise returns False"""
-    return valid_recipe_plist_with_keys(
+    return valid_recipe_dict_with_keys(
         recipe_plist, ["Input", "ParentRecipe"]
-    ) or valid_recipe_plist_with_keys(recipe_plist, ["Input", "Recipe"])
+    ) or valid_recipe_dict_with_keys(recipe_plist, ["Input", "Recipe"])
 
 
 def valid_override_file(filename):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -68,6 +68,9 @@ if sys.platform != "darwin":
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70
 
+# Supported recipe extensions
+RECIPE_EXTS = (".recipe", ".recipe.plist", ".recipe.yaml")
+
 
 def print_version(argv):
     """Prints autopkg version"""
@@ -169,17 +172,20 @@ def valid_override_file(filename):
 
 def find_recipe_by_name(name, search_dirs):
     """Search search_dirs for a recipe by file/directory naming rules"""
-    if name.endswith(".recipe"):
-        # drop ".recipe" from the end of the name because we're
-        # going to add it back on...
-        name = os.path.splitext(name)[0]
+    # drop extension from the end of the name because we're
+    # going to add it back on...
+    for ext in RECIPE_EXTS:
+        if name.endswith(ext):
+            name = name[: -len(ext)]
+            break  # stop after first extension match
+
     # search by "Name", using file/directory hierarchy rules
     for directory in search_dirs:
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
-        patterns = [
-            os.path.join(normalized_dir, f"{name}.recipe"),
-            os.path.join(normalized_dir, f"*/{name}.recipe"),
-        ]
+        patterns = [os.path.join(normalized_dir, f"{name}{ext}") for ext in RECIPE_EXTS]
+        patterns.extend(
+            [os.path.join(normalized_dir, f"*/{name}{ext}") for ext in RECIPE_EXTS]
+        )
         for pattern in patterns:
             matches = glob.glob(pattern)
             for match in matches:

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2328,7 +2328,7 @@ def run_recipes(argv):
             )
 
         # build a pathname for a receipt
-        recipe_basename = os.path.splitext(os.path.basename(recipe_path))[0]
+        recipe_basename = remove_recipe_extension(os.path.basename(recipe_path))
         # TO-DO: if recipe processing fails too early,
         # autopackager.env["RECIPE_CACHE_DIR"] is not defined and we can't
         # write a recipt. We should handle this better.

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -53,6 +53,7 @@ from autopkglib import (
     log_err,
     processor_names,
     recipe_from_file,
+    remove_recipe_extension,
     set_pref,
     version_equal_or_greater,
 )
@@ -159,16 +160,6 @@ def valid_override_file(filename):
     otherwise returns False"""
     override_dict = recipe_from_file(filename)
     return valid_override_dict(override_dict)
-
-
-def remove_recipe_extension(name):
-    """Removes supported recipe extensions from a filename or path.
-    If the filename or path does not end with any known recipe extension,
-    the name is returned as is."""
-    for ext in RECIPE_EXTS:
-        if name.endswith(ext):
-            return name[: -len(ext)]
-    return name
 
 
 def find_recipe_by_name(name, search_dirs):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -131,8 +131,8 @@ def valid_recipe_plist_with_keys(recipe_plist, keys_to_verify):
     return False
 
 
-def valid_recipe_plist(recipe_plist):
-    """Returns True if recipe plist is a valid recipe,
+def valid_recipe_dict(recipe_plist):
+    """Returns True if recipe dict is a valid recipe,
     otherwise returns False"""
     return (
         valid_recipe_plist_with_keys(recipe_plist, ["Input", "Process"])
@@ -145,7 +145,7 @@ def valid_recipe_file(filename):
     """Returns True if filename contains a valid recipe,
     otherwise returns False"""
     recipe_plist = recipe_from_file(filename)
-    return valid_recipe_plist(recipe_plist)
+    return valid_recipe_dict(recipe_plist)
 
 
 def valid_override_plist(recipe_plist):
@@ -1216,7 +1216,7 @@ def get_recipe_list(
             matches = glob.glob(pattern)
             for match in matches:
                 recipe = recipe_from_file(match)
-                if valid_recipe_plist(recipe):
+                if valid_recipe_dict(recipe):
                     recipe_name = os.path.basename(match)
 
                     recipe["Name"] = remove_recipe_extension(recipe_name)

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -188,6 +188,7 @@ def find_recipe_by_name(name, search_dirs):
 
     # search by "Name", using file/directory hierarchy rules
     for directory in search_dirs:
+        # TODO: Combine with similar code in get_recipe_list()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         patterns = [os.path.join(normalized_dir, f"{name}{ext}") for ext in RECIPE_EXTS]
         patterns.extend(
@@ -1208,6 +1209,7 @@ def get_recipe_list(
 
     recipes = []
     for directory in search_dirs:
+        # TODO: Combine with similar code in find_recipe_by_name()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         if not os.path.isdir(normalized_dir):
             continue

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -179,7 +179,7 @@ def find_recipe_by_name(name, search_dirs):
 
     # search by "Name", using file/directory hierarchy rules
     for directory in search_dirs:
-        # TODO: Combine with similar code in get_recipe_list()
+        # TODO: Combine with similar code in get_recipe_list() and find_recipe_by_identifier()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         patterns = [os.path.join(normalized_dir, f"{name}{ext}") for ext in RECIPE_EXTS]
         patterns.extend(
@@ -1200,7 +1200,7 @@ def get_recipe_list(
 
     recipes = []
     for directory in search_dirs:
-        # TODO: Combine with similar code in find_recipe_by_name()
+        # TODO: Combine with similar code in find_recipe_by_name() and find_recipe_by_identifier()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         if not os.path.isdir(normalized_dir):
             continue

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -34,6 +34,7 @@ import traceback
 from urllib.parse import quote, urlparse
 
 import autopkglib.github
+import yaml
 from autopkglib import (
     RECIPE_EXTS,
     AutoPackager,
@@ -1814,8 +1815,12 @@ def update_trust_info(argv):
             recipe["ParentRecipeTrustInfo"] = get_trust_info(
                 parent_recipe, search_dirs=search_dirs
             )
-            with open(recipe_path, "wb") as f:
-                plistlib.dump(recipe, f)
+            if recipe_path.endswith(".recipe.yaml"):
+                with open(recipe_path, "wb") as f:
+                    yaml.dump(recipe, f, encoding="utf-8")
+            else:
+                with open(recipe_path, "wb") as f:
+                    plistlib.dump(recipe, f)
             log(f"Wrote updated {recipe_path}")
         else:
             log_err(

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -159,8 +159,8 @@ def valid_override_dict(recipe_dict):
 def valid_override_file(filename):
     """Returns True if filename contains a valid override,
     otherwise returns False"""
-    override_plist = recipe_from_file(filename)
-    return valid_override_dict(override_plist)
+    override_dict = recipe_from_file(filename)
+    return valid_override_dict(override_dict)
 
 
 def remove_recipe_extension(name):
@@ -1967,19 +1967,19 @@ def make_override(argv):
     reversed_name = ".".join(reversed(override_name.split(".")))
     override_identifier = "local." + reversed_name
 
-    override_plist = {
+    override_dict = {
         "Identifier": override_identifier,
         "Input": recipe["Input"],
         "ParentRecipe": parent_identifier,
     }
 
     # add trust info
-    override_plist["ParentRecipeTrustInfo"] = get_trust_info(
+    override_dict["ParentRecipeTrustInfo"] = get_trust_info(
         recipe, search_dirs=search_dirs
     )
 
-    if "IDENTIFIER" in override_plist["Input"]:
-        del override_plist["Input"]["IDENTIFIER"]
+    if "IDENTIFIER" in override_dict["Input"]:
+        del override_dict["Input"]["IDENTIFIER"]
 
     override_dir = os.path.expanduser(override_dirs[0])
     if not os.path.exists(os.path.join(override_dir)):
@@ -2004,7 +2004,7 @@ def make_override(argv):
             return -1
         os.unlink(override_file)
     with open(override_file, "wb") as f:
-        plistlib.dump(override_plist, f)
+        plistlib.dump(override_dict, f)
     log(f"Override file saved to {override_file}")
     return 0
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -148,19 +148,19 @@ def valid_recipe_file(filename):
     return valid_recipe_dict(recipe_dict)
 
 
-def valid_override_plist(recipe_plist):
+def valid_override_dict(recipe_dict):
     """Returns True if the recipe is a valid override,
     otherwise returns False"""
     return valid_recipe_dict_with_keys(
-        recipe_plist, ["Input", "ParentRecipe"]
-    ) or valid_recipe_dict_with_keys(recipe_plist, ["Input", "Recipe"])
+        recipe_dict, ["Input", "ParentRecipe"]
+    ) or valid_recipe_dict_with_keys(recipe_dict, ["Input", "Recipe"])
 
 
 def valid_override_file(filename):
     """Returns True if filename contains a valid override,
     otherwise returns False"""
     override_plist = recipe_from_file(filename)
-    return valid_override_plist(override_plist)
+    return valid_override_dict(override_plist)
 
 
 def remove_recipe_extension(name):
@@ -1241,7 +1241,7 @@ def get_recipe_list(
                 pathname = os.path.join(normalized_dir, filename)
                 override = recipe_from_file(pathname)
 
-                if valid_override_plist(override):
+                if valid_override_dict(override):
                     # override points to a valid recipe
                     override_name = os.path.basename(pathname)
                     override["Name"] = os.path.splitext(override_name)[0]

--- a/Code/autopkglib/DeprecationWarning.py
+++ b/Code/autopkglib/DeprecationWarning.py
@@ -19,7 +19,7 @@ upcoming removal of a recipe."""
 
 import os
 
-from autopkglib import Processor
+from autopkglib import Processor, remove_recipe_extension
 
 __all__ = ["DeprecationWarning"]
 
@@ -47,8 +47,7 @@ class DeprecationWarning(Processor):
         )
         self.output(warning_message)
         recipe_name = os.path.basename(self.env["RECIPE_PATH"])
-        if recipe_name.endswith(".recipe"):
-            recipe_name = os.path.splitext(recipe_name)[0]
+        recipe_name = remove_recipe_extension(recipe_name)
         self.env["deprecation_summary_result"] = {
             "summary_text": "The following recipes have deprecation warnings:",
             "report_fields": ["name", "warning"],

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -277,7 +277,7 @@ def log_err(msg):
     log(msg, error=True)
 
 
-def recipe_plist_from_file(filename):
+def recipe_from_file(filename):
     """Create a recipe plist from a file. Handle exceptions and log"""
     if os.path.isfile(filename):
         try:
@@ -309,7 +309,7 @@ def get_identifier_from_recipe_file(filename):
     identifier. Otherwise, returns None."""
     recipe_plist = {}
     # make sure we can read it
-    recipe_plist = recipe_plist_from_file(filename)
+    recipe_plist = recipe_from_file(filename)
     return get_identifier(recipe_plist)
 
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -308,12 +308,8 @@ def get_identifier_from_recipe_file(filename):
     """Attempts to read plist file filename and get the
     identifier. Otherwise, returns None."""
     recipe_plist = {}
-    try:
-        # make sure we can read it
-        with open(filename, "rb") as f:
-            recipe_plist = plistlib.load(f)
-    except Exception as err:
-        log_err(f"WARNING: plist error for {filename}: {err}")
+    # make sure we can read it
+    recipe_plist = recipe_plist_from_file(filename)
     return get_identifier(recipe_plist)
 
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -30,6 +30,8 @@ import sys
 import traceback
 from distutils.version import LooseVersion
 
+import yaml
+
 
 class memoize(dict):
     """Class to cache the return values of an expensive function.
@@ -278,16 +280,26 @@ def log_err(msg):
 
 
 def recipe_from_file(filename):
-    """Create a recipe plist from a file. Handle exceptions and log"""
+    """Create a recipe from a plist or yaml file. Handle exceptions and log"""
     if os.path.isfile(filename):
-        try:
-            # make sure we can read it
-            with open(filename, "rb") as f:
-                recipe_plist = plistlib.load(f)
-        except Exception as err:
-            log_err(f"WARNING: plist error for {filename}: {err}")
-            return
-        return recipe_plist
+
+        if filename.endswith((".recipe", ".plist")):
+            try:
+                # try to read it as a plist
+                with open(filename, "rb") as f:
+                    recipe_dict = plistlib.load(f)
+                return recipe_dict
+            except Exception as err:
+                log_err(f"WARNING: plist error for {filename}: {err}")
+
+        elif filename.endswith(".yaml"):
+            try:
+                # try to read it as yaml
+                with open(filename, "rb") as f:
+                    recipe_dict = yaml.load(f, Loader=yaml.FullLoader)
+                return recipe_dict
+            except Exception as err:
+                log_err(f"WARNING: yaml error for {filename}: {err}")
 
 
 def get_identifier(recipe):

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -32,6 +32,9 @@ from distutils.version import LooseVersion
 
 import yaml
 
+# Supported recipe extensions
+RECIPE_EXTS = (".recipe", ".recipe.plist", ".recipe.yaml")
+
 
 class memoize(dict):
     """Class to cache the return values of an expensive function.

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -277,6 +277,19 @@ def log_err(msg):
     log(msg, error=True)
 
 
+def recipe_plist_from_file(filename):
+    """Create a recipe plist from a file. Handle exceptions and log"""
+    if os.path.isfile(filename):
+        try:
+            # make sure we can read it
+            with open(filename, "rb") as f:
+                recipe_plist = plistlib.load(f)
+        except Exception as err:
+            log_err(f"WARNING: plist error for {filename}: {err}")
+            return
+        return recipe_plist
+
+
 def get_identifier(recipe):
     """Return identifier from recipe dict. Tries the Identifier
     top-level key and falls back to the legacy key location."""

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -332,11 +332,12 @@ def find_recipe_by_identifier(identifier, search_dirs):
     """Search search_dirs for a recipe with the given
     identifier"""
     for directory in search_dirs:
+        # TODO: Combine with similar code in get_recipe_list() and find_recipe_by_name()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
-        patterns = [
-            os.path.join(normalized_dir, "*.recipe"),
-            os.path.join(normalized_dir, "*/*.recipe"),
-        ]
+        patterns = [os.path.join(normalized_dir, f"*{ext}") for ext in RECIPE_EXTS]
+        patterns.extend(
+            [os.path.join(normalized_dir, f"*/*{ext}") for ext in RECIPE_EXTS]
+        )
         for pattern in patterns:
             matches = glob.glob(pattern)
             for match in matches:

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -317,12 +317,12 @@ def get_identifier(recipe):
 
 
 def get_identifier_from_recipe_file(filename):
-    """Attempts to read plist file filename and get the
+    """Attempts to read recipe file and get the
     identifier. Otherwise, returns None."""
-    recipe_plist = {}
+    recipe_dict = {}
     # make sure we can read it
-    recipe_plist = recipe_from_file(filename)
-    return get_identifier(recipe_plist)
+    recipe_dict = recipe_from_file(filename)
+    return get_identifier(recipe_dict)
 
 
 def find_recipe_by_identifier(identifier, search_dirs):

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -282,6 +282,16 @@ def log_err(msg):
     log(msg, error=True)
 
 
+def remove_recipe_extension(name):
+    """Removes supported recipe extensions from a filename or path.
+    If the filename or path does not end with any known recipe extension,
+    the name is returned as is."""
+    for ext in RECIPE_EXTS:
+        if name.endswith(ext):
+            return name[: -len(ext)]
+    return name
+
+
 def recipe_from_file(filename):
     """Create a recipe from a plist or yaml file. Handle exceptions and log"""
     if os.path.isfile(filename):

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -283,16 +283,7 @@ def recipe_from_file(filename):
     """Create a recipe from a plist or yaml file. Handle exceptions and log"""
     if os.path.isfile(filename):
 
-        if filename.endswith((".recipe", ".plist")):
-            try:
-                # try to read it as a plist
-                with open(filename, "rb") as f:
-                    recipe_dict = plistlib.load(f)
-                return recipe_dict
-            except Exception as err:
-                log_err(f"WARNING: plist error for {filename}: {err}")
-
-        elif filename.endswith(".yaml"):
+        if filename.endswith(".yaml"):
             try:
                 # try to read it as yaml
                 with open(filename, "rb") as f:
@@ -300,6 +291,15 @@ def recipe_from_file(filename):
                 return recipe_dict
             except Exception as err:
                 log_err(f"WARNING: yaml error for {filename}: {err}")
+
+        else:
+            try:
+                # try to read it as a plist
+                with open(filename, "rb") as f:
+                    recipe_dict = plistlib.load(f)
+                return recipe_dict
+            except Exception as err:
+                log_err(f"WARNING: plist error for {filename}: {err}")
 
 
 def get_identifier(recipe):

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,7 @@ These tasks typically involve at least several of the following steps:
 
 Often these tasks follow similar patterns for each individual application, and when managing many applications this becomes a daily task full of sub-tasks that one must remember (and/or maintain documentation for) about exactly what had to be done for a successful deployment of every update for every managed piece of software.
 
-With AutoPkg, we define these steps in a "Recipe" plist-based format, run automatically instead of by hand, and shared with others.
+With AutoPkg, we define these steps in a "Recipe" plist or yaml format, run automatically instead of by hand, and shared with others.
 
 
 Installation


### PR DESCRIPTION
## Overview

**This PR adds native support for recipes in yaml format.**

The primary benefit of yaml recipes is readability. For people who don't already spend a lot of time looking at plists, yaml recipes are much easier to parse at a glance. Some examples of yaml recipes are already present in @grahampugh's [recipe repo](https://github.com/autopkg/grahampugh-recipes/tree/master/YAML), and I think the difference is clear:

<img width="1903" alt="Image 1" src="https://user-images.githubusercontent.com/7801391/74601306-80b2dc80-5051-11ea-9c44-4f7e3d90dcdf.png">

Aside from the significant reduction in lines needed, there's also no need to escape characters through XML, as demonstrated in the URLTextSearcher regex pattern in the example above.

A secondary benefit of this change is that it includes a lot of the work required to support other recipe formats (e.g. json).

## Timing

Because the addition of a new recipe format is a major feature addition and requires careful testing, I would propose targeting **AutoPkg 2.1** for this merge, with at least one release candidate before the final release.

## Order of dictionary keys

As with plists, the order of keys in a dictionary does not matter, and creating yaml files programmatically often results in alphabetic key order. But unlike plists, yaml dictionaries have less visual separation from each other due to the lack of indentation, so the key order may affect readability more dramatically than in plists.

Specifically: ensuring that the Processor key comes before the Arguments key in processor dictionaries significantly improves how yaml recipes can be scanned by humans. The difference can easily be seen here (arrow indicate the direction of scan when reading the recipe):

![Image 3 001](https://user-images.githubusercontent.com/7801391/74601312-8c9e9e80-5051-11ea-85d4-ecf0cb13ef69.jpeg)

In case recipe authors prefer to put the Processor key first when converting from plist, I've updated @grahampugh's plist-yaml-plist project to do just that: https://github.com/grahampugh/plist-yaml-plist/pull/2

## Recipe filename extensions

With this change comes a design decision about recipe filename extensions. I've chosen to infer recipe format using a **.recipe.yaml** extension instead of trying to parse files with the .recipe extension multiple ways. This requires recipe authors to ensure that yaml recipe filenames end with .recipe.yaml. Recipes that end in .recipe will continue to be treated like plists. (A new .recipe.plist extension is also allowable.)

The extension ".yaml" was chosen over ".yml" at the suggestion of the [yaml.org FAQ](https://yaml.org/faq.html).

## Types

Yaml requires extra caution on the part of recipe authors, due to the way it infers some data types. For example, this version will be treated as a string:

```
MinimumVersion: 1.0.0
```

But this version will be treated as a float, causing problems downstream:

```
MinimumVersion: 1.1
```

The solution is to ensure that such strings are surrounded by single or double quotes when creating recipes manually:

```
MinimumVersion: '1.1'
```

Once this PR is approved and merged, the recipe format wiki page could be updated to include a recommendation to that effect.

## Unresolved issues

A few minor issues are not addressed by this PR, but I wanted to note them here for future work:

- There is code in the get_recipe_list, find_recipe_by_identifier, and find_recipe_by_name functions that can probably be combined. I've added a TODO comment to mark each instance.
- The `new-recipe` and `make-override` verbs could benefit from a `--yaml` or `--format=yaml` option to specify the format of the recipe/override being created, if not plist.
- Determine whether to produce an error/warning if both a plist and a yaml recipe in the search directories have the same identifier.
- Out of scope for now: support for yaml `--prefs` input.

## Testing

### Preferences and environment used for testing:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>MUNKI_REPO</key>
    <string>~/munki_repo</string>
    <key>RECIPE_REPOS</key>
    <dict>
        <key>/Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes</key>
        <dict>
            <key>URL</key>
            <string>https://github.com/autopkg/grahampugh-recipes</string>
        </dict>
        <key>/Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes</key>
        <dict>
            <key>URL</key>
            <string>https://github.com/autopkg/homebysix-recipes</string>
        </dict>
        <key>/Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes</key>
        <dict>
            <key>URL</key>
            <string>https://github.com/autopkg/recipes</string>
        </dict>
    </dict>
    <key>RECIPE_SEARCH_DIRS</key>
    <array>
        <string>.</string>
        <string>~/Library/AutoPkg/Recipes</string>
        <string>/Library/AutoPkg/Recipes</string>
        <string>/Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes</string>
        <string>/Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes</string>
        <string>/Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes</string>
    </array>
</dict>
</plist>
```

### Recipe info by filename, plist:

```
% ./Code/autopkg info ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/DataWarrior/DataWarrior.download.recipe
Description:         Downloads the latest version of DataWarrior.
Identifier:          com.github.grahampugh.download.DataWarrior
Munki import recipe: False
Has check phase:     True
Builds package:      False
Recipe file path:    /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/DataWarrior/DataWarrior.download.recipe
Input values: 
    'DOWNLOAD_URL': 'http://www.openmolecules.org/datawarrior/download.html',
    'NAME': 'DataWarrior'
```

### Recipe info by filename, yaml:

```
% ./Code/autopkg info ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/YAML/DataWarrior/DataWarrior.download.recipe.yaml
Description:         Downloads the latest version of DataWarrior.
Identifier:          com.github.grahampugh.download.DataWarrior
Munki import recipe: False
Has check phase:     True
Builds package:      False
Recipe file path:    /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/YAML/DataWarrior/DataWarrior.download.recipe.yaml
Input values: 
    'DOWNLOAD_URL': 'http://www.openmolecules.org/datawarrior/download.html',
    'NAME': 'DataWarrior'
```

### Recipe suggestion, plist:

```
% ./Code/autopkg run FirefoxSigned
Didn't find a recipe for FirefoxSigned.
Maybe you meant one of: FirefoxSignedPkg.install, FirefoxSignedPkg.pkg, FirefoxSignedPkg.download, FirefoxSignedPkg.munki?
Search GitHub AutoPkg repos for a FirefoxSigned recipe? [y/n]: n

Nothing downloaded, packaged or imported.
```

### Recipe suggestion, yaml:

(The only Gitfox recipes that exist at the moment are in YAML format, [in my repo](https://github.com/autopkg/homebysix-recipes/pull/291).)

```
% ./Code/autopkg run Gitfox
Didn't find a recipe for Gitfox.
Maybe you meant one of: Gitfox.pkg, Gitfox.download, Gitfox.munki, Gitfox.install?
Search GitHub AutoPkg repos for a Gitfox recipe? [y/n]: n

Nothing downloaded, packaged or imported.
```

### Make override, plist:

```
% ./Code/autopkg make-override Gitfox.download
Override file saved to /Users/testuser/Library/AutoPkg/RecipeOverrides/Gitfox.download.recipe

% cat /Users/testuser/Library/AutoPkg/RecipeOverrides/Gitfox.download.recipe
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Identifier</key>
    <string>local.download.Gitfox</string>
    <key>Input</key>
    <dict>
        <key>NAME</key>
        <string>Gitfox</string>
    </dict>
    <key>ParentRecipe</key>
    <string>com.github.homebysix.download.Gitfox</string>
    <key>ParentRecipeTrustInfo</key>
    <dict>
        <key>non_core_processors</key>
        <dict/>
        <key>parent_recipes</key>
        <dict>
            <key>com.github.homebysix.download.Gitfox</key>
            <dict>
                <key>git_hash</key>
                <string>a8f7ad1f3260d0c89a82e5cb712539b952be991b</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitFox/Gitfox.download.recipe.yaml</string>
                <key>sha256_hash</key>
                <string>5a4f3f2ac1efc3d22cb037dd9e20e9719756402c4835b2f1b3756c4b6d077c43</string>
            </dict>
        </dict>
    </dict>
</dict>
</plist>

% ./Code/autopkg make-override Gitfox.download
A recipe override already exists at /Users/testuser/Library/AutoPkg/RecipeOverrides/Gitfox.download.recipe, will not overwrite it. Use --force to overwrite anyway.

% ./Code/autopkg make-override Gitfox.download --force
Override file saved to /Users/testuser/Library/AutoPkg/RecipeOverrides/Gitfox.download.recipe
```

### Make override, yaml:

(Not yet supported)

### List-recipes, plist:

```
% ./Code/autopkg list-recipes -p | grep -i 'firefoxsignedpkg'
FirefoxSignedPkg.download                  ~/Library/AutoPkg/RecipeOverrides/FirefoxSignedPkg.download.recipe
FirefoxSignedPkg.install                   ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/FirefoxSignedPkg.install.recipe
FirefoxSignedPkg.munki                     ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/FirefoxSignedPkg.munki.recipe
FirefoxSignedPkg.pkg                       ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/FirefoxSignedPkg.pkg.recipe
```

### List-recipes, yaml:

```
% ./Code/autopkg list-recipes -p | grep -i 'gitfox'
Gitfox.download                            ~/Library/AutoPkg/RecipeOverrides/Gitfox.download.recipe
Gitfox.install                             ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitFox/Gitfox.install.recipe.yaml
Gitfox.munki                               ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitFox/Gitfox.munki.recipe.yaml
Gitfox.pkg                                 ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitFox/Gitfox.pkg.recipe.yaml
```

### Override verify trust info, plist:

```
% ls ~/Library/AutoPkg/RecipeOverrides
FirefoxSignedPkg.download.recipe    Gitfox.download.recipe
% ./Code/autopkg verify-trust-info FirefoxSignedPkg.download Gitfox.download
FirefoxSignedPkg.download: OK
Gitfox.download: OK
```

### Override verify trust info, yaml:

```
% ls ~/Library/AutoPkg/RecipeOverrides                                    
FirefoxSignedPkg.download.recipe.yaml   Gitfox.download.recipe.yaml
% ./Code/autopkg verify-trust-info FirefoxSignedPkg.download Gitfox.download   
FirefoxSignedPkg.download: OK
Gitfox.download: OK
```

### Yaml override verify trust info, fail, then update trust info, pass:

```
% cat /Users/testuser/Library/AutoPkg/RecipeOverrides/Gitfox.download.recipe.yaml
Identifier: local.download.Gitfox
Input:
  NAME: Gitfox
ParentRecipe: com.github.homebysix.download.Gitfox
ParentRecipeTrustInfo:
  non_core_processors: {}
  parent_recipes:
    com.github.homebysix.download.Gitfox:
      git_hash: abcdef123456
      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitFox/Gitfox.download.recipe.yaml
      sha256_hash: abcdef123456

% ./Code/autopkg verify-trust-info Gitfox.download                 
Gitfox.download: FAILED

% ./Code/autopkg update-trust-info Gitfox.download
Wrote updated /Users/testuser/Library/AutoPkg/RecipeOverrides/Gitfox.download.recipe.yaml

% ./Code/autopkg verify-trust-info Gitfox.download                     
Gitfox.download: OK

% cat /Users/testuser/Library/AutoPkg/RecipeOverrides/Gitfox.download.recipe.yaml
Identifier: local.download.Gitfox
Input:
  NAME: Gitfox
ParentRecipe: com.github.homebysix.download.Gitfox
ParentRecipeTrustInfo:
  non_core_processors: {}
  parent_recipes:
    com.github.homebysix.download.Gitfox:
      git_hash: a8f7ad1f3260d0c89a82e5cb712539b952be991b
      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitFox/Gitfox.download.recipe.yaml
      sha256_hash: 5a4f3f2ac1efc3d22cb037dd9e20e9719756402c4835b2f1b3756c4b6d077c43

```

### Plist override verify trust info, fail, then update trust info, pass:

```
% cat /Users/testuser/Library/AutoPkg/RecipeOverrides/FirefoxSignedPkg.download.recipe
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Identifier</key>
    <string>local.download.FirefoxSignedPkg</string>
    <key>Input</key>
    <dict>
        <key>LATEST_RELEASE</key>
        <string>LATEST_FIREFOX_VERSION</string>
        <key>LOCALE</key>
        <string>en-US</string>
        <key>NAME</key>
        <string>Firefox</string>
    </dict>
    <key>ParentRecipe</key>
    <string>com.github.autopkg.download.FirefoxSignedPkg</string>
    <key>ParentRecipeTrustInfo</key>
    <dict>
        <key>non_core_processors</key>
        <dict/>
        <key>parent_recipes</key>
        <dict>
            <key>com.github.autopkg.download.FirefoxSignedPkg</key>
            <dict>
                <key>git_hash</key>
                <string>abcdef123456</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/FirefoxSignedPkg.download.recipe</string>
                <key>sha256_hash</key>
                <string>abcdef123456</string>
            </dict>
        </dict>
    </dict>
</dict>
</plist>

% ./Code/autopkg verify-trust-info /Users/testuser/Library/AutoPkg/RecipeOverrides/FirefoxSignedPkg.download.recipe
/Users/testuser/Library/AutoPkg/RecipeOverrides/FirefoxSignedPkg.download.recipe: FAILED

% ./Code/autopkg update-trust-info /Users/testuser/Library/AutoPkg/RecipeOverrides/FirefoxSignedPkg.download.recipe
Wrote updated /Users/testuser/Library/AutoPkg/RecipeOverrides/FirefoxSignedPkg.download.recipe

% ./Code/autopkg verify-trust-info /Users/testuser/Library/AutoPkg/RecipeOverrides/FirefoxSignedPkg.download.recipe
/Users/testuser/Library/AutoPkg/RecipeOverrides/FirefoxSignedPkg.download.recipe: OK

% cat /Users/testuser/Library/AutoPkg/RecipeOverrides/FirefoxSignedPkg.download.recipe                             
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Identifier</key>
    <string>local.download.FirefoxSignedPkg</string>
    <key>Input</key>
    <dict>
        <key>LATEST_RELEASE</key>
        <string>LATEST_FIREFOX_VERSION</string>
        <key>LOCALE</key>
        <string>en-US</string>
        <key>NAME</key>
        <string>Firefox</string>
    </dict>
    <key>ParentRecipe</key>
    <string>com.github.autopkg.download.FirefoxSignedPkg</string>
    <key>ParentRecipeTrustInfo</key>
    <dict>
        <key>non_core_processors</key>
        <dict/>
        <key>parent_recipes</key>
        <dict>
            <key>com.github.autopkg.download.FirefoxSignedPkg</key>
            <dict>
                <key>git_hash</key>
                <string>0eb8599b841d2afa070ecdb8a9a34094fd7f27ee</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/FirefoxSignedPkg.download.recipe</string>
                <key>sha256_hash</key>
                <string>04c25b63dd320c5af018dcc3e669be25da36222e82cec5c89122d328538b7977</string>
            </dict>
        </dict>
    </dict>
</dict>
</plist>
```

### Recipe run, plist:

```
% ./Code/autopkg run -vv ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/DataWarrior/DataWarrior.download.recipe 
Processing /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/DataWarrior/DataWarrior.download.recipe...
WARNING: /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/DataWarrior/DataWarrior.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<match>http.*?dmg\\?dl=1)',
           'url': 'http://www.openmolecules.org/datawarrior/download.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://www.dropbox.com/s/zl84sm43mhxheub/datawarrior.dmg?dl=1
{'Output': {'match': 'https://www.dropbox.com/s/zl84sm43mhxheub/datawarrior.dmg?dl=1'}}
URLDownloader
{'Input': {'filename': 'DataWarrior.dmg',
           'url': 'https://www.dropbox.com/s/zl84sm43mhxheub/datawarrior.dmg?dl=1'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg
{'Output': {'pathname': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg'}}
URLTextSearcher
{'Input': {'re_pattern': '(.*Download DataWarrior '
                         'V(?P<webversion>\\d\\.\\d+\\.\\d+).*)',
           'result_output_var_name': 'webversion',
           'url': 'http://www.openmolecules.org/datawarrior/download.html'}}
URLTextSearcher: Found matching text (webversion): 5.2.0
{'Output': {'webversion': '5.2.0'}}
Copier
{'Input': {'destination_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app',
           'overwrite': True,
           'source_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg/DataWarrior.app'}}
Copier: Parsed dmg results: dmg_path: /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg, dmg: .dmg/, dmg_source_path: DataWarrior.app
Copier: Mounted disk image /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg
Copier: Copied /private/tmp/dmg.ISEAG5/DataWarrior.app to /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app
{'Output': {}}
PlistEditor
{'Input': {'input_plist_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app/Contents/Info.plist',
           'output_plist_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app/Contents/Info.plist',
           'plist_data': {'CFBundleShortVersionString': '5.2.0'}}}
PlistEditor: Updated plist at /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app/Contents/Info.plist
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/receipts/DataWarrior.download-receipt-20200215-221251.plist

Nothing downloaded, packaged or imported.
```

### Recipe run, yaml:

```
% ./Code/autopkg run -vv ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/YAML/DataWarrior/DataWarrior.download.recipe.yaml
Processing /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/YAML/DataWarrior/DataWarrior.download.recipe.yaml...
WARNING: /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/YAML/DataWarrior/DataWarrior.download.recipe.yaml is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<match>http.*?dmg\\?dl=1)',
           'url': 'http://www.openmolecules.org/datawarrior/download.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://www.dropbox.com/s/zl84sm43mhxheub/datawarrior.dmg?dl=1
{'Output': {'match': 'https://www.dropbox.com/s/zl84sm43mhxheub/datawarrior.dmg?dl=1'}}
URLDownloader
{'Input': {'filename': 'DataWarrior.dmg',
           'url': 'https://www.dropbox.com/s/zl84sm43mhxheub/datawarrior.dmg?dl=1'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg
{'Output': {'pathname': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg'}}
URLTextSearcher
{'Input': {'re_pattern': '(.*Download DataWarrior '
                         'V(?P<webversion>\\d\\.\\d+\\.\\d+).*)',
           'result_output_var_name': 'webversion',
           'url': 'http://www.openmolecules.org/datawarrior/download.html'}}
URLTextSearcher: Found matching text (webversion): 5.2.0
{'Output': {'webversion': '5.2.0'}}
Copier
{'Input': {'destination_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app',
           'overwrite': True,
           'source_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg/DataWarrior.app'}}
Copier: Parsed dmg results: dmg_path: /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg, dmg: .dmg/, dmg_source_path: DataWarrior.app
Copier: Mounted disk image /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.dmg
Copier: Copied /private/tmp/dmg.e7oMT0/DataWarrior.app to /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app
{'Output': {}}
PlistEditor
{'Input': {'input_plist_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app/Contents/Info.plist',
           'output_plist_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app/Contents/Info.plist',
           'plist_data': {'CFBundleShortVersionString': '5.2.0'}}}
PlistEditor: Updated plist at /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/downloads/DataWarrior.app/Contents/Info.plist
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/testuser/Library/AutoPkg/Cache/com.github.grahampugh.download.DataWarrior/receipts/DataWarrior.download-receipt-20200215-221320.plist

Nothing downloaded, packaged or imported.
```

### Override run, plist:

```
% ./Code/autopkg run -vv FirefoxSignedPkg.download                                                                                  
Processing FirefoxSignedPkg.download...
URLTextSearcher
{'Input': {'re_pattern': '"LATEST_FIREFOX_VERSION": "([\\d\\.abesr]+)"',
           'result_output_var_name': 'version',
           'url': 'https://product-details.mozilla.org/1.0/firefox_versions.json'}}
URLTextSearcher: Found matching text (version): 73.0
{'Output': {'version': '73.0'}}
URLDownloader
{'Input': {'filename': 'Firefox-73.0.pkg',
           'url': 'http://releases.mozilla.org/pub/firefox/releases/73.0/mac/en-US/Firefox%2073.0.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/testuser/Library/AutoPkg/Cache/local.download.FirefoxSignedPkg/downloads/Firefox-73.0.pkg
{'Output': {'pathname': '/Users/testuser/Library/AutoPkg/Cache/local.download.FirefoxSignedPkg/downloads/Firefox-73.0.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Mozilla '
                                        'Corporation (43AQ936H96)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/testuser/Library/AutoPkg/Cache/local.download.FirefoxSignedPkg/downloads/Firefox-73.0.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Firefox-73.0.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Mozilla Corporation (43AQ936H96)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            30 F1 79 C8 D3 39 87 51 99 85 2C 96 B6 15 04 A1 9B 04 5F 5C BC EE 
CodeSignatureVerifier:            81 1F 42 8D FC 07 14 6D F6 D3
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/testuser/Library/AutoPkg/Cache/local.download.FirefoxSignedPkg/receipts/FirefoxSignedPkg.download-receipt-20200215-221436.plist

Nothing downloaded, packaged or imported.
```

### Override run, yaml:

```
% ./Code/autopkg run -vv Gitfox.download          
Processing Gitfox.download...
URLDownloader
{'Input': {'filename': 'Gitfox.zip',
           'url': 'https://storage.googleapis.com/gitfox/Gitfox.latest.stable.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/downloads/Gitfox.zip
{'Output': {'pathname': '/Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/downloads/Gitfox.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/downloads/Gitfox.zip',
           'destination_path': '/Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/Gitfox',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Gitfox.zip
Unarchiver: Unarchived /Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/downloads/Gitfox.zip to /Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/Gitfox
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/Gitfox/Gitfox.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.bytieful.Gitfox" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = MCZZULX74P)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/Gitfox/Gitfox.app: valid on disk
CodeSignatureVerifier: /Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/Gitfox/Gitfox.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/Gitfox/Gitfox.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/Gitfox/Gitfox.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 1.3309 in file /Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/Gitfox/Gitfox.app/Contents/Info.plist
{'Output': {'version': '1.3309'}}
Receipt written to /Users/testuser/Library/AutoPkg/Cache/local.download.Gitfox/receipts/Gitfox.download-receipt-20200215-221459.plist

Nothing downloaded, packaged or imported.
```

### Install verb, plist:

```
% ./Code/autopkg install -vv Firefox                                            
Processing Firefox.install...
WARNING: Firefox.install is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MozillaURLProvider
{'Input': {'locale': 'en_US', 'product_name': 'firefox', 'release': 'latest'}}
MozillaURLProvider: Found URL https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US
{'Output': {'url': 'https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US'}}
URLDownloader
{'Input': {'filename': 'Firefox.dmg',
           'url': 'https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 10 Feb 2020 13:22:22 GMT
URLDownloader: Storing new ETag header: "b698d81d60772ebabb98b7ed77ae17b0"
URLDownloader: Downloaded /Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg
{'Output': {'download_changed': True,
            'etag': '"b698d81d60772ebabb98b7ed77ae17b0"',
            'last_modified': 'Mon, 10 Feb 2020 13:22:22 GMT',
            'pathname': '/Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'DISABLE_CODE_SIGNATURE_VERIFICATION': False,
           'input_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg/Firefox*.app',
           'requirement': 'anchor apple generic and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"43AQ936H96"'}}
CodeSignatureVerifier: Mounted disk image /Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.8W8QQC/Firefox.app' matched from globbed '/private/tmp/dmg.8W8QQC/Firefox*.app'.
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.8W8QQC/Firefox.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.8W8QQC/Firefox.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.8W8QQC/Firefox.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
InstallFromDMG
{'Input': {'dmg_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg',
           'download_changed': True,
           'items_to_copy': [{'destination_path': '/Applications/',
                              'source_item': 'Firefox.app'}]}}
InstallFromDMG: Mounted disk image /Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg
InstallFromDMG: Connecting
InstallFromDMG: Sending installation request
InstallFromDMG: STATUS:Copying Firefox.app to /Applications/Firefox.app
InstallFromDMG: Disconnecting
InstallFromDMG: Result: DONE
{'Output': {'install_from_dmg_summary_result': {'data': {'dmg_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg'},
                                                'summary_text': 'Items from '
                                                                'the following '
                                                                'disk images '
                                                                'were '
                                                                'successfully '
                                                                'installed:'},
            'install_result': 'DONE'}}
Receipt written to /Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/receipts/Firefox.install-receipt-20200215-221839.plist

The following new items were downloaded:
    Download Path                                                                               
    -------------                                                                               
    /Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg  

Items from the following disk images were successfully installed:
    Dmg Path                                                                                    
    --------                                                                                    
    /Users/testuser/Library/AutoPkg/Cache/com.github.autopkg.install.Firefox/downloads/Firefox.dmg  
```

### Install verb, yaml:

```
% ./Code/autopkg install -vv Gitfox 
Processing Gitfox.install...
WARNING: Gitfox.install is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Gitfox.zip',
           'url': 'https://storage.googleapis.com/gitfox/Gitfox.latest.stable.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 08 Feb 2020 13:35:48 GMT
URLDownloader: Storing new ETag header: "9a7e876e01a44d5c6a51a891e5c9f20a"
URLDownloader: Downloaded /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/downloads/Gitfox.zip
{'Output': {'download_changed': True,
            'etag': '"9a7e876e01a44d5c6a51a891e5c9f20a"',
            'last_modified': 'Sat, 08 Feb 2020 13:35:48 GMT',
            'pathname': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/downloads/Gitfox.zip',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/downloads/Gitfox.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/downloads/Gitfox.zip',
           'destination_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Gitfox.zip
Unarchiver: Unarchived /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/downloads/Gitfox.zip to /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox/Gitfox.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.bytieful.Gitfox" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = MCZZULX74P)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox/Gitfox.app: valid on disk
CodeSignatureVerifier: /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox/Gitfox.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox/Gitfox.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox/Gitfox.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 1.3309 in file /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox/Gitfox.app/Contents/Info.plist
{'Output': {'version': '1.3309'}}
DmgCreator
{'Input': {'dmg_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox.dmg',
           'dmg_root': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox'}}
DmgCreator: Created dmg from /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox at /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox.dmg
{'Output': {}}
InstallFromDMG
{'Input': {'dmg_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox.dmg',
           'download_changed': True,
           'items_to_copy': [{'destination_path': '/Applications',
                              'source_item': 'Gitfox.app'}]}}
InstallFromDMG: Mounted disk image /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox.dmg
InstallFromDMG: Connecting
InstallFromDMG: Sending installation request
InstallFromDMG: STATUS:Copying Gitfox.app to /Applications/Gitfox.app
InstallFromDMG: Disconnecting
InstallFromDMG: Result: DONE
{'Output': {'install_from_dmg_summary_result': {'data': {'dmg_path': '/Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox.dmg'},
                                                'summary_text': 'Items from '
                                                                'the following '
                                                                'disk images '
                                                                'were '
                                                                'successfully '
                                                                'installed:'},
            'install_result': 'DONE'}}
Receipt written to /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/receipts/Gitfox.install-receipt-20200215-221905.plist

The following new items were downloaded:
    Download Path                                                                               
    -------------                                                                               
    /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/downloads/Gitfox.zip  

Items from the following disk images were successfully installed:
    Dmg Path                                                                          
    --------                                                                          
    /Users/testuser/Library/AutoPkg/Cache/com.github.homebysix.install.Gitfox/Gitfox.dmg  
```

### Recipe audit, plist:

```
% ./Code/autopkg audit FirefoxSignedPkg.munki   
FirefoxSignedPkg.munki
    File path:        /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/FirefoxSignedPkg.munki.recipe
    Parent recipe(s): /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/FirefoxSignedPkg.download.recipe
    The following http URLs were found in the recipe:
        Process:
            URLDownloader:
                url: http://releases.mozilla.org/pub/firefox/releases/%version%/mac/%LOCALE%/Firefox%20%version%.pkg
```

### Recipe audit, yaml:

```
% ./Code/autopkg audit Gitfox.munki          
Gitfox.munki
    File path:        /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitFox/Gitfox.munki.recipe.yaml
    Parent recipe(s): /Users/testuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/GitFox/Gitfox.download.recipe.yaml
    The following processors make modifications and their use in this recipe should be more closely inspected:
        DmgCreator
```
