### PR TITLE
Windows: Fix inputs bug in SigntoolProcessor

### DIFF
--- a/Code/autopkglib/SignToolVerifier.py
+++ b/Code/autopkglib/SignToolVerifier.py
@@ -63,7 +63,7 @@ class SignToolVerifier(Processor):
             ),
         },
         "signtool_path": {
-            "required": True,
+            "required": False,
             "description": (
                 "The path to signtool.exe. This varies between versions of the "
                 "Windows SDK, so you can explicitly set that here in an override."


### PR DESCRIPTION
The `signtool_path` input variable had a default value as well as
setting `required: True`. Consequently, it didn't work when running as
part of a larger recipe due to inconsistencies in how autopkg interprets
variables.