### PR TITLE
Add gunzip format to Unarchiver

### DIFF
--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -141,7 +141,6 @@ class Unarchiver(Processor):
             cmd = ["/usr/bin/gunzip", "-dkf", archive_path]
             # Strip ending '.gz'
             unarchived_path = archive_path[:-3]
-            mv_cmd = ["/bin/mv", unarchived_path, destination_path]
         elif fmt.startswith("tar"):
             cmd = ["/usr/bin/tar", "-x", "-f", archive_path, "-C", destination_path]
             if fmt.endswith("gzip"):
@@ -157,10 +156,7 @@ class Unarchiver(Processor):
             (_, stderr) = proc.communicate()
             # If gunzip used, move resulting file to destination_path
             if fmt == "gunzip":
-                gunzip_move_proc = subprocess.Popen(
-                    mv_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-                )
-                (_, stderr) = gunzip_move_proc.communicate()
+                shutil.move(unarchived_path, destination_path)
         except OSError as err:
             raise ProcessorError(
                 f"{os.path.basename(cmd[0])} execution failed with error code "

--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -29,7 +29,7 @@ EXTNS = {
     "tar_bzip2": ["tar.bz2", "tbz"],
     "tar": ["tar"],
     "gzip": ["gzip"],
-    "gunzip": ["gz"],
+    "gunzip": ["gz", "xz"],
 }
 
 

--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -29,6 +29,7 @@ EXTNS = {
     "tar_bzip2": ["tar.bz2", "tbz"],
     "tar": ["tar"],
     "gzip": ["gzip"],
+    "gunzip": ["gz"],
 }
 
 
@@ -135,6 +136,8 @@ class Unarchiver(Processor):
             ]
         elif fmt == "gzip":
             cmd = ["/usr/bin/ditto", "--noqtn", "-x", archive_path, destination_path]
+        elif fmt == "gunzip":
+            cmd = ["/usr/bin/gunzip", "-dkf", archive_path]
         elif fmt.startswith("tar"):
             cmd = ["/usr/bin/tar", "-x", "-f", archive_path, "-C", destination_path]
             if fmt.endswith("gzip"):

--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -139,7 +139,8 @@ class Unarchiver(Processor):
         elif fmt == "gunzip":
             # Since gunzip doesn't decompress to alternate destinations, have to do this later
             cmd = ["/usr/bin/gunzip", "-dkf", archive_path]
-            unarchived_path = archive_path.replace(".gz", "")
+            # Strip ending '.gz'
+            unarchived_path = archive_path[:-3]
             mv_cmd = ["/bin/mv", unarchived_path, destination_path]
         elif fmt.startswith("tar"):
             cmd = ["/usr/bin/tar", "-x", "-f", archive_path, "-C", destination_path]


### PR DESCRIPTION
First attempt at addressing #637.

- Adds separate `gunzip` format for using gzip to decompress a `.gz` archive file.
- Add elif statement to handle this.

The problem as far as I can tell is that when decompressing with gzip there's not a way to decompress to another location, and given the use of ditto or flags for other formats, this creates a gap for the situation I'm trying to address.  I attempted to address this by adding the below after line 140:

```
if destination_path is not None:
    unarchived_path = archive_path.replace(".gz", "")
    cmd.extend(["&&", "/bin/mv", unarchived_path, destination_path])
```

However, this didn't ultimately achieve the desired result as everything was fed to gunzip, instead of running after the successful completion of gunzip to move the resulting decompressed file.  With my limited Python skills, I'm not sure the best way to address this.

Here is the recipe that I've been writing to utilize this change:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Description</key>
    <string>Downloads the latest available version of a desired model of Toshiba copier drivers.

Much inspiration is taken from @jazzace's EpsonSureColorDrivers recipe: https://github.com/autopkg/jazzace-recipes/blob/master/Epson/EpsonSureColorDrivers.download.recipe

IMPORTANT:
This recipe requires that you find the support page for your product and copy pieces of info for 
use as the base string for the SEARCH_URL key in your override in order for this to work.

