### PR TITLE
Bump PyYAML to version to 5.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -131,7 +131,7 @@ pyobjc-framework-VideoSubscriberAccount==6.0.1
 pyobjc-framework-VideoToolbox==6.0.1
 pyobjc-framework-Vision==6.0.1
 pyobjc-framework-WebKit==6.0.1
-PyYAML==5.1
+PyYAML==5.3.1
 six==1.12.0
 tokenize-rt==3.2.0
 toml==0.10.0


### PR DESCRIPTION
I ran [safety](https://github.com/pyupio/safety) against the requirements.txt file in the repo.

Results:
```
$:  safety check -r requirements.txt
+==============================================================================+
|                                                                              |
|                               /$$$$$$            /$$                         |
|                              /$$__  $$          | $$                         |
|           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
|          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
|         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
|          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
|          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
|         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
|                                                          /$$  | $$           |
|                                                         |  $$$$$$/           |
|  by pyup.io                                              \______/            |
|                                                                              |
+==============================================================================+
| REPORT                                                                       |
| checked 140 packages, using default DB                                       |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| pyyaml                     | 5.1       | <5.3.1                   | 38100    |
+==============================================================================+
```

CVE-2020-1747 for PyYAML at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1747

I couldn't find any `yaml` imports throughout the code, so the CVE isn't a huge deal. Nevertheless, went ahead and bumped the version anyways 🙂 

