### PR TITLE
Support Internal GitHub URLs

### DIFF
--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -68,6 +68,26 @@ class GitHubReleasesInfoProvider(Processor):
             "default": "/usr/bin/curl",
             "description": "Path to curl binary. Defaults to /usr/bin/curl.",
         },
+        "GITHUB_URL": {
+            "required": False,
+            "default": "https://api.github.com",
+            "description": (
+                "If your organization has an internal GitHub instance "
+                "set this value to your internal GitHub URL "
+                "ie. 'https://git.internal.corp.com/api/v3'"
+            ),
+        },
+        "GITHUB_TOKEN_PATH": {
+            "required": False,
+            "default": "~/.autopkg_gh_token",
+            "description": (
+                "Path to a file containing your GitHub token. "
+                "Can be a relative path or absolute path. "
+                "ie. '~/.custom_gh_token' or '/path/to/token' "
+                "NOTE: the AutoPkg preference 'GITHUB_TOKEN' "
+                "takes precedence over this value."
+            ),
+        },
     }
     output_variables = {
         "release_notes": {
@@ -92,7 +112,12 @@ class GitHubReleasesInfoProvider(Processor):
         be of the form 'user/repo'"""
         releases = None
         curl_opts = self.env.get("curl_opts")
-        github = autopkglib.github.GitHubSession(self.env["CURL_PATH"], curl_opts)
+        github = autopkglib.github.GitHubSession(
+            self.env["CURL_PATH"],
+            curl_opts,
+            self.env["GITHUB_URL"],
+            self.env["GITHUB_TOKEN_PATH"],
+        )
         releases_uri = f"/repos/{repo}/releases"
         (releases, status) = github.call_api(releases_uri)
         if status != 200:

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -33,7 +33,9 @@ DEFAULT_SEARCH_USER = "autopkg"
 class GitHubSession(URLGetter):
     """Handles a session with the GitHub API"""
 
-    def __init__(self, curl_path=None, curl_opts=None):
+    def __init__(
+        self, curl_path=None, curl_opts=None, github_url=None, token_path=TOKEN_LOCATION
+    ):
         super(GitHubSession, self).__init__()
         self.env = {}
         self.env["url"] = None
@@ -41,20 +43,29 @@ class GitHubSession(URLGetter):
             self.env["CURL_PATH"] = curl_path
         if curl_opts:
             self.env["curl_opts"] = curl_opts
+        if github_url:
+            self.url = github_url
+        else:
+            self.url = BASE_URL
         self.http_result_code = None
-        self.token = self._get_token()
+        if token_path.startswith("~"):
+            token_abspath = os.path.expanduser(token_path)
+        else:
+            token_abspath = token_path
+        self.token = self._get_token(token_path=token_abspath)
 
-    def _get_token(self) -> Optional[str]:
-        """Reads token from perferences or TOKEN_LOCATION.
+    def _get_token(self, token_path: str = TOKEN_LOCATION) -> Optional[str]:
+        """Reads token from perferences or provided token path.
+            Defaults to TOKEN_LOCATION for the token path.
             Otherwise returns None.
         """
         token = get_pref("GITHUB_TOKEN")
-        if not token and os.path.exists(TOKEN_LOCATION):
+        if not token and os.path.exists(token_path):
             try:
-                with open(TOKEN_LOCATION, "r") as tokenf:
+                with open(token_path, "r") as tokenf:
                     token = tokenf.read()
             except OSError as err:
-                log_err(f"Couldn't read token file at {TOKEN_LOCATION}! Error: {err}")
+                log_err(f"Couldn't read token file at {token_path}! Error: {err}")
                 token = None
         # TODO: validate token given we found one but haven't checked its
         # auth status
@@ -171,7 +182,7 @@ To save the token, paste it to the following prompt."""
             query += "+in:path,file"
         query += f"&per_page={results_limit}"
 
-        results = self.code_search(query, use_token=False)
+        results = self.code_search(query, use_token=use_token)
 
         if not results or not results.get("total_count"):
             log("Nothing found.")
@@ -233,7 +244,7 @@ To save the token, paste it to the following prompt."""
                 assets)."""
 
         # Compose the URL
-        self.env["url"] = BASE_URL + endpoint
+        self.env["url"] = self.url + endpoint
         if query:
             self.env["url"] += "?" + query
 


### PR DESCRIPTION
###Summary

Add support for AutoPkg users to override the default GitHub API URL and API token location when using the GitHubReleasesInfoProvider. This would allow organizations to search against an internal GitHub Enterprise instance. Additionally, if they choose to search against an internal instance, one can specify a specific token location path on disk (can be either a relative path or absolute path). Or, if they rather just use another Github token, stored elsewhere on disk, they can specify that path (instead of using the default location at ~/.gh_autopkg_token).


###Changes

**GitHubSession:**
I added two new parameters to the GitHubSession constructor - `github_url` and `token_path` - and a new class attribute  `self.url`.

If the `github_url` parameter is set, then it assigns `self.url` to its value, otherwise, it will use `BASE_URL` (https://api.github.com) as its value.

If the`token_path` value is provided, it will use that, otherwise, it defaults to `TOKEN_LOCATION` (~/.autopkg_gh_token)

**GitHubReleasesInfoProvider:**
- `GITHUB_URL`:  This new input is passed as the `github_url` parameter
- `GITHUB_TOKEN_PATH`: This new input is passed as the `token_path` parameter

Lastly, in my testing, I noticed that `autopkg search $name -t` was not prompting me to create a token if it didn't exist. I traced it down to the `GitHubSession().search_for_name()` function. In that method, when it makes to call to `self.code_search()` it was setting the `use_token` boolean to False, essentially ignoring whatever `use_token` parameter value that was passed to the `search_for_name()` function. I made a quick change that restored the original behavior.


###Testing

**autopkg search**
```
$:~/autopkg/Code|bfreezy/internal-github-urls⚡
⇒  ./autopkg search GoogleChrome

Name                                    Repo                      Path
----                                    ----                      ----
GoogleChrome-Win64.filewave.recipe      andredb90-recipes         Google/GoogleChrome-Win64.filewave.recipe
ChromeRemoteDesktop.munki.recipe        apizz-recipes             Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
GoogleChrome.filewave.recipe            filewave                  GoogleChrome/GoogleChrome.filewave.recipe
GoogleChromeCanary.download.recipe      foigus-recipes            Google/GoogleChromeCanary.download.recipe
GoogleChromeEnterprise.munki.recipe     grahamgilbert-recipes     Google/GoogleChromeEnterprise.munki.recipe
GoogleChrome-Win.download.recipe        hansen-m-recipes          Google/GoogleChrome-Win.download.recipe
GoogleChrome-Win64.download.recipe      hansen-m-recipes          Google/GoogleChrome-Win64.download.recipe
Google Chrome.jss.recipe                jss-recipes               Google Chrome/Google Chrome.jss.recipe
Google Chrome.jss.recipe                novaksam-recipes          Google Chrome/Google Chrome.jss.recipe
GoogleChrome-Win32.LANrev.recipe        patgmac-recipes           Google Chrome/GoogleChrome-Win32.LANrev.recipe
GoogleChrome-Win64.LANrev.recipe        patgmac-recipes           Google Chrome/GoogleChrome-Win64.LANrev.recipe
GoogleChrome.pkg.recipe                 recipes                   GoogleChrome/GoogleChrome.pkg.recipe
GoogleChrome.download.recipe            recipes                   GoogleChrome/GoogleChrome.download.recipe
GoogleChromePkg.download.recipe         recipes                   GoogleChrome/GoogleChromePkg.download.recipe
GoogleChrome.install.recipe             recipes                   GoogleChrome/GoogleChrome.install.recipe
GoogleChrome.munki.recipe               recipes                   GoogleChrome/GoogleChrome.munki.recipe
GoogleChromePkg.pkg.recipe              recipes                   GoogleChrome/GoogleChromePkg.pkg.recipe
GoogleChromePkg.munki.recipe            recipes                   GoogleChrome/GoogleChromePkg.munki.recipe
GoogleChrome.jss.recipe                 rtrouton-recipes          JSS/GoogleChrome.jss.recipe
GoogleChrome.install.recipe             rtrouton-recipes          GoogleChrome/GoogleChrome.install.recipe
GoogleChrome.pkg.recipe                 rtrouton-recipes          GoogleChrome/GoogleChrome.pkg.recipe
GoogleChromeEnterprise.jss.recipe       rtrouton-recipes          JSS/GoogleChromeEnterprise.jss.recipe
GoogleChromeUSC.jss.recipe              scriptingosx-recipes      GoogleChrome/GoogleChromeUSC.jss.recipe
GoogleChromeUSC.pkg.recipe              scriptingosx-recipes      GoogleChrome/GoogleChromeUSC.pkg.recipe
GoogleChrome.LANrev.recipe              seansgm-recipes           LANrevRecipes/GoogleChrome.LANrev.recipe
GoogleChrome.Absolute.recipe            seansgm-recipes           AbsoluteRecipes/GoogleChrome.Absolute.recipe
GoogleChrome.ds.recipe                  triti-recipes             GoogleChrome/GoogleChrome.ds.recipe

To add a new recipe repo, use 'autopkg repo-add <repo name>'
```

Using the `-t` flag with autopkg search:
```
$:~/autopkg/Code|bfreezy/internal-github-urls⚡
⇒  ./autopkg search GoogleChrome -t
Create a new token in your GitHub settings page:

    https://github.com/settings/tokens

To save the token, paste it to the following prompt.
Token: <redacted>
Writing token file /Users/brandonfriess/.autopkg_gh_token.

Name                                    Repo                      Path
----                                    ----                      ----
GoogleChrome-Win64.filewave.recipe      andredb90-recipes         Google/GoogleChrome-Win64.filewave.recipe
ChromeRemoteDesktop.munki.recipe        apizz-recipes             Chrome_Remote_Desktop/ChromeRemoteDesktop.munki.recipe
GoogleChrome.filewave.recipe            filewave                  GoogleChrome/GoogleChrome.filewave.recipe
GoogleChromeCanary.download.recipe      foigus-recipes            Google/GoogleChromeCanary.download.recipe
GoogleChromeEnterprise.munki.recipe     grahamgilbert-recipes     Google/GoogleChromeEnterprise.munki.recipe
GoogleChrome-Win.download.recipe        hansen-m-recipes          Google/GoogleChrome-Win.download.recipe
GoogleChrome-Win64.download.recipe      hansen-m-recipes          Google/GoogleChrome-Win64.download.recipe
Google Chrome.jss.recipe                jss-recipes               Google Chrome/Google Chrome.jss.recipe
Google Chrome.jss.recipe                novaksam-recipes          Google Chrome/Google Chrome.jss.recipe
GoogleChrome-Win32.LANrev.recipe        patgmac-recipes           Google Chrome/GoogleChrome-Win32.LANrev.recipe
GoogleChrome-Win64.LANrev.recipe        patgmac-recipes           Google Chrome/GoogleChrome-Win64.LANrev.recipe
GoogleChrome.pkg.recipe                 recipes                   GoogleChrome/GoogleChrome.pkg.recipe
GoogleChrome.download.recipe            recipes                   GoogleChrome/GoogleChrome.download.recipe
GoogleChromePkg.download.recipe         recipes                   GoogleChrome/GoogleChromePkg.download.recipe
GoogleChrome.install.recipe             recipes                   GoogleChrome/GoogleChrome.install.recipe
GoogleChrome.munki.recipe               recipes                   GoogleChrome/GoogleChrome.munki.recipe
GoogleChromePkg.pkg.recipe              recipes                   GoogleChrome/GoogleChromePkg.pkg.recipe
GoogleChromePkg.munki.recipe            recipes                   GoogleChrome/GoogleChromePkg.munki.recipe
GoogleChrome.jss.recipe                 rtrouton-recipes          JSS/GoogleChrome.jss.recipe
GoogleChrome.install.recipe             rtrouton-recipes          GoogleChrome/GoogleChrome.install.recipe
GoogleChrome.pkg.recipe                 rtrouton-recipes          GoogleChrome/GoogleChrome.pkg.recipe
GoogleChromeEnterprise.jss.recipe       rtrouton-recipes          JSS/GoogleChromeEnterprise.jss.recipe
GoogleChromeUSC.jss.recipe              scriptingosx-recipes      GoogleChrome/GoogleChromeUSC.jss.recipe
GoogleChromeUSC.pkg.recipe              scriptingosx-recipes      GoogleChrome/GoogleChromeUSC.pkg.recipe
GoogleChrome.LANrev.recipe              seansgm-recipes           LANrevRecipes/GoogleChrome.LANrev.recipe
GoogleChrome.Absolute.recipe            seansgm-recipes           AbsoluteRecipes/GoogleChrome.Absolute.recipe
GoogleChrome.ds.recipe                  triti-recipes             GoogleChrome/GoogleChrome.ds.recipe

To add a new recipe repo, use 'autopkg repo-add <repo name>'
```

**AutoPkg run with public GitHub**
```
$: ./autopkg run --ignore-parent-trust-verification-errors /Users/brandonfriess/autopkg/Flycut/Flycut.download.recipe -vvvv
Processing /Users/brandonfriess/autopkg/Flycut/Flycut.download.recipe...
{'AUTOPKG_VERSION': '2.1.1',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GITHUB_REPO': 'TermiT/Flycut',
 'MUNKI_REPO': '/Users/brandonfriess/munki-mac-packages/public',
 'NAME': 'flycut',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/brandonfriess/Library/AutoPkg/Cache/com.foo.autopkg.flycut.download',
 'RECIPE_DIR': '/Users/brandonfriess/autopkg/Flycut',
 'RECIPE_OVERRIDE_DIRS': ['/Users/brandonfriess/cpe/autopkg/overrides'],
 'RECIPE_PATH': '/Users/brandonfriess/autopkg/Flycut/Flycut.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/RecipeRepos/com.foo.corp.git.internal.autopkg': {'URL': 'https://git.corp.foo.com/foo-internal/autopkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['/Users/brandonfriess/cpe/autopkg/overrides,',
                        '/Users/Shared/RecipeRepos/com.foo.corp.git.internal.autopkg'],
 'verbose': 4}
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'TermiT/Flycut'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Selected asset 'Flycut.1.9.4.zip' from release '1.9.4'
{'Output': {'release_notes': '- Removed sandboxing\r\n'
                             '- Made search case-insensitive',
            'url': 'https://github.com/TermiT/Flycut/releases/download/1.9.4/Flycut.1.9.4.zip',
            'version': '1.9.4'}}
```

**AutoPkg run with internal GitHub**
```
$: ./autopkg run --ignore-parent-trust-verification-errors /Users/brandonfriess/contoso/autopkg/fooapp/fooapp.download.recipe -vvvv
Processing /Users/brandonfriess/contoso/autopkg/fooapp/fooapp.download.recipe...
{'AUTOPKG_VERSION': '2.1.1',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GITHUB_REPO': 'contoso-internal/fooapp',
 'MUNKI_REPO': '/Users/brandonfriess/contoso/munki-mac-packages/public',
 'NAME': 'fooapp',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/brandonfriess/Library/AutoPkg/Cache/com.contoso.autopkg.fooapp.download',
 'RECIPE_DIR': '/Users/brandonfriess/contoso/autopkg/fooapp',
 'RECIPE_OVERRIDE_DIRS': ['/Users/brandonfriess/contoso/cpe/autopkg/overrides'],
 'RECIPE_PATH': '/Users/brandonfriess/contoso/autopkg/fooapp/fooapp.download.recipe',
 'RECIPE_REPOS': {'/Users/Shared/RecipeRepos/com.contoso.corp.git.contoso-internal.autopkg': {'URL': 'https://git.corp.contoso.com/contoso-internal/autopkg.git'}},
 'RECIPE_REPO_DIR': '/Users/Shared/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['/Users/brandonfriess/contoso/cpe/autopkg/overrides,',
                        '/Users/Shared/RecipeRepos/com.contoso.corp.git.contoso-internal.autopkg'],
 'verbose': 4}
com.contoso.autopkg.shared/AbsPath
{'Input': {'relative_path': '~/.contosoproxy'}}
AbsPath: /Users/brandonfriess/.contosoproxy
{'Output': {'absolute_path': '/Users/brandonfriess/.contosoproxy'}}
GitHubReleasesInfoProvider
{'Input': {'GITHUB_TOKEN_PATH': '~/.contoso_autopkg_github_token',
           'GITHUB_URL': 'http://git.corp.contoso.com/api/v3',
           'curl_opts': ['--unix-socket', '/Users/brandonfriess/.contosoproxy'],
           'github_repo': 'contoso-internal/fooapp'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'fooapp.authn_bundle' from release 'fooapp v2.0.3'
{'Output': {'release_notes': 'Reminder: We publish authn signed bundles. In '
                             'order to verify the signature and\r\n'
                             'extract a usable original binary from the authn '
                             'bundle use `bin/verify`.\r\n'
                             '\r\n'
                             '```\r\n'
                             '$ sha256sum *\r\n'
                             'c8cb12a357a160bddd92283235dbf84104f1959aff2f655943c07f5274dcb451  '
                             'fooapp\r\n'
                             '4b3b28b931aa70cec2532c53f6fa3a7d9afc37663631f554b2fdb95e7b80f50f  '
                             'fooapp.authn_bundle\r\n'
                             '```',
            'url': 'https://git.corp.contoso.com/contoso-internal/fooapp/releases/download/v2.0.3/certproxy.authn_bundle',
            'version': '2.0.3'}}
EndOfCheckPhase
```

Excerpt of recipe Input for internal Github:
```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>github_repo</key>
                <string>%GITHUB_REPO%</string>
                <key>curl_opts</key>
                <array>
                    <string>--unix-socket</string>
                    <string>%absolute_path%</string>
                </array>
                <key>GITHUB_URL</key>
                <string>http://git.corp.contoso.com/api/v3</string>
                <key>GITHUB_TOKEN_PATH</key>
                <string>~/.contoso_autopkg_github_token</string>
            </dict>
            <key>Processor</key>
            <string>GitHubReleasesInfoProvider</string>
        </dict>
```

Thanks for considering this!
