### PR TITLE
Improvements to testing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,6 +21,8 @@ exclude =
 # This will be fine-tuned over time
 max-complexity = 65
 # Ignore the line length limits on tests, where we have in-line plist strings
-# that often exceed 88 characters
+# that often exceed 88 characters. Test directory path specified twice to account
+# for running flake8 from root of repo or within the Code/ directory.
 per-file-ignores =
   tests/*:B950
+  Code/tests/*:B950

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = autopkgcmd,autopkglib,certifi,xattr
+known_third_party = autopkgcmd,autopkglib,certifi,grp,pwd,xattr

--- a/Code/tests/test_autopkglib.py
+++ b/Code/tests/test_autopkglib.py
@@ -16,7 +16,7 @@ from unittest.mock import mock_open, patch
 patch("autopkglib.memoize", lambda x: x).start()
 import autopkglib  # isort:skip
 
-autopkg = imp.load_source("autopkg", os.path.join("Code", "autopkg"))
+autopkg = imp.load_source("autopkg", os.path.join(os.path.dirname(__file__), "..", "autopkg"))
 
 
 class TestAutoPkg(unittest.TestCase):

--- a/Scripts/run_tests.py
+++ b/Scripts/run_tests.py
@@ -1,0 +1,31 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from unittest import TestSuite, TextTestRunner
+
+AUTOPKG_TOP: str = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "Code")
+)
+sys.path.insert(0, AUTOPKG_TOP)
+
+TESTS_DIR: str = os.path.join(AUTOPKG_TOP, "tests")
+TEST_SUITE: TestSuite = unittest.defaultTestLoader.discover(TESTS_DIR)
+RUNNER: TextTestRunner = TextTestRunner()
+
+if RUNNER.run(TEST_SUITE).wasSuccessful():
+    sys.exit(0)
+sys.exit(1)


### PR DESCRIPTION
This makes flake8 ignore line length limits for `Code/tests/` the same as `tests/`, so that it gives consistent results regardless of where you run it. The autopkglib test now derives where to import autopkg from its own module path instead of expecting to run from the repository root. Lastly, add a test runner to make it easier to run tests correctly.