### PR TITLE
Restores ability to run processors standalone on the commandline

### DIFF
--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -444,6 +444,8 @@ class Processor:
         try:
             with open(self.outfile, "wb") as f:
                 plistlib.dump(self.env, f)
+        except TypeError:
+            plistlib.dump(self.env, self.outfile.buffer)
         except BaseException as err:
             raise ProcessorError(err)
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -432,6 +432,8 @@ class Processor:
                 self.env = plistlib.loads(indata)
             else:
                 self.env = {}
+        except TypeError:
+            self.env = plistlib.loads(self.infile.buffer.read())
         except BaseException as err:
             raise ProcessorError(err)
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -427,7 +427,7 @@ class Processor:
         """Read environment from input plist."""
 
         try:
-            indata = self.infile.read()
+            indata = self.infile.buffer.read()
             if indata:
                 self.env = plistlib.loads(indata)
             else:

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -409,7 +409,7 @@ class Processor:
 
     def output(self, msg, verbose_level=1):
         """Print a message if verbosity is >= verbose_level"""
-        if self.env.get("verbose", 0) >= verbose_level:
+        if int(self.env.get("verbose", 0)) >= verbose_level:
             print(f"{self.__class__.__name__}: {msg}")
 
     def main(self):

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -432,8 +432,6 @@ class Processor:
                 self.env = plistlib.loads(indata)
             else:
                 self.env = {}
-        except TypeError:
-            self.env = plistlib.loads(self.infile.buffer.read())
         except BaseException as err:
             raise ProcessorError(err)
 


### PR DESCRIPTION
Sample usage:
```
defaults write /tmp/processor.plist ARTICLE_NUMBER '1888'
defaults write /tmp/processor.plist verbose -int 3
plutil -convert xml1 /tmp/processor.plist

# Change to be your git dev branch of AutoPkg
export PYTHONPATH=${HOME}/src/autopkg/autopkg/Code 

/Library/AutoPkg/Python3/Python.framework/Versions/Current/bin/python3 ${HOME}/src/autopkg/n8felton-recipes/SharedProcessors/AppleSupportDownloadInfoProvider.py < /tmp/processor.plist
```

Sample Usage 2:
```
# Change to be your git dev branch of AutoPkg
export PYTHONPATH=${HOME}/src/autopkg/autopkg/Code 

/Library/AutoPkg/Python3/Python.framework/Versions/Current/bin/python3 ${HOME}/src/autopkg/n8felton-recipes/SharedProcessors/AppleSupportDownloadInfoProvider.py ARTICLE_NUMBER=1888 verbose=3

# Press CTRL-D to send EOF to Python waiting for stdin input. This is a fix for another day....
```

Sample Output in both cases:
```
AppleSupportDownloadInfoProvider: Article URL: https://support.apple.com/kb/DL1888
AppleSupportDownloadInfoProvider: Download URL: https://support.apple.com/downloads/DL1888/en_US/&
AppleSupportDownloadInfoProvider: Full URL: https://updates.cdn-apple.com/2019/cert/041-88763-20191011-6e70f498-9d39-420c-b11b-b252b17233e2/HewlettPackardPrinterDrivers.dmg
AppleSupportDownloadInfoProvider: Article title: HP Printer Drivers v5.1 for OS X
AppleSupportDownloadInfoProvider: Version: 5.1
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>ARTICLE_NUMBER</key>
	<string>1888</string>
	<key>article_url</key>
	<string>https://support.apple.com/kb/DL1888</string>
	<key>url</key>
	<string>https://updates.cdn-apple.com/2019/cert/041-88763-20191011-6e70f498-9d39-420c-b11b-b252b17233e2/HewlettPackardPrinterDrivers.dmg</string>
	<key>verbose</key>
	<integer>3</integer>
	<key>version</key>
	<string>5.1</string>
</dict>
</plist>
```