### PR TITLE
Windows: Add signtool processor 

### DIFF
--- a/Code/autopkglib/SignToolVerifier.py
+++ b/Code/autopkglib/SignToolVerifier.py
@@ -1,0 +1,149 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for SignToolVerifier class"""
+
+import os
+import os.path
+import subprocess
+from typing import Any, Dict, List, Optional
+
+from autopkglib import Processor, ProcessorError
+
+__all__ = ["SignToolVerifier"]
+
+
+def signtool_default_path() -> Optional[str]:
+    """Looks for signtool in a few well known paths. Deliberately naive."""
+    for program_files_candidate, arch in (
+        (os.environ.get("ProgramFiles(x86)"), "x64"),
+        (os.environ.get("ProgramFiles(x86)"), "x86"),
+        (os.environ.get("ProgramFiles"), "x64"),
+        (os.environ.get("ProgramFiles"), "x86"),
+    ):
+        if program_files_candidate is None:
+            continue
+        candpath = os.path.abspath(
+            os.path.join(
+                program_files_candidate, r"Windows Kits\10\bin", arch, "signtool.exe"
+            )
+        )
+        if os.path.exists(candpath):
+            return candpath
+    return None
+
+
+class SignToolVerifier(Processor):
+    """Verifies an authenticode signed installer using the Microsoft SDK
+    signtool executable."""
+
+    EXTENSIONS: List[str] = [".exe", ".msi"]
+
+    # TODO: How much of this is needed to act as a drop-in replacement in an
+    # override recipe??
+    input_variables: Dict[str, Any] = {
+        "DISABLE_CODE_SIGNATURE_VERIFICATION": {
+            "required": False,
+            "description": ("Prevents this processor from running."),
+        },
+        "input_path": {
+            "required": True,
+            "description": (
+                "File path to an `.msi` or `.exe` file for Authenticode verification",
+            ),
+        },
+        "signtool_path": {
+            "required": True,
+            "description": (
+                "The path to signtool.exe. This varies between versions of the "
+                "Windows SDK, so you can explicitly set that here in an override."
+            ),
+            "default": signtool_default_path(),
+        },
+        "additional_arguments": {
+            "required": False,
+            "description": (
+                "Array of additional argument strings to pass to signtool. "
+                "Note that currently '/v' and '/pa' are always passed."
+            ),
+            "default": None,
+        },
+    }
+    output_variables: Dict[str, Any] = {}
+
+    description: str = __doc__
+
+    def codesign_verify(
+        self,
+        signtool_path: str,
+        path: str,
+        additional_arguments: Optional[List[str]] = None,
+    ) -> bool:
+        """
+        Runs 'signtool.exe /pa <path>'. Returns True if signtool exited with 0
+        and False otherwise.
+        """
+        if not additional_arguments:
+            additional_arguments = []
+
+        # Call signtool with "/v" to produce information about the signer when run,
+        # and "/pa" to use the "Default Authenticode" Verification Policy.
+        process = [signtool_path, "verify", "/v", "/pa"] + additional_arguments
+
+        # Makes the path absolute and normalizes it into standard Windows form.
+        # E.g., /Program Files (x86)/Windows Kits/10/bin/x64/signtool.exe will be
+        # converted to the appropriate C:\\... path after this.
+        process.append(os.path.abspath(path))
+
+        # Run signtool with stderr redirected to stdout to ensure that all output
+        # is always captured from the tool.
+        proc = subprocess.Popen(
+            process,
+            stdin=None,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        (output, _) = proc.communicate()
+
+        for line in output.replace("\n\n", "\n").replace("\n\n\n", "\n\n").splitlines():
+            self.output(line)
+
+        if proc.returncode == 1:
+            raise ProcessorError(
+                "Authenticode verification failed. Note that all "
+                "verification can be disabled by setting the variable "
+                "DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value."
+            )
+        elif proc.returncode == 2:
+            self.output("WARNING: Verification had warnings. Check output above.")
+
+        return proc.returncode == 0
+
+    def main(self):
+        if self.env.get("DISABLE_CODE_SIGNATURE_VERIFICATION"):
+            self.output("Authenticode verification disabled for this recipe run.")
+            return
+
+        input_path = self.env["input_path"]
+        signtool_path = self.env["signtool_path"]
+        additional_arguments = self.env["additional_arguments"]
+
+        self.codesign_verify(
+            signtool_path, input_path, additional_arguments=additional_arguments,
+        )
+
+
+if __name__ == "__main__":
+    PROCESSOR = SignToolVerifier()
+    PROCESSOR.execute_shell()

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -19,12 +19,8 @@
 import os.path
 import tempfile
 
-from autopkglib import BUNDLE_ID, ProcessorError, is_mac
+from autopkglib import BUNDLE_ID, ProcessorError, xattr
 from autopkglib.URLGetter import URLGetter
-
-if is_mac():
-    import xattr
-
 
 __all__ = ["URLDownloader"]
 
@@ -115,8 +111,9 @@ class URLDownloader(URLGetter):
 
     def getxattr(self, attr):
         """Get a named xattr from a file. Return None if not present."""
+
         if attr in xattr.listxattr(self.env["pathname"]):
-            return xattr.getxattr(self.env["pathname"], attr).decode()
+            return xattr.getxattr(self.env["pathname"], attr)
         return None
 
     def prepare_base_curl_cmd(self):
@@ -176,7 +173,11 @@ class URLDownloader(URLGetter):
         header = self.parse_headers(raw_headers)
 
         if "filename=" in header.get("content-disposition", ""):
-            filename = header["content-disposition"].rpartition("filename=")[2].replace('"', '')
+            filename = (
+                header["content-disposition"]
+                .rpartition("filename=")[2]
+                .replace('"', "")
+            )
             self.output(
                 f"Filename prefetched from the HTTP Content-Disposition header: {filename}",
                 verbose_level=2,
@@ -307,9 +308,6 @@ class URLDownloader(URLGetter):
             self.output(f"Storing new ETag header: {header.get('etag')}")
 
     def main(self):
-        if not is_mac():
-            raise ProcessorError("This processor is Mac-only!")
-
         # Clear and initiazize data structures
         self.clear_vars()
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -915,7 +915,7 @@ def import_processors():
     processor_files = [
         os.path.splitext(name)[0]
         for name in os.listdir(mydir)
-        if name.endswith(".py") and not name == "__init__.py"
+        if name.endswith(".py") and name not in ("__init__.py", "xattr.py")
     ]
 
     # Warning! Fancy dynamic importing ahead!

--- a/Code/autopkglib/xattr.py
+++ b/Code/autopkglib/xattr.py
@@ -1,0 +1,100 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Wrapper module that provides a consistent xattr interface
+regardless of platform support.
+"""
+from typing import Any, List, Optional
+
+__all__ = ["getxattr", "listxattr", "removexattr", "setxattr"]
+
+
+class __xattr_wrapper:
+    def __init__(self, impl: Any) -> None:
+        self._impl = impl
+
+    def getxattr(self, path: str, attr: str, symlink: bool = False) -> str:
+        return self._impl.getxattr(path, attr, symlink)
+
+    def listxattr(self, path: str, symlink: bool = False) -> List[str]:
+        return self._impl.listxattr(path, symlink)
+
+    def removexattr(self, path: str, attr: str, symlink: bool = False) -> None:
+        return self._impl.removexattr(path, attr, symlink)
+
+    def setxattr(
+        self, path: str, attr: str, value: str, options: int = 0, symlink: bool = False
+    ) -> None:
+        return self._impl.setxattr(path, attr, value, options, symlink)
+
+
+_xattr = __xattr_wrapper(None)
+
+try:
+    import xattr as _xattr_real  # type: ignore
+
+    _xattr = __xattr_wrapper(_xattr_real)
+except ImportError:
+    print("WARNING: Library 'xattr' unavailable. Defining no-op implementation.")
+
+    class __xattr_stub:
+        """A stub class that will perform noop for any calls to the
+        xattr module on platforms where it is not supported."""
+
+        @staticmethod
+        def getxattr(cls, path: str, attr: str, symlink: bool = False) -> Optional[str]:
+            return None
+
+        @staticmethod
+        def listxattr(cls, path: str, symlink: bool = False) -> List[str]:
+            return []
+
+        @staticmethod
+        def removexattr(cls, path: str, attr: str, symlink: bool = False) -> None:
+            return None
+
+        @staticmethod
+        def setxattr(
+            cls,
+            path: str,
+            attr: str,
+            value: str,
+            options: int = 0,
+            symlink: bool = False,
+        ) -> None:
+            return None
+
+    _xattr = __xattr_wrapper(__xattr_stub)
+
+assert (
+    _xattr._impl is not None
+), "Failed to initialize xattr library, or stub. This is a bug."
+
+
+def getxattr(path: str, attr: str, symlink: bool = False) -> Optional[str]:
+    return _xattr.getxattr(path, attr, symlink)
+
+
+def listxattr(path: str, symlink: bool = False) -> List[str]:
+    return _xattr.listxattr(path, symlink)
+
+
+def removexattr(path: str, attr: str, symlink: bool = False) -> None:
+    return _xattr.removexattr(path, attr, symlink)
+
+
+def setxattr(
+    path: str, attr: str, value: str, options: int = 0, symlink: bool = False
+) -> None:
+    return _xattr.setxattr(path, attr, value, options, symlink)

