### PR TITLE
Add support for internal GitHub urls

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = autopkglib,certifi,xattr
+known_third_party = autopkgcmd,autopkglib,certifi,xattr

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -21,7 +21,6 @@ import copy
 import difflib
 import glob
 import hashlib
-import optparse
 import os
 import plistlib
 import pprint
@@ -32,10 +31,10 @@ import sys
 import time
 import traceback
 from base64 import b64decode
-from typing import List
+from typing import Optional
 from urllib.parse import quote, urlparse
 
-import autopkglib.github
+from autopkgcmd import common_parse, gen_common_parser, search_recipes
 from autopkglib import (
     AutoPackager,
     AutoPackagerError,
@@ -48,7 +47,6 @@ from autopkglib import (
     get_identifier,
     get_pref,
     get_processor,
-    globalPreferences,
     is_mac,
     log,
     log_err,
@@ -56,6 +54,7 @@ from autopkglib import (
     set_pref,
     version_equal_or_greater,
 )
+from autopkglib.github import GitHubSession, print_gh_search_results
 
 if sys.platform != "darwin":
     print(
@@ -77,22 +76,6 @@ def print_version(argv):
     """Prints autopkg version"""
     _ = argv[1]
     print(get_autopkg_version())
-
-
-def gen_common_parser():
-    """Generate a common optparse parser with default options."""
-    parser = optparse.OptionParser()
-    parser.add_option("--prefs", dest="file_path")
-    return parser
-
-
-def common_parse(parser, argv):
-    """Parse an optparse parser with some enhancements and return a tuple."""
-    options, arguments = parser.parse_args(argv[2:])
-    if options.file_path:
-        # Attempt to set the global preferences
-        globalPreferences.read_file(options.file_path)
-    return (options, arguments)
 
 
 def recipe_has_step_processor(recipe, processor):
@@ -229,29 +212,9 @@ def get_identifier_from_override(override):
     return name
 
 
-def search_gh_for_name(name: str) -> List:
-    """Search GitHub for results for a given name."""
-    results_limit = 100
-    query = f"q={name}+extension:recipe+user:autopkg+in:file,path"
-    query += f"&per_page={results_limit}"
-
-    results = do_gh_code_search(query, use_token=False)
-
-    if not results or not results.get("total_count"):
-        log("Nothing found.")
-        return []
-
-    results_items = results["items"]
-
-    if not results_items:
-        log("Nothing found.")
-        return []
-    return results_items
-
-
 def get_repository_from_identifier(identifier: str):
     """Get a repository name from a recipe identifier."""
-    results = search_gh_for_name(identifier)
+    results = GitHubSession().search_for_name(identifier)
     # so now we have a list of items containing file names and URLs
     # we want to fetch these so we can look inside the contents for a matching
     # identifier
@@ -330,7 +293,7 @@ def locate_recipe(
                 repo_names = [parent_repo] if parent_repo else []
 
             if not repo_names:
-                results_items = search_gh_for_name(name)
+                results_items = GitHubSession().search_for_name(name)
                 print_gh_search_results(results_items)
                 # make a list of unique repo names
                 repo_names = []
@@ -921,9 +884,9 @@ def repo_update(argv):
 
 def do_gh_repo_contents_fetch(
     repo: str, path: str, use_token=False, decode=True
-) -> str:
+) -> Optional[bytes]:
     """Fetch file contents from GitHub and return as a string."""
-    gh_session = autopkglib.github.GitHubSession()
+    gh_session = GitHubSession()
     if use_token:
         gh_session.setup_token()
     # Do the search, including text match metadata
@@ -948,145 +911,6 @@ def do_gh_repo_contents_fetch(
     if decode:
         return b64decode(results["content"])
     return results["content"]
-
-
-def do_gh_code_search(query, use_token=False):
-    """Search GitHub code repos"""
-    gh_session = autopkglib.github.GitHubSession()
-    if use_token:
-        gh_session.setup_token()
-    # Do the search, including text match metadata
-    (results, code) = gh_session.call_api(
-        "/search/code", query=query, accept="application/vnd.github.v3.text-match+json"
-    )
-
-    if code == 403:
-        log_err(
-            "You've probably hit the GitHub's search rate limit, officially 5 "
-            "requests per minute.\n"
-        )
-        if results:
-            log_err("Server response follows:\n")
-            log_err(results.get("message", None))
-            log_err(results.get("documentation_url", None))
-
-        return None
-    if results is None or code is None:
-        log_err("A GitHub API error occurred!")
-        return None
-    return results
-
-
-def print_gh_search_results(results_items):
-    """Pretty print our GitHub search results"""
-    if not results_items:
-        return
-    column_spacer = 4
-    max_name_length = max([len(r["name"]) for r in results_items]) + column_spacer
-    max_repo_length = (
-        max([len(r["repository"]["name"]) for r in results_items]) + column_spacer
-    )
-    spacers = (max_name_length, max_repo_length)
-
-    print()
-    format_str = "%-{}s %-{}s %-40s".format(*spacers)
-    print(format_str % ("Name", "Repo", "Path"))
-    print(format_str % ("----", "----", "----"))
-    results_items.sort(key=lambda x: x["repository"]["name"])
-    for result in results_items:
-        repo = result["repository"]
-        name = result["name"]
-        path = result["path"]
-        if repo["full_name"].startswith("autopkg"):
-            repo_name = repo["name"]
-        else:
-            repo_name = repo["full_name"]
-        print(format_str % (name, repo_name, path))
-
-
-def search_recipes(argv):
-    """Search recipes on GitHub"""
-    default_user = "autopkg"
-    verb = argv[1]
-    parser = gen_common_parser()
-    parser.set_usage(
-        f"Usage: %prog {verb} [options] search_term\n"
-        "Search for recipes on GitHub. The AutoPkg organization "
-        "at github.com/autopkg\n"
-        "is the canonical 'repository' of recipe repos, "
-        "which is what is searched by\n"
-        "default."
-    )
-    parser.add_option(
-        "-u",
-        "--user",
-        default=default_user,
-        help=(
-            "Alternate GitHub user whose repos to search. "
-            f"Defaults to '{default_user}'."
-        ),
-    )
-    parser.add_option(
-        "-p",
-        "--path-only",
-        action="store_true",
-        default=False,
-        help=(
-            "Restrict search results to the recipe's path "
-            "only. Note that the search API currently does not "
-            "support fuzzy matches, so only exact directory or "
-            "filenames (minus the extensions) will be "
-            "returned."
-        ),
-    )
-    parser.add_option(
-        "-t",
-        "--use-token",
-        action="store_true",
-        default=False,
-        help=(
-            "Use a public-scope GitHub token for a higher "
-            "rate limit. If a token doesn't exist, you'll "
-            "be prompted for your account credentials to "
-            "create one."
-        ),
-    )
-
-    # Parse arguments
-    (options, arguments) = common_parse(parser, argv)
-    if len(arguments) < 1:
-        log_err("No search query specified!")
-        return -1
-
-    results_limit = 100
-    term = quote(arguments[0])
-    query = f"q={term}+extension:recipe+user:{options.user}"
-    qualifier_in = "in:path,file"
-    if options.path_only:
-        qualifier_in += "path"
-    query += "+" + qualifier_in
-    query += f"&per_page={results_limit}"
-
-    results = do_gh_code_search(query, use_token=options.use_token)
-    if not results:
-        return
-
-    count = results.get("total_count", 0)
-    if count == 0:
-        log("No results.")
-        return
-
-    print_gh_search_results(results["items"])
-
-    print()
-    print("To add a new recipe repo, use 'autopkg repo-add <repo name>'")
-
-    if count > results_limit:
-        print()
-        print(
-            "Warning: Search yielded more than 100 results. Please try a "
-            "more specific search term."
-        )
 
 
 def display_help(argv, subcommands):
@@ -1168,7 +992,7 @@ def processor_info(argv):
         """Print a dict of dicts and strings"""
         for key, value in list(var_dict.items()):
             if isinstance(value, dict):
-                print(f" " * indent, f"{key}:")
+                print(" " * indent, f"{key}:")
                 print_vars(value, indent=indent + 2)
             else:
                 print(" " * indent, f"{key}: {value}")
@@ -1611,7 +1435,7 @@ def get_trust_info(recipe, search_dirs=None):
             processor_hash = getsha256hash(processor_path)
             git_hash = get_git_commit_hash(processor_path)
         else:
-            log_err(f"WARNING: processor path not found for processor")
+            log_err(f"WARNING: processor path not found for processor: {processor}")
             processor_path = ""
             processor_hash = "PROCESSOR FILEPATH NOT FOUND"
             git_hash = None
@@ -2820,10 +2644,7 @@ def main(argv):
             "function": processor_info,
             "help": "Get information about a specific processor",
         },
-        "processor-list": {
-            "function": list_processors,
-            "help": "see list-processors",
-        },
+        "processor-list": {"function": list_processors, "help": "see list-processors"},
         "repo-add": {
             "function": repo_add,
             "help": "Add one or more recipe repo from a URL",

--- a/Code/autopkgcmd/__init__.py
+++ b/Code/autopkgcmd/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from autopkgcmd.opts import common_parse, gen_common_parser
+from autopkgcmd.searchcmd import search_recipes
+
+__all__ = ["search_recipes", "gen_common_parser", "common_parse"]

--- a/Code/autopkgcmd/opts.py
+++ b/Code/autopkgcmd/opts.py
@@ -1,0 +1,36 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import optparse
+from typing import List, Tuple
+
+from autopkglib import globalPreferences
+
+
+def gen_common_parser() -> optparse.OptionParser:
+    """Generate a common optparse parser with default options."""
+    parser = optparse.OptionParser()
+    parser.add_option("--prefs", dest="file_path")
+    return parser
+
+
+def common_parse(
+    parser: optparse.OptionParser, argv: List[str]
+) -> Tuple[optparse.Values, List[str]]:
+    """Parse an optparse parser with some enhancements and return a tuple."""
+    options, arguments = parser.parse_args(argv[2:])
+    if options.file_path:
+        # Attempt to set the global preferences
+        globalPreferences.read_file(options.file_path)
+    return (options, arguments)

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -1,0 +1,101 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+from urllib.parse import quote
+
+from autopkgcmd.opts import common_parse, gen_common_parser
+from autopkglib import log_err
+from autopkglib.github import (
+    DEFAULT_SEARCH_USER,
+    GitHubSession,
+    print_gh_search_results,
+)
+
+
+def search_recipes(argv: List[str]):
+    """Search recipes on GitHub"""
+    verb = argv[1]
+    parser = gen_common_parser()
+    parser.set_usage(
+        f"Usage: %prog {verb} [options] search_term\n"
+        "Search for recipes on GitHub. The AutoPkg organization "
+        "at github.com/autopkg\n"
+        "is the canonical 'repository' of recipe repos, "
+        "which is what is searched by\n"
+        "default."
+    )
+    parser.add_option(
+        "-u",
+        "--user",
+        default=DEFAULT_SEARCH_USER,
+        help=(
+            "Alternate GitHub user whose repos to search. "
+            f"Defaults to '{DEFAULT_SEARCH_USER}'."
+        ),
+    )
+    parser.add_option(
+        "-p",
+        "--path-only",
+        action="store_true",
+        default=False,
+        help=(
+            "Restrict search results to the recipe's path "
+            "only. Note that the search API currently does not "
+            "support fuzzy matches, so only exact directory or "
+            "filenames (minus the extensions) will be "
+            "returned."
+        ),
+    )
+    parser.add_option(
+        "-t",
+        "--use-token",
+        action="store_true",
+        default=False,
+        help=(
+            "Use a public-scope GitHub token for a higher "
+            "rate limit. If a token doesn't exist, you'll "
+            "be prompted for your account credentials to "
+            "create one."
+        ),
+    )
+
+    # Parse arguments
+    (options, arguments) = common_parse(parser, argv)
+    if len(arguments) < 1:
+        log_err("No search query specified!")
+        return 1
+
+    results_limit = 100
+    term = quote(arguments[0])
+
+    results = GitHubSession().search_for_name(
+        term, options.path_only, options.user, options.use_token, results_limit
+    )
+    if not results:
+        return 2
+
+    print_gh_search_results(results)
+
+    print()
+    print("To add a new recipe repo, use 'autopkg repo-add <repo name>'")
+
+    if len(results) > results_limit:
+        print()
+        print(
+            "Warning: Search yielded more than 100 results. Please try a "
+            "more specific search term."
+        )
+        return 3
+    return 0

--- a/Code/autopkglib/Copier.py
+++ b/Code/autopkglib/Copier.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 """See docstring for Copier class"""
 
+import glob
 import os.path
 import shutil
-import glob
 
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter

--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -68,6 +68,26 @@ class GitHubReleasesInfoProvider(Processor):
             "default": "/usr/bin/curl",
             "description": "Path to curl binary. Defaults to /usr/bin/curl.",
         },
+        "GITHUB_URL": {
+            "required": False,
+            "default": "https://api.github.com",
+            "description": (
+                "If your organization has an internal GitHub instance "
+                "set this value to your internal GitHub URL "
+                "ie. 'https://git.internal.corp.com/api/v3'"
+            ),
+        },
+        "GITHUB_TOKEN_PATH": {
+            "required": False,
+            "default": "~/.autopkg_gh_token",
+            "description": (
+                "Path to a file containing your GitHub token. "
+                "Can be a relative path or absolute path. "
+                "ie. '~/.custom_gh_token' or '/path/to/token' "
+                "NOTE: the AutoPkg preference 'GITHUB_TOKEN' "
+                "take precedence over this value."
+            ),
+        },
     }
     output_variables = {
         "release_notes": {
@@ -92,7 +112,12 @@ class GitHubReleasesInfoProvider(Processor):
         be of the form 'user/repo'"""
         releases = None
         curl_opts = self.env.get("curl_opts")
-        github = autopkglib.github.GitHubSession(self.env["CURL_PATH"], curl_opts)
+        github = autopkglib.github.GitHubSession(
+            self.env["CURL_PATH"],
+            curl_opts,
+            self.env["GITHUB_URL"],
+            self.env["GITHUB_TOKEN_PATH"],
+        )
         releases_uri = f"/repos/{repo}/releases"
         (releases, status) = github.call_api(releases_uri)
         if status != 200:

--- a/Code/autopkglib/InstallFromDMG.py
+++ b/Code/autopkglib/InstallFromDMG.py
@@ -135,9 +135,7 @@ class InstallFromDMG(DmgMounter):
 
         errors = data.rstrip().split("\n")
         if not errors:
-            errors = [
-                "ERROR:No reply from autopkginstalld (crash?), check system logs"
-            ]
+            errors = ["ERROR:No reply from autopkginstalld (crash?), check system logs"]
         raise ProcessorError(", ".join([s.replace("ERROR:", "") for s in errors]))
 
     def disconnect(self):

--- a/Code/autopkglib/Installer.py
+++ b/Code/autopkglib/Installer.py
@@ -133,9 +133,7 @@ class Installer(DmgMounter):
             self.env["install_result"] = result
             if result == "DONE":
                 self.env["installer_summary_result"] = {
-                    "summary_text": (
-                        "The following pkgs were successfully installed:"
-                    ),
+                    "summary_text": ("The following pkgs were successfully installed:"),
                     "data": {"pkg_path": matched_pkg_path},
                 }
 
@@ -169,9 +167,7 @@ class Installer(DmgMounter):
 
         errors = data.rstrip().split("\n")
         if not errors:
-            errors = [
-                "ERROR:No reply from autopkginstalld (crash?), check system logs"
-            ]
+            errors = ["ERROR:No reply from autopkginstalld (crash?), check system logs"]
         raise ProcessorError(", ".join([s.replace("ERROR:", "") for s in errors]))
 
     def disconnect(self):

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -176,7 +176,7 @@ class URLDownloader(URLGetter):
         header = self.parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):
-            filename = header["content-disposition"].rpartition("filename=")[2]
+            filename = header["content-disposition"].rpartition("filename=")[2].replace('"', '')
             self.output(
                 f"Filename prefetched from the HTTP Content-Disposition header: {filename}",
                 verbose_level=2,

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -25,6 +25,7 @@ from typing import List, Optional
 from autopkglib import get_pref, log, log_err
 from autopkglib.URLGetter import URLGetter
 
+BASE_URL = "https://api.github.com"
 TOKEN_LOCATION = os.path.expanduser("~/.autopkg_gh_token")
 DEFAULT_SEARCH_USER = "autopkg"
 
@@ -57,14 +58,13 @@ class GitHubSession(URLGetter):
         """Reads token from perferences or TOKEN_LOCATION.
             Otherwise returns None.
         """
-        token_location = token_path
         token = get_pref("GITHUB_TOKEN")
-        if not token and os.path.exists(token_location):
+        if not token and os.path.exists(token_path):
             try:
-                with open(token_location, "r") as tokenf:
+                with open(token_path, "r") as tokenf:
                     token = tokenf.read()
             except OSError as err:
-                log_err(f"Couldn't read token file at {token_location}! Error: {err}")
+                log_err(f"Couldn't read token file at {token_path}! Error: {err}")
                 token = None
         # TODO: validate token given we found one but haven't checked its
         # auth status

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -25,7 +25,6 @@ from typing import List, Optional
 from autopkglib import get_pref, log, log_err
 from autopkglib.URLGetter import URLGetter
 
-BASE_URL = "https://api.github.com"
 TOKEN_LOCATION = os.path.expanduser("~/.autopkg_gh_token")
 DEFAULT_SEARCH_USER = "autopkg"
 

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -33,7 +33,9 @@ DEFAULT_SEARCH_USER = "autopkg"
 class GitHubSession(URLGetter):
     """Handles a session with the GitHub API"""
 
-    def __init__(self, curl_path=None, curl_opts=None):
+    def __init__(
+        self, curl_path=None, curl_opts=None, github_url=None, token_path=TOKEN_LOCATION
+    ):
         super(GitHubSession, self).__init__()
         self.env = {}
         self.env["url"] = None
@@ -41,25 +43,34 @@ class GitHubSession(URLGetter):
             self.env["CURL_PATH"] = curl_path
         if curl_opts:
             self.env["curl_opts"] = curl_opts
+        if github_url:
+            self.url = github_url
+        else:
+            self.url = BASE_URL
         self.http_result_code = None
-        self.token = self._get_token()
+        if token_path.startswith("~"):
+            token_abspath = os.path.expanduser(token_path)
+        else:
+            token_abspath = token_path
+        self.token = self._get_token(token_path=token_abspath)
 
-    def _get_token(self) -> Optional[str]:
+    def _get_token(self, token_path: str = TOKEN_LOCATION) -> Optional[str]:
         """Reads token from perferences or TOKEN_LOCATION.
             Otherwise returns None.
         """
+        token_location = token_path
         token = get_pref("GITHUB_TOKEN")
-        if not token and os.path.exists(TOKEN_LOCATION):
+        if not token and os.path.exists(token_location):
             try:
-                with open(TOKEN_LOCATION, "r") as tokenf:
+                with open(token_location, "r") as tokenf:
                     token = tokenf.read()
             except OSError as err:
-                log_err(f"Couldn't read token file at {TOKEN_LOCATION}! Error: {err}")
+                log_err(f"Couldn't read token file at {token_location}! Error: {err}")
                 token = None
         # TODO: validate token given we found one but haven't checked its
         # auth status
         return token
-
+    
     def get_or_setup_token(self):
         """Setup a GitHub OAuth token string. Will help to create one if necessary.
         The string will be stored in TOKEN_LOCATION and used again
@@ -171,7 +182,7 @@ To save the token, paste it to the following prompt."""
             query += "+in:path,file"
         query += f"&per_page={results_limit}"
 
-        results = self.code_search(query, use_token=False)
+        results = self.code_search(query, use_token=use_token)
 
         if not results or not results.get("total_count"):
             log("Nothing found.")
@@ -233,7 +244,7 @@ To save the token, paste it to the following prompt."""
                 assets)."""
 
         # Compose the URL
-        self.env["url"] = BASE_URL + endpoint
+        self.env["url"] = self.url + endpoint
         if query:
             self.env["url"] += "?" + query
 

--- a/Code/autopkgserver/launch.py
+++ b/Code/autopkgserver/launch.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ctypes import *
+from ctypes import CDLL, CFUNCTYPE, c_char_p, c_int, c_size_t, c_void_p
 
 libc = CDLL("/usr/lib/libc.dylib")
 
@@ -228,21 +228,21 @@ def get_launchd_socket_fds():
     try:
         # Create a checkin request.
         checkin_request = launch_data_new_string(LAUNCH_KEY_CHECKIN)
-        if checkin_request == None:
+        if checkin_request is None:
             raise LaunchDCheckInError("Could not create checkin request")
 
         # Check the checkin response.
         checkin_response = launch_msg(checkin_request)
-        if checkin_response == None:
+        if checkin_response is None:
             raise LaunchDCheckInError("Error checking in")
 
         if launch_data_get_type(checkin_response) == LAUNCH_DATA_ERRNO:
             errno = launch_data_get_errno(checkin_response)
-            raise LaunchDCheckInError("Checkin failed")
+            raise LaunchDCheckInError(f"Checkin failed with errno:{errno}")
 
         # Get a dictionary of sockets.
         sockets = launch_data_dict_lookup(checkin_response, LAUNCH_JOBKEY_SOCKETS)
-        if sockets == None:
+        if sockets is None:
             raise LaunchDCheckInError(
                 "Could not get socket dictionary from checkin response"
             )

--- a/Code/tests/test_filecreator.py
+++ b/Code/tests/test_filecreator.py
@@ -19,9 +19,7 @@ class TestFileCreator(unittest.TestCase):
     def tearDown(self):
         pass
 
-    @patch(
-        "builtins.open", new_callable=mock_open, read_data="Hello world",
-    )
+    @patch("builtins.open", new_callable=mock_open, read_data="Hello world")
     @patch("autopkglib.FileCreator")
     def test_file_content(self, mock_load, mock_file):
         """The file created by the processor should have the expected contents."""

--- a/Code/tests/test_searchcmd.py
+++ b/Code/tests/test_searchcmd.py
@@ -1,0 +1,55 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from autopkgcmd import search_recipes
+
+
+class TestSearchCmd(unittest.TestCase):
+    def setUp(self):
+        # Disable preference reading for consistency
+        patch("autopkgcmd.opts.globalPreferences").start()
+        pass
+
+    def test_no_term(self):
+        self.assertEqual(1, search_recipes(["TestSearchCmd", "search"]))
+
+    @patch("autopkgcmd.searchcmd.GitHubSession.code_search")
+    def test_empty_results(self, gh_mock):
+        gh_mock.return_value = []
+        self.assertEqual(
+            2, search_recipes(["TestSearchCmd", "search", "#test-search#"])
+        )
+
+    @patch("autopkgcmd.searchcmd.print_gh_search_results")
+    @patch("autopkgcmd.searchcmd.GitHubSession.search_for_name")
+    def test_too_many_results(self, search_mock, _print_results_mock):
+        search_mock.return_value = list(range(101))
+        self.assertEqual(
+            3, search_recipes(["TestSearchCmd", "search", "#test-search#"])
+        )
+
+    @patch("autopkgcmd.searchcmd.print_gh_search_results")
+    @patch("autopkgcmd.searchcmd.GitHubSession.search_for_name")
+    def test_got_results(self, search_mock, _print_results_mock):
+        search_mock.return_value = list(range(10))
+        self.assertEqual(
+            0, search_recipes(["TestSearchCmd", "search", "#test-search#"])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
###Summary
Add support for AutoPkg users to override the default GitHub API URL and API token location when using the GitHubReleasesInfoProvider. This would allow organizations to search against an internal GitHub Enterprise instance. Additionally, if they choose to search against an internal instance, one can specify a specific token location path on the disk (can be either a relative path or absolute path).

###How?

**Additions to GitHubSession**
I changed the GitHubSession constructor and added two new parameters: `github_url` and `token_path` and a new class attribute: `self.url`.

If the `github_url` parameter is set, then it assigns `self.url` to its value, otherwise, it will use the constant `BASE_URL` (https://api.github.com) as its value.

The `token_path` defaults to the constant `TOKEN_LOCATION` (~/.autopkg_gh_token).

**Additions to GitHubReleasesInfoProvider**
- `GITHUB_URL`:  This new input is passed as the `github_url` parameter
- `GITHUB_TOKEN_PATH`: This new input is passed as the `token_path` parameter

###Testing

**autopkg search**
```
$:~/autopkg/Code|bfreezy/add-support-for-internal-github-urls⚡
⇒  ./autopkg search GoogleChrome

Name                                    Repo                      Path
----                                    ----                      ----
GoogleChrome-Win64.filewave.recipe      andredb90-recipes         Google/GoogleChrome-Win64.filewave.recipe
ChromeRemoteDesktop.munki.recipe        apizz-recipes             Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
GoogleChrome.filewave.recipe            filewave                  GoogleChrome/GoogleChrome.filewave.recipe
GoogleChromeCanary.download.recipe      foigus-recipes            Google/GoogleChromeCanary.download.recipe
GoogleChromeEnterprise.munki.recipe     grahamgilbert-recipes     Google/GoogleChromeEnterprise.munki.recipe
GoogleChrome-Win.download.recipe        hansen-m-recipes          Google/GoogleChrome-Win.download.recipe
GoogleChrome-Win64.download.recipe      hansen-m-recipes          Google/GoogleChrome-Win64.download.recipe
Google Chrome.jss.recipe                jss-recipes               Google Chrome/Google Chrome.jss.recipe
Google Chrome.jss.recipe                novaksam-recipes          Google Chrome/Google Chrome.jss.recipe
GoogleChrome-Win32.LANrev.recipe        patgmac-recipes           Google Chrome/GoogleChrome-Win32.LANrev.recipe
GoogleChrome-Win64.LANrev.recipe        patgmac-recipes           Google Chrome/GoogleChrome-Win64.LANrev.recipe
GoogleChrome.pkg.recipe                 recipes                   GoogleChrome/GoogleChrome.pkg.recipe
GoogleChrome.download.recipe            recipes                   GoogleChrome/GoogleChrome.download.recipe
GoogleChromePkg.download.recipe         recipes                   GoogleChrome/GoogleChromePkg.download.recipe
GoogleChrome.install.recipe             recipes                   GoogleChrome/GoogleChrome.install.recipe
GoogleChrome.munki.recipe               recipes                   GoogleChrome/GoogleChrome.munki.recipe
GoogleChromePkg.pkg.recipe              recipes                   GoogleChrome/GoogleChromePkg.pkg.recipe
GoogleChromePkg.munki.recipe            recipes                   GoogleChrome/GoogleChromePkg.munki.recipe
GoogleChrome.jss.recipe                 rtrouton-recipes          JSS/GoogleChrome.jss.recipe
GoogleChrome.install.recipe             rtrouton-recipes          GoogleChrome/GoogleChrome.install.recipe
GoogleChrome.pkg.recipe                 rtrouton-recipes          GoogleChrome/GoogleChrome.pkg.recipe
GoogleChromeEnterprise.jss.recipe       rtrouton-recipes          JSS/GoogleChromeEnterprise.jss.recipe
GoogleChromeUSC.jss.recipe              scriptingosx-recipes      GoogleChrome/GoogleChromeUSC.jss.recipe
GoogleChromeUSC.pkg.recipe              scriptingosx-recipes      GoogleChrome/GoogleChromeUSC.pkg.recipe
GoogleChrome.LANrev.recipe              seansgm-recipes           LANrevRecipes/GoogleChrome.LANrev.recipe
GoogleChrome.Absolute.recipe            seansgm-recipes           AbsoluteRecipes/GoogleChrome.Absolute.recipe
GoogleChrome.ds.recipe                  triti-recipes             GoogleChrome/GoogleChrome.ds.recipe

To add a new recipe repo, use 'autopkg repo-add <repo name>'
```

Using the `-t` flag with autopkg search:
```
$:~/autopkg/Code|bfreezy/add-support-for-internal-github-urls⚡
⇒  ./autopkg search GoogleChrome -t
Create a new token in your GitHub settings page:

    https://github.com/settings/tokens

To save the token, paste it to the following prompt.
Token: <redacted>
Writing token file /Users/brandonfriess/.autopkg_gh_token.

Name                                    Repo                      Path
----                                    ----                      ----
GoogleChrome-Win64.filewave.recipe      andredb90-recipes         Google/GoogleChrome-Win64.filewave.recipe
ChromeRemoteDesktop.munki.recipe        apizz-recipes             Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
GoogleChrome.filewave.recipe            filewave                  GoogleChrome/GoogleChrome.filewave.recipe
GoogleChromeCanary.download.recipe      foigus-recipes            Google/GoogleChromeCanary.download.recipe
GoogleChromeEnterprise.munki.recipe     grahamgilbert-recipes     Google/GoogleChromeEnterprise.munki.recipe
GoogleChrome-Win.download.recipe        hansen-m-recipes          Google/GoogleChrome-Win.download.recipe
GoogleChrome-Win64.download.recipe      hansen-m-recipes          Google/GoogleChrome-Win64.download.recipe
Google Chrome.jss.recipe                jss-recipes               Google Chrome/Google Chrome.jss.recipe
Google Chrome.jss.recipe                novaksam-recipes          Google Chrome/Google Chrome.jss.recipe
GoogleChrome-Win32.LANrev.recipe        patgmac-recipes           Google Chrome/GoogleChrome-Win32.LANrev.recipe
GoogleChrome-Win64.LANrev.recipe        patgmac-recipes           Google Chrome/GoogleChrome-Win64.LANrev.recipe
GoogleChrome.pkg.recipe                 recipes                   GoogleChrome/GoogleChrome.pkg.recipe
GoogleChrome.download.recipe            recipes                   GoogleChrome/GoogleChrome.download.recipe
GoogleChromePkg.download.recipe         recipes                   GoogleChrome/GoogleChromePkg.download.recipe
GoogleChrome.install.recipe             recipes                   GoogleChrome/GoogleChrome.install.recipe
GoogleChrome.munki.recipe               recipes                   GoogleChrome/GoogleChrome.munki.recipe
GoogleChromePkg.pkg.recipe              recipes                   GoogleChrome/GoogleChromePkg.pkg.recipe
GoogleChromePkg.munki.recipe            recipes                   GoogleChrome/GoogleChromePkg.munki.recipe
GoogleChrome.jss.recipe                 rtrouton-recipes          JSS/GoogleChrome.jss.recipe
GoogleChrome.install.recipe             rtrouton-recipes          GoogleChrome/GoogleChrome.install.recipe
GoogleChrome.pkg.recipe                 rtrouton-recipes          GoogleChrome/GoogleChrome.pkg.recipe
GoogleChromeEnterprise.jss.recipe       rtrouton-recipes          JSS/GoogleChromeEnterprise.jss.recipe
GoogleChromeUSC.jss.recipe              scriptingosx-recipes      GoogleChrome/GoogleChromeUSC.jss.recipe
GoogleChromeUSC.pkg.recipe              scriptingosx-recipes      GoogleChrome/GoogleChromeUSC.pkg.recipe
GoogleChrome.LANrev.recipe              seansgm-recipes           LANrevRecipes/GoogleChrome.LANrev.recipe
GoogleChrome.Absolute.recipe            seansgm-recipes           AbsoluteRecipes/GoogleChrome.Absolute.recipe
GoogleChrome.ds.recipe                  triti-recipes             GoogleChrome/GoogleChrome.ds.recipe

To add a new recipe repo, use 'autopkg repo-add <repo name>'
```

**AutoPkg run with public GitHub**
```
$: ./autopkg run --ignore-parent-trust-verification-errors /Users/brandonfriess/autopkg/Flycut/Flycut.download.recipe -vvvv
Processing /Users/brandonfriess/autopkg/Flycut/Flycut.download.recipe...
{'AUTOPKG_VERSION': '2.1.1',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GITHUB_REPO': 'TermiT/Flycut',
 'MUNKI_REPO': '/Users/brandonfriess/munki-mac-packages/public',
 'NAME': 'flycut',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/brandonfriess/Library/AutoPkg/Cache/com.foo.autopkg.flycut.download',
 'RECIPE_DIR': '/Users/brandonfriess/autopkg/Flycut',
 'RECIPE_OVERRIDE_DIRS': ['/Users/brandonfriess/cpe/autopkg/overrides'],
 'RECIPE_PATH': '/Users/brandonfriess/autopkg/Flycut/Flycut.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/RecipeRepos/com.foo.corp.git.internal.autopkg': {'URL': 'https://git.corp.foo.com/foo-internal/autopkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['/Users/brandonfriess/cpe/autopkg/overrides,',
                        '/Users/Shared/RecipeRepos/com.foo.corp.git.internal.autopkg'],
 'verbose': 4}
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'TermiT/Flycut'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Selected asset 'Flycut.1.9.4.zip' from release '1.9.4'
{'Output': {'release_notes': '- Removed sandboxing\r\n'
                             '- Made search case-insensitive',
            'url': 'https://github.com/TermiT/Flycut/releases/download/1.9.4/Flycut.1.9.4.zip',
            'version': '1.9.4'}}
```

**AutoPkg run with internal GitHub**
```
$: ./autopkg run --ignore-parent-trust-verification-errors /Users/brandonfriess/contoso/autopkg/fooapp/fooapp.download.recipe -vvvv
Processing /Users/brandonfriess/contoso/autopkg/fooapp/fooapp.download.recipe...
{'AUTOPKG_VERSION': '2.1.1',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GITHUB_REPO': 'contoso-internal/fooapp',
 'MUNKI_REPO': '/Users/brandonfriess/contoso/munki-mac-packages/public',
 'NAME': 'fooapp',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/brandonfriess/Library/AutoPkg/Cache/com.contoso.autopkg.fooapp.download',
 'RECIPE_DIR': '/Users/brandonfriess/contoso/autopkg/fooapp',
 'RECIPE_OVERRIDE_DIRS': ['/Users/brandonfriess/contoso/cpe/autopkg/overrides'],
 'RECIPE_PATH': '/Users/brandonfriess/contoso/autopkg/fooapp/fooapp.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/RecipeRepos/com.contoso.corp.git.contoso-internal.autopkg': {'URL': 'https://git.corp.contoso.com/contoso-internal/autopkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['/Users/brandonfriess/contoso/cpe/autopkg/overrides,',
                        '/Users/Shared/RecipeRepos/com.contoso.corp.git.contoso-internal.autopkg'],
 'verbose': 4}
com.contoso.autopkg.shared/AbsPath
{'Input': {'relative_path': '~/.contosoproxy'}}
AbsPath: /Users/brandonfriess/.contosoproxy
{'Output': {'absolute_path': '/Users/brandonfriess/.contosoproxy'}}
GitHubReleasesInfoProvider
{'Input': {'GITHUB_TOKEN_PATH': '~/.contoso_autopkg_github_token',
           'GITHUB_URL': 'http://git.corp.contoso.com/api/v3',
           'curl_opts': ['--unix-socket', '/Users/brandonfriess/.contosoproxy'],
           'github_repo': 'contoso-internal/fooapp'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'fooapp.authn_bundle' from release 'fooapp v2.0.3'
{'Output': {'release_notes': 'Reminder: We publish authn signed bundles. In '
                             'order to verify the signature and\r\n'
                             'extract a usable original binary from the authn '
                             'bundle use `bin/verify`.\r\n'
                             '\r\n'
                             '```\r\n'
                             '$ sha256sum *\r\n'
                             'c8cb12a357a160bddd92283235dbf84104f1959aff2f655943c07f5274dcb451  '
                             'fooapp\r\n'
                             '4b3b28b931aa70cec2532c53f6fa3a7d9afc37663631f554b2fdb95e7b80f50f  '
                             'fooapp.authn_bundle\r\n'
                             '```',
            'url': 'https://git.corp.contoso.com/contoso-internal/fooapp/releases/download/v2.0.3/certproxy.authn_bundle',
            'version': '2.0.3'}}
EndOfCheckPhase
```

Excerpt of recipe Input for internal Github:
```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>github_repo</key>
                <string>%GITHUB_REPO%</string>
                <key>curl_opts</key>
                <array>
                    <string>--unix-socket</string>
                    <string>%absolute_path%</string>
                </array>
                <key>GITHUB_URL</key>
                <string>http://git.corp.contoso.com/api/v3</string>
                <key>GITHUB_TOKEN_PATH</key>
                <string>~/.contoso_autopkg_github_token</string>
            </dict>
            <key>Processor</key>
            <string>GitHubReleasesInfoProvider</string>
        </dict>
```

Thanks for considering this!