### PR TITLE
Update GitHubReleasesInfoProvider.py for private repos

### DIFF
--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -21,8 +21,6 @@ import re
 import autopkglib.github
 from autopkglib import APLooseVersion, Processor, ProcessorError
 
-BASE_URL = "https://api.github.com"
-
 __all__ = ["GitHubReleasesInfoProvider"]
 
 


### PR DESCRIPTION
Change `url` to the API asset url and supply a `filename` and `curl_opts` so that assets can be retrieved from a private GitHub repository.

Tested on a set of 136 recipes that use the `GitHubReleasesInfoProvider` and found no issues.

Note that this change will work with or without a `GITHUB_TOKEN`.

~Note: I realise this will break the trust info for a lot of recipes..~ As noted by Greg: core recipes are not recorded in trust info.