--- a/Code/tests/test_signtool.py
+++ b/Code/tests/test_signtool.py
@@ -1,0 +1,37 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+from typing import Any, Dict
+
+from autopkglib.SignToolVerifier import ProcessorError, SignToolVerifier
+
+
+class TestSignToolVerifier(unittest.TestCase):
+    @unittest.skipUnless(sys.platform == "win32", "Requires Windows")
+    def test_verify_ntdll(self):
+        env: Dict[str, str] = {"input_path": r"C:\Windows\System32\ntdll.dll"}
+        processor = SignToolVerifier(env)
+        processor.process()
+
+    @unittest.skipUnless(sys.platform == "win32", "Requires Windows")
+    def test_verify_nopath(self):
+        env: Dict[str, Any] = {"input_path": r"C:\Fake\Path\To.dll", "verbose": 4}
+        processor = SignToolVerifier(env)
+        self.assertRaises(ProcessorError, processor.process)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a new processor for Windows `signtool.exe`. Additionally, this includes a wrapper library around `xattr` to so that `URLDownloader` has no more platform specific code in it. This PR depends on #648.

The signtool integration/functional tests pass on Windows and are correctly excluded on other platforms. With the inclusion of the `xattr` changes, autopkg is also now able to download a package on Windows.

Test results:
* [Autopkg Windows example output](https://gist.github.com/linuxfood/eb4efe457bb2415b4c5a9acab52d3b61) - showing successfully downloading a package on Windows. The CodeSignatureVerifier error is expected and a future PR will make sure that CodeSignatureVerifier explicitly to run on Windows.
* [Autopkg macOS run -vv output](https://gist.github.com/linuxfood/f04bd008b5e18d992d1ca94bfb39e4eb) - demonstrating that macOS still works after these changes.