### PR TITLE
Use a GET request in URLDownloader.prefetch_filename()

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -170,7 +170,7 @@ class URLDownloader(URLGetter):
     def prefetch_filename(self):
         """Attempt to find filename in HTTP headers."""
         curl_cmd = self.prepare_base_curl_cmd()
-        curl_cmd.extend(["--head"])
+        curl_cmd.extend(["--head", "--request", "GET"])
 
         raw_headers = self.download_with_curl(curl_cmd)
         header = self.parse_headers(raw_headers)


### PR DESCRIPTION
Some servers disallow HTTP HEAD requests, used to get information about a file. This is the default request type that curl sends when '--head' is passed.

By passing '--request GET' to curl, this default behavior is overridden. curl will now perform a GET request but stop after it receives the headers. This ensures that we get the correct headers for every file (some servers may return different headers for GET vs HEAD) and don't receive HTTP Forbidden errors for an incorrect request type.

Fixes https://github.com/autopkg/autopkg/issues/624

Does anyone have some recipes that should be tested with this change? It only affects prefetch_filename.