### PR TITLE
improve Content-Disposition filename parsing

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -176,7 +176,7 @@ class URLDownloader(URLGetter):
         header = self.parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):
-            filename = header["content-disposition"].rpartition("filename=")[2]
+            filename = header["content-disposition"].rpartition("filename=")[2].replace('"', '')
             self.output(
                 f"Filename prefetched from the HTTP Content-Disposition header: {filename}",
                 verbose_level=2,


### PR DESCRIPTION
This update improves the way the `URLDownloader` parses the `Content-Disposition` HTTP header, the `filename` parameter value in particular.

The value of the `filename` parameter can be quoted, like in the following example:
`Content-Disposition: attachment; filename="sth.dmg"`
Currently, if a server quotes the `filename` parameter value like in the example above, further processing breaks.

This improvement removes the quotation marks, if they are present.  It does not resolve all potential issues with how HTTP headers parsing currently works, it only brings the present parsing mechanism a bit closer to standards.