### PR TITLE
Windows/autopkg recipe support

### DIFF
--- a/Code/autopkglib/Versioner.py
+++ b/Code/autopkglib/Versioner.py
@@ -16,12 +16,25 @@
 """See docstring for Versioner class"""
 
 import os.path
+import posixpath
+import zipfile
+from typing import Callable, Iterator, List, Optional
 
+from autopkglib import FileOrPath, ProcessorError, VarDict
 from autopkglib.DmgMounter import DmgMounter
 
-NO_VERSION_MESSAGE = "UNKNOWN_VERSION"
+UNKNOWN_VERSION = "UNKNOWN_VERSION"
 
 __all__ = ["Versioner"]
+
+
+def _zip_listdir(file: zipfile.ZipFile, dir: str) -> Iterator[zipfile.ZipInfo]:
+    dir = dir.rstrip("/")
+
+    def is_direct_child(info: zipfile.ZipInfo):
+        return posixpath.dirname(info.filename.rstrip("/")) == dir
+
+    return filter(is_direct_child, file.infolist())
 
 
 class Versioner(DmgMounter):
@@ -44,34 +57,162 @@ class Versioner(DmgMounter):
                 "Which plist key to use; defaults to CFBundleShortVersionString"
             ),
         },
+        "skip_single_root_dir": {
+            "required": False,
+            "default": False,
+            "description": (
+                "If this flag is set, `input_plist_path` points inside a zip file, "
+                "and there is a single directory inside the zip file at the root of "
+                "the archive, then interpret the path in the archive as being relative "
+                "to that directory. Example:"
+                """
+          input_plist_path=/tmp/some/archive.zip/path/to/version.plist
+          archive.zip
+            archive-abcdef/
+              path/to/version.plist\n"""
+                "        Will use `archive-abcdef/path/to/version.plist` as the final "
+                "path. If there is more than one file or directory at the root, the "
+                "Processor will fail."
+            ),
+        },
     }
     output_variables = {"version": {"description": "Version of the item."}}
 