Recommended Procedure for Creating URL:
1. Go to https://business.toshiba.com/support/#downloads
2. Enter your Toshiba copier model number or select your model from the available list in order
to get to the main driver / support page for your copier model (ex. https://business.toshiba.com/support/downloads/index.html?model=e-STUDIO4508A).
3. Take the model # after 'model=' in the URL and enter this into the TOSHIBA_MODEL variable (ex. e-STUDIO4508A).
4. On the copier model support page, find the desired driver under the 'E-BRIDGE CURRENT DRIVERS' section. This is likely either the 'Mac OSX 10.7 and later, Duplex, Monochrome' or 'Mac OSX 10.7 and later, Single Sided, Monochrome' downloads. Copy the driver description exactly as listed and enter this into the TOSHIBA_DRIVER variable (ex. 'Mac OSX 10.7 and later, Duplex, Monochrome').
5. Run the recipe.
6. Profit.</string>
    <key>Identifier</key>
    <string>com.github.apizz.download.ToshibaCopierDrivers</string>
    <key>Input</key>
    <dict>
        <key>TOSHIBA_MODEL</key>
        <string>e-STUDIO4508A</string>
        <key>TOSHIBA_DRIVER</key>
        <string>Mac OSX 10.7 and later, Duplex, Monochrome</string>
        <key>NAME</key>
        <string>ToshibaCopierDrivers</string>
    </dict>
    <key>MinimumVersion</key>
    <string>0.6.1</string>
    <key>Process</key>
    <array>
        <dict>
            <key>Arguments</key>
            <dict>
                <key>re_pattern</key>
                <string>"id":"(?P&lt;driver_id&gt;[\d]+)","description":"%TOSHIBA_DRIVER%","versionDate":"[\d\/]+","versionName":"(?P&lt;version&gt;[\d.]+)",.*"downloadFile":"(?P&lt;file_name&gt;[\w.]+.dmg.gz)"</string>
                <key>url</key>
                <string>https://business.toshiba.com/support/downloads/GetDownloads.jsp?model=%TOSHIBA_MODEL%</string>
            </dict>
            <key>Processor</key>
            <string>URLTextSearcher</string>
        </dict>
        <dict>
            <key>Arguments</key>
            <dict>
                <key>filename</key>
                <string>%NAME%.dmg.gz</string>
                <key>url</key>
                <string>https://business.toshiba.com/downloads/KB/f1Ulds/%driver_id%/%file_name%</string>
            </dict>
            <key>Processor</key>
            <string>URLDownloader</string>
        </dict>
        <dict>
            <key>Processor</key>
            <string>EndOfCheckPhase</string>
        </dict>
        <dict>
            <key>Arguments</key>
            <dict>
                <key>archive_path</key>
                <string>%pathname%</string>
                <key>purge_destination</key>
                <true/>
            </dict>
            <key>Processor</key>
            <string>Unarchiver</string>
        </dict>
        <dict>
            <key>Arguments</key>
            <dict>
                <key>pattern</key>
                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/*.pkg</string>
            </dict>
            <key>Processor</key>
            <string>FileFinder</string>
        </dict>
        <dict>
            <key>Arguments</key>
            <dict>
                <key>input_path</key>
                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%dmg_found_filename%</string>
                <key>expected_authority_names</key>
                <array>
                    <string>Developer ID Installer: TOSHIBA TEC CORPORATION (D33FG43975)</string>
                    <string>Developer ID Certification Authority</string>
                    <string>Apple Root CA</string>
                </array>
            </dict>
            <key>Processor</key>
            <string>CodeSignatureVerifier</string>
        </dict>
    </array>
</dict>
</plist>
```

Recipe output:

```
autopkg run /Users/admin/Documents/GitHub/apizz-recipes/ToshibaCopierDrivers/ToshibaCopierDrivers.download.recipe -vv
Processing /Users/admin/Documents/GitHub/apizz-recipes/ToshibaCopierDrivers/ToshibaCopierDrivers.download.recipe...
WARNING: /Users/admin/Documents/GitHub/apizz-recipes/ToshibaCopierDrivers/ToshibaCopierDrivers.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '"id":"(?P<driver_id>[\\d]+)","description":"Mac OSX '
                         '10.7 and later, Duplex, '
                         'Monochrome","versionDate":"[\\d\\/]+","versionName":"(?P<version>[\\d.]+)",.*"downloadFile":"(?P<file_name>[\\w.]+.dmg.gz)"',
           'url': 'https://business.toshiba.com/support/downloads/GetDownloads.jsp?model=e-STUDIO4508A'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (driver_id): 17881
URLTextSearcher: Found matching text (version): 7.111
URLTextSearcher: Found matching text (file_name): TOSHIBA_MonoMFP.dmg.gz
URLTextSearcher: Found matching text (match): TOSHIBA_MonoMFP.dmg.gz
{'Output': {'driver_id': '17881',
            'file_name': 'TOSHIBA_MonoMFP.dmg.gz',
            'match': 'TOSHIBA_MonoMFP.dmg.gz',
            'version': '7.111'}}
URLDownloader
{'Input': {'filename': 'ToshibaCopierDrivers.dmg.gz',
           'url': 'https://business.toshiba.com/downloads/KB/f1Ulds/17881/TOSHIBA_MonoMFP.dmg.gz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/downloads/ToshibaCopierDrivers.dmg.gz
{'Output': {'pathname': '/Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/downloads/ToshibaCopierDrivers.dmg.gz'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/downloads/ToshibaCopierDrivers.dmg.gz',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'gunzip' from filename ToshibaCopierDrivers.dmg.gz
Unarchiver: Unarchived /Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/downloads/ToshibaCopierDrivers.dmg.gz to /Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/ToshibaCopierDrivers
{'Output': {}}
FileFinder
{'Input': {'pattern': '/Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/downloads/ToshibaCopierDrivers.dmg/*.pkg'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/downloads/ToshibaCopierDrivers.dmg
FileFinder: Found file match: '/private/tmp/dmg.nPql60/TOSHIBA MonoMFP.pkg' from globbed '/private/tmp/dmg.nPql60/*.pkg'
FileFinder: DMG-relative file match: 'TOSHIBA MonoMFP.pkg'
{'Output': {'dmg_found_filename': 'TOSHIBA MonoMFP.pkg',
            'found_filename': '/private/tmp/dmg.nPql60/TOSHIBA MonoMFP.pkg'}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: TOSHIBA TEC '
                                        'CORPORATION (D33FG43975)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/downloads/ToshibaCopierDrivers.dmg/TOSHIBA '
                         'MonoMFP.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/downloads/ToshibaCopierDrivers.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "TOSHIBA MonoMFP":
CodeSignatureVerifier:    Status: signed by a certificate trusted by Mac OS X
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: TOSHIBA TEC CORPORATION (D33FG43975)
CodeSignatureVerifier:        SHA1 fingerprint: C0 9D ED 72 17 BA 70 29 F2 3F 57 63 D7 F6 69 AE B5 D7 67 F8
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.apizz.download.ToshibaCopierDrivers/receipts/ToshibaCopierDrivers.download-receipt-20200809-225625.plist

Nothing downloaded, packaged or imported.
```