### PR TITLE
Support exporting processors outside of AutoPkg

### DIFF
--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -29,6 +29,11 @@ class URLGetter(Processor):
 
     description = __doc__
 
+    def __init__(self, env=None, infile=None, outfile=None):
+        super().__init__(env, infile, outfile)
+        if not self.env:
+            self.env = {}
+
     def curl_binary(self):
         """Return a path to a curl binary, priority in the order below.
         Return None if none found.

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -378,7 +378,7 @@ class Processor:
     returns a new or updated property list that can be processed further.
     """
 
-    def __init__(self, env={}, infile=None, outfile=None):
+    def __init__(self, env=None, infile=None, outfile=None):
         # super(Processor, self).__init__()
         self.env = env
         if infile is None:

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -378,7 +378,7 @@ class Processor:
     returns a new or updated property list that can be processed further.
     """
 
-    def __init__(self, env=None, infile=None, outfile=None):
+    def __init__(self, env={}, infile=None, outfile=None):
         # super(Processor, self).__init__()
         self.env = env
         if infile is None:


### PR DESCRIPTION
Currently, if a processor, such as `URLGetter` is imported into an external codebase (for example: `from autopkglib import URLGetter`), `self.env` is set to `None`. This causes problems as `self.env` is expected to be, at a minimum, an empty dictionary.

This commit simply sets `self.env` to `{}` if not provided otherwise.

Here is an example of the error seen before the change:

```
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 661, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 468, in process
    self.main()
  File "/Library/AutoPkg/autopkglib/MunkiImporter.py", line 250, in main
    matchingitem = library.find_matching_pkginfo(pkginfo)
  File "/Library/AutoPkg/autopkglib/munkirepolibs/MunkiLibAdapter.py", line 39, in find_matching_pkginfo
    match = self.munkiimportlib.find_matching_pkginfo(self.repo, pkginfo)
  File "/usr/local/munki/munkilib/admin/munkiimportlib.py", line 234, in find_matching_pkginfo
    catdb = make_catalog_db(repo)
  File "/usr/local/munki/munkilib/admin/munkiimportlib.py", line 137, in make_catalog_db
    plist = repo.get('catalogs/all')
  File "/usr/local/munki/munkilib/munkirepo/SimpleMDMRepo.py", line 82, in get
    resp = self._curl(resource_identifier)
  File "/usr/local/munki/munkilib/munkirepo/SimpleMDMRepo.py", line 46, in _curl
    curl_cmd = self.getter.prepare_curl_cmd()
  File "/Library/AutoPkg/autopkglib/URLGetter.py", line 68, in prepare_curl_cmd
    return [self.curl_binary(), "--compressed", "--location"]
  File "/Library/AutoPkg/autopkglib/URLGetter.py", line 41, in curl_binary
    if "CURL_PATH" in self.env and is_executable(self.env["CURL_PATH"]):
TypeError: argument of type 'NoneType' is not iterable
  File "/Library/AutoPkg/autopkglib/__init__.py", line 661, in process
    self.env = processor.process()
argument of type 'NoneType' is not iterable
Failed.
```

Does this change seem appropriate?