### PR TITLE
Remove use of site exit in autopkg main

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -905,7 +905,10 @@ def display_help(argv, subcommands):
         subcommand = key + (" " * (max_key_len - len(key)))
         print(f"    {subcommand}  ({subcommands[key]['help']})")
     print()
-    print(f"{main_command_name} <verb> --help for more help for that verb")
+    if len(argv) > 1 and argv[1] not in subcommands:
+        print(f"Error: unknown verb: {argv[1]}")
+    else:
+        print(f"{main_command_name} <verb> --help for more help for that verb")
 
 
 def get_info(argv):
@@ -2680,15 +2683,14 @@ def main(argv):
     if verb.startswith("-"):
         # option instead of a verb
         verb = "help"
-    if verb == "help" or verb not in list(subcommands.keys()):
+    if verb == "help" or verb not in subcommands:
         display_help(argv, subcommands)
-    else:
-        # call the function and pass it the argument list
-        # we leave the verb in the list in case one function can handle
-        # multiple verbs
-        exit(subcommands[verb]["function"](argv))
+        return 1
 
-    exit()
+    # Call the command function and pass it the argument list.
+    # We leave the verb in the list in case one function can handle
+    # multiple verbs.
+    return subcommands[verb]["function"](argv)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `site` module fiddles with the global namespace to add `exit`.
However, this is only meant for interactive use. Generally speaking,
this module is auto-imported so it was never an issue. However, in some
environments the module is not present, or the `-S` flag is used to
disable importing it.