### PR TITLE
Update FileFinder.py

### DIFF
--- a/Code/autopkglib/FileFinder.py
+++ b/Code/autopkglib/FileFinder.py
@@ -58,7 +58,7 @@ class FileFinder(DmgMounter):
         """If multiple files are found the last alphanumerically sorted found
         file is returned"""
 
-        glob_matches = glob(pattern)
+        glob_matches = glob(pattern, recursive=True)
 
         if len(glob_matches) < 1:
             raise ProcessorError("No matching filename found")


### PR DESCRIPTION
Sets recursive to True for glob.

This will only take affect if the "**" pattern is passed to FileFinder, exisiting recipes etc will be fine (& have tested a few post change).

'''
If recursive is true, the pattern “**” will match any files and zero or more directories, subdirectories and symbolic links to directories. If the pattern is followed by an os.sep or os.altsep then files will not match.
'''