### PR TITLE
update README/typo, verbiage tweak in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,7 @@ requirements are enforced by [pre-commit](https://pre-commit.com).
 ## Use relocatable-python to safely build 3
 
 We recommend using Greg Neagle's [Relocatable Python](https://github.com/gregneagle/relocatable-python)
-to build a custom Python 2 and Python 3 framework.
-
-This project provides a requirements.txt files for Python 3. You can use
-Relocatable Python to build a custom Python framework with all
-of the requirements pre-installed.
+to build a custom Python 3 framework with the included [requirements.txt](https://github.com/autopkg/autopkg/blob/master/requirements.txt).
 
 First, create a safe path to place your frameworks. The easiest choice is
 /Users/Shared, because you won't have any permissions issues there, but you can

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -34,7 +34,7 @@ AutoPkg is tested on the current macOS release. It may work on older releases, b
 
 Git can be installed via Apple's command-line developer tools package, which can be prompted for installation by simply typing 'git' in a Terminal window (OS X 10.9 or later).
 
-AutoPkg uses (and is currenly only tested with) Apple's provided Python. While it is definely possible to use AutoPkg with Python from other sources, it is currently not supported, and you are on your own.
+Since AutoPkg 2.0, Python 2 is no longer supported. The installer linked above contains a bundled version of Python 3 and all needed dependencies.
 
 
 Usage


### PR DESCRIPTION
typo in readme made me notice it hadn't been updated for the now-stable python3/2.x versions, updated verbiage accordingly. Tweaked CONTRIBUTING while I was there