### PR TITLE
Escaped spaces with %20 in recipes with spaces in its name.

### DIFF
--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -164,8 +164,8 @@ To save the token, paste it to the following prompt."""
         results_limit: int = 100,
     ):
         """Search GitHub for results for a given name."""
-        name = quote(name)
-        query = f"q={name}+extension:recipe+user:{user}"
+
+        query = f"q={quote(name)}+extension:recipe+user:{user}"
 
         if path_only:
             query += "+in:path,filepath"

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -163,8 +163,8 @@ To save the token, paste it to the following prompt."""
         results_limit: int = 100,
     ):
         """Search GitHub for results for a given name."""
-
         query = f"q={name}+extension:recipe+user:{user}"
+        query = query.replace(" ", "%20")
         if path_only:
             query += "+in:path,filepath"
         else:

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 import tempfile
+from urllib.parse import quote
 from typing import List, Optional
 
 from autopkglib import get_pref, log, log_err
@@ -163,8 +164,9 @@ To save the token, paste it to the following prompt."""
         results_limit: int = 100,
     ):
         """Search GitHub for results for a given name."""
+        name = quote(name)
         query = f"q={name}+extension:recipe+user:{user}"
-        query = query.replace(" ", "%20")
+
         if path_only:
             query += "+in:path,filepath"
         else:


### PR DESCRIPTION
Currently the query sent to Github API fail if the parent recipe name has spaces in it.
# Current behaviour:
``` joaquin  ~/gitlab/autopkg-build   master  autopkg info -p --override-dir="./overrides/" Word2019.munki.recipe
Didn't find a recipe for com.github.dataJAR-recipes.munki.Microsoft Word 2019.
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/URLGetter.py", line 196, in execute_curl
    errors=errors,
  File "/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/opt/local/bin/curl', '--location', '--silent', '--show-error', '--fail', '--dump-header', '-', '-X', 'GET', '--header', 'User-Agent: AutoPkg', '--header', 'Accept: application/vnd.github.v3.text-match+json', '--url', 'https://api.github.com/search/code?q=com.github.dataJAR-recipes.munki.Microsoft Word 2019+extension:recipe+user:autopkg+in:path,file&per_page=100', '--output', '/var/folders/8v/0m8j9cks4_zcv003h9fhb3300000gn/T/tmps3ygepn5']' returned non-zero exit status 22.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/autopkg", line 2708, in <module>
    sys.exit(main(sys.argv))
  File "/usr/local/bin/autopkg", line 2702, in main
    exit(subcommands[verb]["function"](argv))
  File "/usr/local/bin/autopkg", line 978, in get_info
    auto_pull=options.pull,
  File "/usr/local/bin/autopkg", line 474, in get_recipe_info
    auto_pull=auto_pull,
  File "/usr/local/bin/autopkg", line 393, in load_recipe
    auto_pull=auto_pull,
  File "/usr/local/bin/autopkg", line 363, in load_recipe
    auto_pull=auto_pull,
  File "/usr/local/bin/autopkg", line 292, in locate_recipe
    parent_repo = get_repository_from_identifier(name)
  File "/usr/local/bin/autopkg", line 217, in get_repository_from_identifier
    results = GitHubSession().search_for_name(identifier)
  File "/Library/AutoPkg/autopkglib/github/__init__.py", line 174, in search_for_name
    results = self.code_search(query, use_token=False)
  File "/Library/AutoPkg/autopkglib/github/__init__.py", line 195, in code_search
    accept="application/vnd.github.v3.text-match+json",
  File "/Library/AutoPkg/autopkglib/github/__init__.py", line 245, in call_api
    raw_headers = self.download_with_curl(curl_cmd)
  File "/Library/AutoPkg/autopkglib/github/__init__.py", line 138, in download_with_curl
    p_stdout, p_stderr, retcode = self.execute_curl(curl_cmd)
  File "/Library/AutoPkg/autopkglib/URLGetter.py", line 199, in execute_curl
    raise ProcessorError(e)
autopkglib.ProcessorError: Command '['/opt/local/bin/curl', '--location', '--silent', '--show-error', '--fail', '--dump-header', '-', '-X', 'GET', '--header', 'User-Agent: AutoPkg', '--header', 'Accept: application/vnd.github.v3.text-match+json', '--url', 'https://api.github.com/search/code?q=com.github.dataJAR-recipes.munki.Microsoft Word 2019+extension:recipe+user:autopkg+in:path,file&per_page=100', '--output', '/var/folders/8v/0m8j9cks4_zcv003h9fhb3300000gn/T/tmps3ygepn5']' returned non-zero exit status 22.
```
# After the change:
```autopkg info -p --override-dir="./overrides/" Word2019.munki.recipe  
Didn't find a recipe for com.github.dataJAR-recipes.munki.Microsoft Word 2019.
Found this recipe in repository: dataJAR-recipes
Attempting git clone...

Adding /Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes to RECIPE_SEARCH_DIRS...
Updated search path:
  '.'
  '~/Library/AutoPkg/Recipes'
  '/Library/AutoPkg/Recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.cgerke-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hansen-m-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dankeller-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.novaksam-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.valdore86-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.peertransfer.flywire-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.flywire-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/tech.flywire.gitlab.flywire.it.flywire-autopkg-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.chilcote-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes'
  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes'

Description:         This recipe downloads and imports the full installer pkg for Microsoft Word 2019 into Munki
                         
                     	This is accomplished via the Office 365 recipes from rtrouton-recipes.
                     	
                         These in turn, utilise the fwlink's found on macadmins.software
                         
                         These can have a volume license applied using appropriate pkg downloadable from Microsofts VLSC
Identifier:          local.munki.Microsoft Word 2019
Munki import recipe: True
Has check phase:     True
Builds package:      False
Recipe file path:    /Users/joaquincabrerizo/gitlab/autopkg-build/overrides/Word2019.munki.recipe
Parent recipe(s):    /Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes/Microsoft Word 2019/Microsoft Word 2019.munki.recipe
                     /Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/MicrosoftWord365/MicrosoftWord365.pkg.recipe
                     /Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/MicrosoftWord365/MicrosoftWord365.download.recipe
Input values: 
    'DOWNLOADURL': 'https://go.microsoft.com/fwlink/?linkid=%PRODUCTID%',
    'MINIMUM_OS_VERSION': '10.12.0',
    'MUNKI_REPO_SUBDIR': 'apps/office',
    'NAME': 'Word2019',
    'PRODUCTID': '525134',
    'SOFTWARETITLE': 'Word',
    'VENDOR': 'Microsoft',
    'pkginfo': {   'blocking_applications': [   'Microsoft Auto Update',
                                                'Microsoft Error Reporting',
                                                'Microsoft Word'],
                   'catalogs': ['testing', 'production'],
                   'category': 'Office',
                   'description': 'The Word you want. State-of-the-art '
                                  'editing, reviewing, and sharing tools make '
                                  'creating and polishing documents easy.',
                   'developer': '%VENDOR%',
                   'display_name': 'Microsoft Word',
                   'icon_name': 'Word2019.png',
                   'name': '%NAME%',
                   'unattended_install': True,
                   'unattended_uninstall': True}`