### PR TITLE
Add deprecation awareness to make-override

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1866,13 +1866,14 @@ def make_override(argv):
     if "DeprecationWarning" in proc_names:
         if options.ignore_deprecation:
             log_err(
-                f"WARNING: {recipe.get('RECIPE_PATH', recipe_name)} is deprecated. "
-                "Making an override anyway, because --ignore-deprecation is specified."
+                f"WARNING: {recipe.get('RECIPE_PATH', recipe_name)} or one of "
+                "its parents is deprecated. Making an override anyway, "
+                "because --ignore-deprecation is specified."
             )
         else:
             log_err(
-                f"{recipe.get('RECIPE_PATH', recipe_name)} is deprecated. "
-                "Will not make an override."
+                f"{recipe.get('RECIPE_PATH', recipe_name)} or one of its parents "
+                "is deprecated. Will not make an override."
             )
             return 1
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1873,7 +1873,8 @@ def make_override(argv):
         else:
             log_err(
                 f"{recipe.get('RECIPE_PATH', recipe_name)} or one of its parents "
-                "is deprecated. Will not make an override."
+                "is deprecated. Will not make an override. Use --ignore-deprecation "
+                "to make an override regardless of deprecation status."
             )
             return 1
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1822,6 +1822,14 @@ def make_override(argv):
             "Implies agreement to search GitHub."
         ),
     )
+    parser.add_option(
+        "--ignore-deprecation",
+        action="store_true",
+        help=(
+            "Make an override even if the specified recipe or one of "
+            "its parents is deprecated."
+        ),
+    )
     (options, arguments) = common_parse(parser, argv)
 
     override_dirs = options.override_dirs or get_override_dirs()
@@ -1852,6 +1860,21 @@ def make_override(argv):
         log_err(f"No valid recipe found for {recipe_name}")
         log_err("Dir(s) searched:\n\t{}".format("\n\t".join(search_dirs)))
         return 1
+
+    # stop or warn if DeprecationWarning processor is detected
+    proc_names = {x.get("Processor") for x in recipe.get("Process", [{}])}
+    if "DeprecationWarning" in proc_names:
+        if options.ignore_deprecation:
+            log_err(
+                f"WARNING: {recipe.get('RECIPE_PATH', recipe_name)} is deprecated. "
+                "Making an override anyway, because --ignore-deprecation is specified."
+            )
+        else:
+            log_err(
+                f"{recipe.get('RECIPE_PATH', recipe_name)} is deprecated. "
+                "Will not make an override."
+            )
+            return 1
 
     # make sure parent has an identifier
     parent_identifier = get_identifier(recipe)


### PR DESCRIPTION
This PR modifies the `make-override` verb such that if the recipe being overridden or any of its parents contains the [DeprecationWarning processor](https://github.com/autopkg/autopkg/wiki/Processor-DeprecationWarning), the override will not be created by default. An `--ignore-deprecation` flag has also been added, in cases where AutoPkg users want to create the override regardless of deprecation status.

I chose not to add a single-letter equivalent for `--ignore-deprecation` because (a) `-d` is already used and `-i` seemed too general, and (b) ignoring deprecation should be gently discouraged.

## `make-override` help text

```
% ./autopkg make-override -h                                                           
Usage: autopkg make-override [options] [recipe]
Create a skeleton override file for a recipe. It will be stored in the first default override directory or that given by '--override-dir'

Options:
  -h, --help            show this help message and exit
  --prefs=FILE_PATH     
  -d DIRECTORY, --search-dir=DIRECTORY
                        Directory to search for recipes. Can be specified
                        multiple times.
  --override-dir=DIRECTORY
                        Directory to search for recipe overrides. Can be
                        specified multiple times.
  -n FILENAME, --name=FILENAME
                        Name for override file.
  -f, --force           Force overwrite an override file.
  -p, --pull            Pull the parent repos if they can't be found in the
                        search path.Implies agreement to search GitHub.
  --ignore-deprecation  Make an override even if the specified recipe or one
                        of its parents is deprecated.
```

## Creation of a regular, non-deprecated override

```
% ./autopkg make-override DeltaWalker.pkg
Override file saved to ~/Library/AutoPkg/RecipeOverrides/DeltaWalker.pkg.recipe
```

## Creation of an override for a deprecated recipe

```
% ./autopkg make-override DEVONagentPro.download
~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/DevonTechnologies/DEVONagentPro.download.recipe or one of its parents is deprecated. Will not make an override.
```

## Creation of an override for a recipe with a deprecated parent

```
% ./autopkg make-override DEVONagentPro.munki   
~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/DevonTechnologies/DEVONagentPro.munki.recipe or one of its parents is deprecated. Will not make an override.
```

## Creation of an override, ignoring deprecation

```
% ./autopkg make-override --ignore-deprecation DEVONagentPro.munki           
WARNING: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/DevonTechnologies/DEVONagentPro.munki.recipe or one of its parents is deprecated. Making an override anyway, because --ignore-deprecation is specified.
Override file saved to ~/Library/AutoPkg/RecipeOverrides/DEVONagentPro.munki.recipe
```