+    ZIP_EXTENSIONS = [".zip"]
+
+    def _read_from_zip(
+        self,
+        path: str,
+        skip_single_root_dir: bool,
+        deserializer: Callable[[FileOrPath], VarDict],
+        extensions: List[str],
+    ) -> Optional[VarDict]:
+        """Parse a member from a zip and return `bytes`, or `None` if it does not exist.
+
+        The `path` argument should be structured such that the path into the zip file
+        follows the path to the zip file directly.
+
+        Example:
+            path/to/archive.zip/path/in/archive/to/version.plist
+        If the flag `skip_single_root_dir` and there is more than one top-level
+        directory inside the zip file, an exception will be raised.
+
+        File extensions provided must be provided with a leading `.` i.e., `.zip`.
+        All file extensions are considered case-insensitively.
+        """
+        # Normalize path to ensure consistent cross-platform behavior.
+        path = os.path.normpath(path)
+        archive_path: Optional[str] = None
+        inner_path: Optional[str] = None
+        for ext in extensions:
+            ext_index: int = path.lower().find(f"{ext.lower()}{os.path.sep}")
+            if ext_index == -1:
+                continue
+            archive_path = path[: ext_index + len(ext)]
+            # Convert to POSIX path separators, as this is what zipfile uses.
+            inner_path = path[ext_index + len(ext) + 1 :].replace("\\", "/")
+            break
+        if archive_path is None or inner_path is None:
+            raise ProcessorError(
+                f"Expected ZIP archive path, but '{path}' is not a ZIP path."
+            )
+
+        archive = zipfile.ZipFile(archive_path)
+        root_names: List[zipfile.ZipInfo] = list(
+            filter(zipfile.ZipInfo.is_dir, _zip_listdir(archive, ""))
+        )
+        if len(root_names) == 0:
+            self.output(f"Zip archive '{archive_path}' is empty.")
+            return None
+        if not skip_single_root_dir:
+            return deserializer(archive.open(inner_path))
+        if skip_single_root_dir and len(root_names) > 1:
+            raise ProcessorError(
+                f"Zip archive '{archive_path}' has more than one directory at "
+                f"root: {root_names} and skip_single_root_directory was set."
+            )
+
+        inner_path = posixpath.join(root_names[0].filename, inner_path)
+        if inner_path not in archive.namelist():
+            self.output(f"Zip archive '{archive_path}' does not contain '{inner_path}'")
+            return None
+        return deserializer(archive.open(inner_path))
+
+    def _read_from_dmg(
+        self, path: str, deserializer: Callable[[FileOrPath], VarDict],
+    ) -> Optional[VarDict]:
+        """Parse a file from a DMG and return `bytes`, or `None` if no such file exists.
+
+        The `path` argument should be structured such that the path into the disk image
+        follows the path to the disk image directly.
+
+        Example:
+            path/to/disk.dmg/path/in/dmg/to/version.plist
+        """
+        # Check if we're trying to read something inside a dmg.
+        (dmg_path, dmg, dmg_source_path) = self.parsePathForDMG(path)
+        if not dmg:
+            raise ProcessorError(f"Expected DMG path, but '{path}' is not a DMG path.")
+        try:
+            dmg_path = os.path.normpath(dmg_path)
+            # Mount dmg and copy path inside.
+            mount_point = self.mount(dmg_path)
+            input_plist_path = os.path.normpath(
+                os.path.join(mount_point, dmg_source_path)
+            )
+            if not os.path.exists(input_plist_path):
+                return None
+            try:
+                return deserializer(input_plist_path)
+            except Exception as err:
+                raise ProcessorError(err)
+        finally:
+            self.unmount(dmg_path)
+        return None
+
+    def _read_auto_detect(
+        self,
+        path: str,
+        skip_single_root_dir: bool,
+        deserializer: Callable[[FileOrPath], VarDict],
+    ) -> Optional[VarDict]:
+        """Use simple herustics to read a file from a dmg, zip, or the filesystem.
+
+        Returns `None` if the provided `path` could not be found. Exceptions are raised
+        in the event that the file is corrupt or unaccessible.
+        """
+        is_dmg_input: List[bool] = [ext in path for ext in self.DMG_EXTENSIONS]
+        is_zip_input: List[bool] = [ext in path for ext in self.ZIP_EXTENSIONS]
+        if any(is_dmg_input):
+            return self._read_from_dmg(path, deserializer)
+        elif any(is_zip_input):
+            return self._read_from_zip(
+                path, skip_single_root_dir, deserializer, self.ZIP_EXTENSIONS
+            )
+        elif not os.path.exists(path):
+            return None
+        return deserializer(path)
+
     def main(self):
         """Return a version for file at input_plist_path"""
-        # Check if we're trying to read something inside a dmg.
-        (dmg_path, dmg, dmg_source_path) = self.parsePathForDMG(
-            self.env["input_plist_path"]
-        )
+        input_plist_path: str = self.env["input_plist_path"]
+        skip_single_root_dir: bool = self.env["skip_single_root_dir"]
+        version_key: str = self.env["plist_version_key"]
+
         try:
