### PR TITLE
Fix platform detection for python >3.7

### DIFF
--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -21,7 +21,6 @@ import glob
 import imp
 import json
 import os
-import platform
 import plistlib
 import pprint
 import re
@@ -45,17 +44,17 @@ VarDict = Dict[str, Any]
 
 def is_mac():
     """Return True if current OS is macOS."""
-    return "Darwin" in platform.platform()
+    return "darwin" in sys.platform.lower()
 
 
 def is_windows():
     """Return True if current OS is Windows."""
-    return "Windows" in platform.platform()
+    return "win32" in sys.platform.lower()
 
 
 def is_linux():
     """Return True if current OS is Linux."""
-    return "Linux" in platform.platform()
+    return "linux" in sys.platform.lower()
 
 
 def log(msg, error=False):


### PR DESCRIPTION
Python 3.8 `platform` module returns `macOS` and not `darwin`, which
breaks AutoPkg loading and saving preferences when using the native
Preference store. Instead use the `sys` module which has more stable identifiers.

To test, I ran AutoPkg under Python 3.7 and 3.8 on macOS and observed that it used
the native preference store when a `--prefs` option is not provided on
the command line.