### PR TITLE
Update pre-commit-config to remove `seed-isort-config`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,6 @@ repos:
     rev: v5.0.4  # Use the revision sha / tag you want to point at
     hooks:
     - id: isort
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-    -   id: seed-isort-config
-        # Prevent listing autopkg code as 'third-party'
-        # https://github.com/asottile/seed-isort-config#usage-with-pre-commit
-        args: [--application-directories=Code]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3  # Use the ref you want to point at
     hooks:

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -20,8 +20,8 @@ import json
 import os
 import re
 import tempfile
-from urllib.parse import quote
 from typing import List, Optional
+from urllib.parse import quote
 
 from autopkglib import get_pref, log, log_err
 from autopkglib.URLGetter import URLGetter

--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -15,17 +15,16 @@
 # limitations under the License.
 
 
+import grp
 import os
 import plistlib
+import pwd
 import re
 import shutil
 import stat
 import subprocess
 import tempfile
 from xml.parsers.expat import ExpatError
-
-import grp
-import pwd
 
 __all__ = ["Packager", "PackagerError"]
 


### PR DESCRIPTION
Per https://github.com/asottile-archive/seed-isort-config, this hook is deprecated now that `isort>=5` has the functionality built-in. This should resolve some of the spurious additions and removals of `known_third_party` entries.