### PR TITLE
Cleanup some dead code and fix two bugs

### DIFF
--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -32,34 +32,16 @@ from copy import deepcopy
 from distutils.version import LooseVersion
 
 
-class memoize(dict):
-    """Class to cache the return values of an expensive function.
-    This version supports only functions with non-keyword arguments"""
-
-    def __init__(self, func):
-        self.func = func
-
-    def __call__(self, *args):
-        return self[args]
-
-    def __missing__(self, key):
-        result = self[key] = self.func(*key)
-        return result
-
-
-# @memoize
 def is_mac():
     """Return True if current OS is macOS."""
     return "Darwin" in platform.platform()
 
 
-# @memoize
 def is_windows():
     """Return True if current OS is Windows."""
     return "Windows" in platform.platform()
 
 
-# @memoize
 def is_linux():
     """Return True if current OS is Linux."""
     return "Linux" in platform.platform()

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -489,7 +489,7 @@ class Processor:
         try:
             self.read_input_plist()
             self.parse_arguments()
-            self.main()
+            self.process()
             self.write_output_plist()
         except ProcessorError as err:
             log_err(f"ProcessorError: {err}")

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -460,7 +460,7 @@ class Processor:
                 )
             # Make sure all required arguments have been supplied.
             if flags.get("required") and (variable not in self.env):
-                raise ProcessorError(f"{self.__name__} requires {variable}")
+                raise ProcessorError(f"{self.__class__.__name__} requires {variable}")
 
         self.main()
         return self.env

--- a/Code/tests/test_autopkglib.py
+++ b/Code/tests/test_autopkglib.py
@@ -9,12 +9,7 @@ import unittest
 from textwrap import dedent
 from unittest.mock import mock_open, patch
 
-# DO NOT MOVE THIS! This needs to happen BEFORE importing autopkglib
-# Annoyingly, I can't figure out how to correctly suppress memoization
-# in all contexts. You may have to comment out the @memoize calls in
-# autopkglib.__init__.py to correctly run these tests.
-patch("autopkglib.memoize", lambda x: x).start()
-import autopkglib  # isort:skip
+import autopkglib
 
 autopkg = imp.load_source("autopkg", os.path.join("Code", "autopkg"))
 


### PR DESCRIPTION
This PR: removes the `memoize` decorator, fixes a bug in `execute_shell`, and #650 which makes autopkg throw the wrong error in an error case. 

The usages of the `memoize` decorator seem to have all been commented out at one point. The python standard library has an equivalent `lru_cache` decorator that can be used should the need arise for memoize again. The `execute_shell` and wrong error error bugs are just a cases of mistaken identity (wrong methods).