-            if dmg:
-                # Mount dmg and copy path inside.
-                mount_point = self.mount(dmg_path)
-                input_plist_path = os.path.join(mount_point, dmg_source_path)
-            else:
-                # just use the given path
-                input_plist_path = self.env["input_plist_path"]
-            plist = self.load_plist_from_file(input_plist_path)
-            self.env["version"] = plist.get(
-                self.env["plist_version_key"], NO_VERSION_MESSAGE
+            plist = self._read_auto_detect(
+                input_plist_path, skip_single_root_dir, self.load_plist_from_file
             )
+            if plist is None:
+                raise ProcessorError(f"File '{input_plist_path}' was not found.")
+            self.env["version"] = plist.get(version_key, UNKNOWN_VERSION)
             self.output(
                 f"Found version {self.env['version']} in file {input_plist_path}"
             )
-
-        finally:
-            if dmg:
-                self.unmount(dmg_path)
+        except ProcessorError:
+            raise
+        except Exception as ex:
+            raise ProcessorError(ex)
 
 
 if __name__ == "__main__":

--- a/Code/tests/__init__.py
+++ b/Code/tests/__init__.py
@@ -1,0 +1,41 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+from types import ModuleType
+from typing import Type, Union
+
+from autopkglib import Processor
+
+
+def get_processor_module(
+    processor: Union[str, Type[Processor]], package_name: str = "autopkglib"
+) -> ModuleType:
+    """Get the module for a processor, which may be passed as a string or class object.
+
+    Typically used for patching module scoped functions for unit testing like so:
+        proc_module = get_processor_module("Unarchiver")
+        patcher = unittest.mock.patch.object(proc_module, "is_mac", return_value=False)
+
+    Necessary because `autopkglib` contains code that makes it impossible to import a
+    processor *module* without significant effort and/or modifications to some of the
+    basic machinery of `autopkglib`. This function wraps simple `importlib` machinery.
+    """
+    if isinstance(processor, str):
+        module_name: str = ".".join([package_name, processor])
+    else:
+        module_name = processor.__module__
+    # The default value for `package_name` relies on the convention in
+    # `autopkglib.import_processors` that expects module name to equal processor name.
+    return importlib.import_module(module_name)

--- a/Code/tests/test_chocolatey_packager.py
+++ b/Code/tests/test_chocolatey_packager.py
@@ -20,12 +20,12 @@ import unittest
 import unittest.mock
 from copy import deepcopy
 from io import BytesIO
-from typing import Dict
+from typing import Any, Dict
 
 from autopkglib import find_binary
 from autopkglib.ChocolateyPackager import ChocolateyPackager
 
-VarDict = Dict[str, str]
+VarDict = Dict[str, Any]
 
 
 def get_mocked_writes(mock: unittest.mock.MagicMock) -> str:
@@ -46,7 +46,7 @@ class TestChocolateyPackager(unittest.TestCase):
 
     def setUp(self):
         self.maxDiff = 100000
-        self.test_dir: str = tempfile.TemporaryDirectory()
+        self.test_dir: tempfile.TemporaryDirectory = tempfile.TemporaryDirectory()
         self.common_nuspec_vars: VarDict = {
             "id": "a-package",
             "version": "1.4.4",

--- a/Code/tests/test_unarchiver.py
+++ b/Code/tests/test_unarchiver.py
@@ -1,0 +1,134 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import unittest.mock
+from copy import deepcopy
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, List, Optional, Tuple
+
+from autopkglib.Unarchiver import Unarchiver
+from tests import get_processor_module
+
+UnarchiverModule: Any = get_processor_module(Unarchiver)
+
+
+class TestUnarchiver(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = 100000
+        self.tempdir = TemporaryDirectory()
+        self.default_archive_path = (
+            f"{self.tempdir.name}/archive_path/is/irrelevant.zip"
+        )
+        self.default_destination_path = (
+            f"{self.tempdir.name}/destination_path/is/irrelevant"
+        )
+        self.processor_env: Dict[str, Any] = {
+            "archive_path": self.default_archive_path,
+            "destination_path": self.default_destination_path,
+            "purge_destination": False,
+            "archive_format": None,
+            "RECIPE_CACHE_DIR": self.tempdir.name,
+            "NAME": "destination_path/FAILURE",
+        }
+        self.processor = Unarchiver(env=deepcopy(self.processor_env))
+
+        self._popen_patcher = unittest.mock.patch.object(
+            UnarchiverModule.subprocess, "Popen", autospec=True
+        )
+        self.popen_mock = self._popen_patcher.start()
+        self.process_mock = self.popen_mock.return_value
+
+        self.addCleanup(unittest.mock.patch.stopall)
+        self.addCleanup(self.tempdir.cleanup)
+
+    @unittest.mock.patch.object(UnarchiverModule, "is_mac", return_value=True)
+    def test_default_extractor_selection_macos(self, _mock):
+        """Test that we use utility extraction on macOS."""
+        self.assertEqual(False, UnarchiverModule._default_use_python_native_extractor())
+
+    @unittest.mock.patch.object(UnarchiverModule, "is_mac", return_value=False)
+    def test_default_extractor_selection_other(self, _mock):
+        """Test that we use native extraction on other platforms."""
+        self.assertEqual(True, UnarchiverModule._default_use_python_native_extractor())
+
+    @unittest.mock.patch.object(Unarchiver, "_extract")
+    def test_extract_called(self, extract_mock):
+        """Smoke test the processor with a basic configuration."""
+        self.processor.process()
+        extract_mock.assert_called_once_with(
+            "zip", self.default_archive_path, self.default_destination_path
+        )
+
+    def test_utility_extract(self):
+        # Ensure that utility extraction is used on any test platform,
+        # since it won't actually run.
+        self.processor.env["USE_PYTHON_NATIVE_EXTRACTOR"] = False
+        self.process_mock.communicate.return_value = ("", "")
+        self.process_mock.returncode = 0
+
+        utility_cases: List[Tuple[str, str, Optional[str]]] = [
+            ("autodetects zip format", "/usr/bin/ditto", None),
+            ("manual zip", "/usr/bin/ditto", "zip"),
+            ("manual tar.gz", "/usr/bin/tar", "tar_gzip"),
+            ("manual tar.bz2", "/usr/bin/tar", "tar_bzip2"),
+            ("manual gzip", "/usr/bin/ditto", "gzip"),
+        ]
+
+        for subtest_name, expected_binary, archive_format in utility_cases:
+            with self.subTest(subtest_name, expected_binary=expected_binary):
+                self.processor.env["archive_format"] = archive_format
+                self.processor.process()
+                self.popen_mock.assert_called()
+                self.process_mock.communicate.assert_called()
+
+                # Checks the first value of the first positional argument.
+                self.assertEqual(expected_binary, self.popen_mock.call_args[0][0][0])
+
+    def test_native_extract(self):
+        # Ensure that native extraction is used on any test platform,
+        # since it won't actually run.
+        self.processor.env["USE_PYTHON_NATIVE_EXTRACTOR"] = True
+
+        zipfile_mock = unittest.mock.MagicMock(spec=UnarchiverModule.zipfile.ZipFile)
+        tarfile_mock = unittest.mock.MagicMock(spec=UnarchiverModule.tarfile.TarFile)
+        native_cases: List[
+            Tuple[str, UnarchiverModule.ExtractorType, Optional[str], str]
+        ] = [
+            ("autodetects zip format", zipfile_mock, None, "zip"),
+            ("manual zip", zipfile_mock, "zip", "zip"),
+            ("manual tar.gz", tarfile_mock, "tar_gzip", "tar_gzip"),
+            ("manual tar.bz2", tarfile_mock, "tar_bzip2", "tar_bzip2"),
+        ]
+
+        for (
+            subtest_name,
+            expected_class,
+            forced_archive_format,
+            auto_archive_format,
+        ) in native_cases:
+            with unittest.mock.patch.dict(
+                UnarchiverModule.NATIVE_EXTRACTORS,
+                {auto_archive_format: expected_class},
+                clear=True,
+            ):
+                with self.subTest(subtest_name, expected_class=expected_class):
+                    self.processor.env["archive_format"] = forced_archive_format
+                    self.processor.process()
+                    expected_class.assert_called_with(
+                        self.processor.env["archive_path"], mode="r"
+                    )
+                    expected_class.return_value.extractall.assert_called()
+
+        self.popen_mock.assert_not_called()

--- a/Code/tests/test_versioner.py
+++ b/Code/tests/test_versioner.py
@@ -1,102 +1,286 @@
 #!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+import os.path
 import plistlib
+import posixpath
 import unittest
-from textwrap import dedent
+import zipfile
+from copy import deepcopy
+from io import BytesIO
+from tempfile import TemporaryDirectory
+from typing import Any, Dict
+from unittest import mock
 from unittest.mock import patch
 
-from autopkglib.Versioner import NO_VERSION_MESSAGE, Versioner
+from autopkglib import VarDict
+from autopkglib.Versioner import UNKNOWN_VERSION, ProcessorError, Versioner
+
+
+def patch_open(data: bytes, **kwargs) -> mock._patch:
+    def _new_mock():
+        omock = mock.MagicMock(name="open", spec="open")
+        omock.side_effect = lambda *args, **kwargs: BytesIO(data)
+        return omock
+
+    return patch("builtins.open", new_callable=_new_mock, **kwargs)
+
+
+TEST_VERSION_DEFAULT_KEY: str = "CFBundleShortVersionString"
+TEST_VERSION_DEFAULT: str = "1.2.3"
+TEST_VERSION_CUSTOM_KEY: str = "com.someapp.customversion"
+TEST_VERSION_CUSTOM: str = "3.2.1"
+
+TEST_VERSION_PLIST: bytes = f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleShortVersionString</key>
+    <string>{TEST_VERSION_DEFAULT}</string>
+    <key>{TEST_VERSION_CUSTOM_KEY}</key>
+    <string>{TEST_VERSION_CUSTOM}</string>
+</dict>
+</plist>""".encode(
+    "utf-8"
+)
+
+TEST_NO_VERSION_PLIST: bytes = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>""".encode(
+    "utf-8"
+)
 
 
 class TestVersioner(unittest.TestCase):
     """Test class for Versioner Processor."""
 
-    version_default_key = "CFBundleShortVersionString"
-    version_default = "1.2.3"
-    version_custom_key = "com.someapp.customversion"
-    version_custom = "3.2.1"
-
-    info_plist = dedent(
-        f"""<?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-            <key>CFBundleShortVersionString</key>
-            <string>{version_default}</string>
-            <key>{version_custom_key}</key>
-            <string>{version_custom}</string>
-        </dict>
-        </plist>
-    """
-    ).encode()
-
-    no_version_plist = dedent(
-        """<?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-        </dict>
-        </plist>
-    """
-    ).encode()
-
     def setUp(self):
-        self.good_env = {
+        self.maxDiff: int = 100000
+        self.tempdir = TemporaryDirectory()
+        self.good_env: Dict[str, Any] = {
             "input_plist_path": "dummy_path",
-            "plist_version_key": self.version_default_key,
+            "plist_version_key": TEST_VERSION_DEFAULT_KEY,
+            "RECIPE_CACHE_DIR": self.tempdir.name,
         }
-        self.bad_env = {}
-        self.input_plist = plistlib.dumps(self.good_env)
-        self.processor = Versioner(infile=self.input_plist)
-        self.processor.env = self.good_env
+        self.bad_env: Dict[str, Any] = {}
+        self.processor = Versioner(data=deepcopy(self.good_env))
+        self.addCleanup(self.tempdir.cleanup)
 
     def tearDown(self):
         pass
 
-    def run_direct_plist(self, plist, mock_dmg, mock_plist):
+    def _mkpath(self, *parts: str) -> str:
+        """Returns a path into the per testcase temporary directory.
+        On POSIX-y platforms the paths are sensible. On Windows they will non-standard
+        because they will use the format `C:/path/to/tmpdir/file.txt` instead of the
+        conventional `C:\\path\\....`. This is due to the interaction of code written
+        only for macOS and code written to be cross-platform."""
+        return posixpath.normpath(os.path.join(self.tempdir.name, *parts))
+
+    def _run_direct_plist(
+        self, plist: bytes, mock_dmg: mock.Mock, mock_plist: mock.Mock
+    ):
         """Find version in specified plist file."""
         mock_dmg.return_value = (self.processor.env["input_plist_path"], "", "")
         mock_plist.return_value = plistlib.loads(plist)
-        self.processor.main()
+        with patch("os.path.exists", return_value=True):
+            self.processor.process()
 
     @patch("autopkglib.Versioner.load_plist_from_file")
     @patch("autopkglib.Versioner.parsePathForDMG")
     def test_no_fail_if_good_env(self, mock_dmg, mock_plist):
         """The processor should not raise any exceptions if run normally."""
-        self.run_direct_plist(self.info_plist, mock_dmg, mock_plist)
+        self._run_direct_plist(TEST_VERSION_PLIST, mock_dmg, mock_plist)
 
     @patch("autopkglib.Versioner.load_plist_from_file")
     @patch("autopkglib.Versioner.parsePathForDMG")
     def test_find_cfbundle_short_version(self, mock_dmg, mock_plist):
-        """The processor should find version in default CFBundleShortVersionString."""
-        self.run_direct_plist(self.info_plist, mock_dmg, mock_plist)
-        self.assertEqual(self.processor.env["version"], self.version_default)
+        """The processor should find version in default `CFBundleShortVersionString`."""
+        self._run_direct_plist(TEST_VERSION_PLIST, mock_dmg, mock_plist)
+        self.assertEqual(self.processor.env["version"], TEST_VERSION_DEFAULT)
 
     @patch("autopkglib.Versioner.load_plist_from_file")
     @patch("autopkglib.Versioner.parsePathForDMG")
     def test_find_custom_version(self, mock_dmg, mock_plist):
-        """The processor should find version under key specified by plist_version_key."""
-        self.processor.env["plist_version_key"] = self.version_custom_key
-        self.run_direct_plist(self.info_plist, mock_dmg, mock_plist)
-        self.assertEqual(self.processor.env["version"], self.version_custom)
+        """The processor should find version under key specified by `plist_version_key`."""
+        self.processor.env["plist_version_key"] = TEST_VERSION_CUSTOM_KEY
+        self._run_direct_plist(TEST_VERSION_PLIST, mock_dmg, mock_plist)
+        self.assertEqual(self.processor.env["version"], TEST_VERSION_CUSTOM)
 
     @patch("autopkglib.Versioner.load_plist_from_file")
     @patch("autopkglib.Versioner.parsePathForDMG")
     def test_no_version_found(self, mock_dmg, mock_plist):
         """The processor should not find version if plist misses it."""
-        self.run_direct_plist(self.no_version_plist, mock_dmg, mock_plist)
-        self.assertEqual(self.processor.env["version"], NO_VERSION_MESSAGE)
+        self._run_direct_plist(TEST_NO_VERSION_PLIST, mock_dmg, mock_plist)
+        self.assertEqual(self.processor.env["version"], UNKNOWN_VERSION)
 
-    @patch("autopkglib.Versioner.unmount")
-    @patch("autopkglib.Versioner.mount")
-    @patch("autopkglib.Versioner.load_plist_from_file")
-    @patch("autopkglib.Versioner.parsePathForDMG")
-    def test_no_fail_if_dmg(self, mock_dmg, mock_plist, mock_mount, mock_unmount):
-        """The processor should not raise any exceptions when plist is in the dmg image."""
-        mock_dmg.return_value = ("path_to_dmg", ".dmg/", "path_to_plist")
-        mock_plist.return_value = plistlib.loads(self.info_plist)
-        mock_mount.return_value = "dmg_mount_point"
-        self.processor.main()
+    @patch("os.path.exists", return_value=True)
+    @patch.object(Versioner, "_read_from_zip", return_value={})
+    @patch.object(Versioner, "_read_from_dmg", return_value={})
+    def test_read_auto_detect(self, mock_dmg, mock_zip, mock_exists):
+        """File type auto detection"""
+        mock_deserializer = mock.MagicMock()
+
+        zip_inner_path = self._mkpath("archive.zip", "dummy", "file.txt")
+        dmg_inner_path = self._mkpath("image.dmg", "dummy", "file2.txt")
+        real_path = self._mkpath("regular", "dummy", "file3.txt")
+        for path in (
+            real_path,
+            zip_inner_path,
+            dmg_inner_path,
+        ):
+            with self.subTest(path=path):
+                self.processor._read_auto_detect(
+                    path=path,
+                    skip_single_root_dir=False,
+                    deserializer=mock_deserializer,
+                )
+        mock_deserializer.assert_called_once_with(real_path)
+        mock_exists.assert_called_once_with(real_path)
+        mock_zip.assert_called_once_with(
+            zip_inner_path, False, mock_deserializer, self.processor.ZIP_EXTENSIONS
+        )
+        mock_dmg.assert_called_once_with(dmg_inner_path, mock_deserializer)
+
+    def test_version_from_image(self):
+        """Inner image-like (DMG/ISO) paths work"""
+
+        @patch("os.path.exists", return_value=True)
+        @patch.object(Versioner, "_read_from_zip")
+        @patch.object(Versioner, "unmount")
+        @patch.object(Versioner, "mount")
+        # @patch("autopkglib.Versioner.load_plist_from_file")
+        @patch_open(TEST_VERSION_PLIST)
+        def test_for_extension(
+            ext: str, mock_plist, mock_mount, mock_unmount, mock_zip, mock_exists
+        ):
+            mount_path: str = self._mkpath("dmg_mount")
+            plist_path: str = self._mkpath(f"fake{ext}/dir/version.plist")
+            dmg_path: str = self._mkpath(f"fake{ext}")
+            mock_mount.return_value = mount_path
+            self.processor.env["input_plist_path"] = plist_path
+            result: Dict[str, Any] = self.processor.process()
+            mock_zip.assert_not_called()
+            mock_exists.assert_called_once_with(
+                os.path.normpath(os.path.join(mount_path, "dir/version.plist"))
+            )
+            mock_mount.assert_called_once_with(dmg_path)
+            mock_unmount.assert_called_once_with(dmg_path)
+            mock_plist.assert_called_once_with(
+                os.path.normpath(os.path.join(mount_path, "dir/version.plist")), "rb"
+            )
+            self.assertIn("version", result)
+            self.assertEqual(TEST_VERSION_DEFAULT, result["version"])
+
+        for ext_case in self.processor.DMG_EXTENSIONS:
+            with self.subTest(image_extension=ext_case):
+                test_for_extension(ext_case)
+
+    @patch("os.path.exists", return_value=False)
+    @patch("autopkglib.Versioner._read_from_dmg")
+    def test_version_from_zip(self, mock_dmg, mock_exists):
+        multi_subdir = list(
+            map(
+                zipfile.ZipInfo,
+                (
+                    "subdir/",
+                    "subdir/version.plist",
+                    "root_level_file.txt",
+                    "subdir2/",
+                    "subdir2/boring_file.txt",
+                ),
+            )
+        )
+        single_subdir = list(
+            map(
+                zipfile.ZipInfo,
+                ("subdir/", "subdir/version.plist", "root_level_file.txt",),
+            )
+        )
+        for skip_single_root_dir, plist_file, expected_plist_file, filelist in (
+            (False, "subdir/version.plist", "subdir/version.plist", multi_subdir),
+            (True, "version.plist", "subdir/version.plist", single_subdir),
+        ):
+            zip_path = self._mkpath("test.zip")
+            plist_path = self._mkpath(f"test.zip/{plist_file}")
+            self.processor.env["input_plist_path"] = plist_path
+            self.processor.env["skip_single_root_dir"] = skip_single_root_dir
+            with patch("zipfile.ZipFile") as mock_zipfile:
+                mock_zinst = mock_zipfile.return_value
+                mock_zinst.open.return_value = BytesIO(TEST_VERSION_PLIST)
+                mock_zinst.filelist = filelist
+                mock_zinst.infolist.return_value = filelist
+                mock_zinst.namelist.return_value = [zi.filename for zi in filelist]
+                with self.subTest(
+                    skip_single_root_dir=skip_single_root_dir,
+                    plist_file=plist_file,
+                    filelist=[zi.filename for zi in filelist],
+                ):
+                    result: VarDict = self.processor.process()
+                    mock_zipfile.assert_called_once_with(zip_path)
+                    mock_zinst.open.assert_called_once_with(expected_plist_file)
+                    mock_exists.assert_not_called()
+                    mock_dmg.assert_not_called()
+                    self.assertIn("version", result)
+                    self.assertEqual(TEST_VERSION_DEFAULT, result["version"])
+
+    @patch("os.path.exists", return_value=False)
+    @patch.object(Versioner, "_read_from_dmg")
+    @patch("zipfile.ZipFile", autospec=True)
+    def test_multi_root_zip(self, mock_zipfile, mock_dmg, mock_exists):
+        """Raises ProcessorError when skip_single_root_dir=True and extra dir exists"""
+        zip_path = self._mkpath("test.zip")
+        plist_path = self._mkpath("test.zip/version.plist")
+        self.processor.env["input_plist_path"] = plist_path
+        self.processor.env["skip_single_root_dir"] = True
+        mock_zinst = mock_zipfile.return_value
+        mock_zinst.infolist.return_value = [
+            zipfile.ZipInfo("subdir/"),
+            zipfile.ZipInfo("subdir/version.plist"),
+            zipfile.ZipInfo("subdir2/"),
+            zipfile.ZipInfo("subdir2/file.txt"),
+        ]
+        for zi in mock_zinst.infolist.return_value:
+            zi.file_size = 0
+            zi.compress_size = 0
+        mock_zinst.open.return_value.read.return_value = TEST_VERSION_PLIST
+        result: Dict[str, Any] = {}
+        with self.assertRaisesRegex(
+            ProcessorError, r".*rchive.*has more than one.*at root"
+        ):
+            result = self.processor.process()
+
+        mock_zipfile.assert_called_once_with(zip_path)
+        mock_zinst.open.assert_not_called()
+        mock_exists.assert_not_called()
+        mock_dmg.assert_not_called()
+        self.assertNotIn("version", result)
+
+    def test_path_missing_raises(self):
+        """Raises ProcessorError when the provided path does not exist."""
+        for path in self._mkpath(
+            "not_real_version.plist", "archive.zip/nope.txt", "image.dmg/darn.json"
+        ):
+            with self.subTest(path=path):
+                with self.assertRaisesRegex(
+                    ProcessorError,
+                    f"File.*{self.processor.env['input_plist_path']}.*not found",
+                ):
+                    self.processor.process()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add capabilities to read plist files from inside zip archives in addition to dmg and iso images.  Add unit tests as well. There is likely some merging with the work done in #600 that will need to happen either in this PR or in a merge with master and dev.