### PR TITLE
Create default preferences file if not found

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -17,6 +17,7 @@
 related tasks"""
 
 
+import appdirs
 import copy
 import difflib
 import glob
@@ -36,6 +37,7 @@ from urllib.parse import quote, urlparse
 
 from autopkgcmd import common_parse, gen_common_parser, search_recipes
 from autopkglib import (
+    APP_NAME,
     AutoPackager,
     AutoPackagerError,
     PreferenceError,
@@ -49,6 +51,7 @@ from autopkglib import (
     get_pref,
     get_processor,
     is_mac,
+    is_windows,
     log,
     log_err,
     processor_names,
@@ -646,7 +649,20 @@ def save_pref_or_warn(key, value):
 
 def get_search_dirs():
     """Return search dirs from preferences or default list"""
-    default = [".", "~/Library/AutoPkg/Recipes", "/Library/AutoPkg/Recipes"]
+    if is_windows():
+        default = [
+            ".",
+            os.path.join(
+                appdirs.user_config_dir(APP_NAME, appauthor=False), "Autopkg", "Recipes"
+            ),
+            os.path.join(
+                appdirs.user_config_dir(APP_NAME, appauthor=False, roaming=True),
+                "Autopkg",
+                "Recipes",
+            ),
+        ]
+    else:
+        default = [".", "~/Library/AutoPkg/Recipes", "/Library/AutoPkg/Recipes"]
 
     dirs = get_pref("RECIPE_SEARCH_DIRS")
     if isinstance(dirs, str):

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -19,7 +19,6 @@ import glob
 import imp
 import json
 import os
-import platform
 import plistlib
 import pprint
 import re
@@ -44,17 +43,17 @@ VarDict = Dict[str, Any]
 
 def is_mac():
     """Return True if current OS is macOS."""
-    return "Darwin" in platform.platform()
+    return "darwin" in sys.platform.lower()
 
 
 def is_windows():
     """Return True if current OS is Windows."""
-    return "Windows" in platform.platform()
+    return "win32" in sys.platform.lower()
 
 
 def is_linux():
     """Return True if current OS is Linux."""
-    return "Linux" in platform.platform()
+    return "linux" in sys.platform.lower()
 
 
 def log(msg, error=False):


### PR DESCRIPTION
This is a work-in-progress, requesting commentary.

`autopkg repo-add recipes` works now and saves the preferences:
```
> .\autopkg.ps1 repo-add recipes   

WARNING: No prefs file found, creating one.
WARNING: Library 'xattr' unavailable. Defining no-op implementation.
WARNING: Failed 'from Foundation import NSDictionary' in autopkglib.MunkiInstallsItemsCreator
WARNING: Failed 'from Foundation import CFPreferencesCopyAppValue' in autopkglib.MunkiSetDefaultCatalog
WARNING: Failed 'from Foundation import NSPredicate' in autopkglib.StopProcessingIf

--------------------------------------------------------------------------------
-- WARNING: AutoPkg is not completely functional on platforms other than OS X --
--------------------------------------------------------------------------------

Attempting git clone...

Adding C:\Users\nmcspadden\Library\AutoPkg\RecipeRepos\com.github.autopkg.recipes to RECIPE_SEARCH_DIRS...
Updated search path:
  '.'
  'C:\Users\nmcspadden\AppData\Local\Autopkg\Autopkg\Recipes'
  'C:\Users\nmcspadden\AppData\Roaming\Autopkg\Autopkg\Recipes'
  'C:\Users\nmcspadden\Library\AutoPkg\RecipeRepos\com.github.autopkg.recipes'
```

The contents of the default config file:
```
{
  "CACHE_DIR": "stuff",
  "RECIPE_REPOS": {
    "C:\\Users\\nmcspadden\\Library\\AutoPkg\\RecipeRepos\\com.github.autopkg.recipes": {
      "URL": "https://github.com/autopkg/recipes"
    }
  },
  "RECIPE_SEARCH_DIRS": [
    ".",
    "C:\\Users\\nmcspadden\\AppData\\Local\\Autopkg\\Autopkg\\Recipes",
    "C:\\Users\\nmcspadden\\AppData\\Roaming\\Autopkg\\Autopkg\\Recipes",
    "C:\\Users\\nmcspadden\\Library\\AutoPkg\\RecipeRepos\\com.github.autopkg.recipes"
  ]
}
```