### PR TITLE
Add support for recipes in yaml format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 exclude: '^Code/nuget/generated/.*$'
 repos:
--   repo: https://github.com/python/black
-    rev: 19.10b0
-    hooks:
-    - id: black
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.0.4  # Use the revision sha / tag you want to point at
-    hooks:
-    - id: isort
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3  # Use the ref you want to point at
-    hooks:
-    - id: flake8
+- repo: https://github.com/python/black
+  rev: 20.8b1
+  hooks:
+  - id: black
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v5.6.4
+  hooks:
+  - id: isort
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.4
+  hooks:
+  - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 exclude: '^Code/nuget/generated/.*$'
 repos:
-- repo: https://github.com/python/black
-  rev: 20.8b1
-  hooks:
-  - id: black
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.6.4
-  hooks:
-  - id: isort
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
-  hooks:
-  - id: flake8
+-   repo: https://github.com/python/black
+    rev: 19.10b0
+    hooks:
+    - id: black
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.0.4  # Use the revision sha / tag you want to point at
+    hooks:
+    - id: isort
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3  # Use the ref you want to point at
+    hooks:
+    - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### [2.3](https://github.com/autopkg/autopkg/compare/v2.2...HEAD) (Unreleased)
 
+NEW FEATURES
+
+AutoPkg now supports recipes in yaml format.
+
+CHANGES FROM 2.2:
+
+- MunkiImporter now uses consistent pkginfo matching logic (https://github.com/autopkg/autopkg/pull/671)
+- Typo fixed in the recipe template created by `new-recipe`
+- Minor edits to help text
+
 ### [2.2](https://github.com/autopkg/autopkg/compare/v2.1...v2.2) (August 24, 2020)
 
 NEW FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,12 @@ CHANGES FROM 2.2:
 ### [2.2](https://github.com/autopkg/autopkg/compare/v2.1...v2.2) (August 24, 2020)
 
 NEW FEATURES
-
 MunkiImporter now supports Munki repo plugins, thanks to @tboyko. The default behavior
 is still to use FileRepo as the default local behavior, so existing behavior is
 unchanged. (https://github.com/autopkg/autopkg/pull/654)
 
 
 CHANGES FROM 2.1:
-
 - URLDownloader handles Content-Disposition filenames with quotes correctly (https://github.com/autopkg/autopkg/pull/633)
 - README and CONTRIBUTING guides updated with correct Python 3 framework info (https://github.com/autopkg/autopkg/pull/638)
 - PyYAML updated to 5.3.1 to address PyYAML-CVE-2020-1747 (https://github.com/autopkg/autopkg/pull/642)
@@ -42,7 +40,6 @@ CHANGES FROM 2.1:
 ### [2.1](https://github.com/autopkg/autopkg/compare/v2.0.2...v2.1) (May 19, 2020)
 
 NEW FEATURES
-
 AutoPkg now supports the verbs `list-repos` and `processor-list` for convenience (https://github.com/autopkg/autopkg/pull/628)
 
 `autopkg info --pull`/`-p` now allows you to fetch all parent repos of a recipe
@@ -83,7 +80,6 @@ dynamically fetch parents on-demand, instead of preconfiguring your environment 
 list of known repos.
 
 CHANGES FROM 2.0.2:
-
 - URLGetter can handle parsing headers without an explicit `url` in the environment (https://github.com/autopkg/autopkg/pull/605)
 - FileCreator now has a unit test (https://github.com/autopkg/autopkg/pull/591)
 - AutoPkg warns you more helpfully if you are trying to run it with Python 2 (https://github.com/autopkg/autopkg/pull/610)
@@ -99,14 +95,12 @@ CHANGES FROM 2.0.2:
 ### [2.0.2](https://github.com/autopkg/autopkg/compare/v2.0.1...v2.0.2) (February 05, 2020)
 
 CHANGES FROM RC2:
-
 - Fixed an encoding bug in the make_new_release script (https://github.com/autopkg/autopkg/commit/fca40526a3a19f3e208574be775fa7309244c0d5)
 - Removed some orphaned dead code (https://github.com/autopkg/autopkg/commit/c90e92b1988f347834ed4957cc9108c2b1eef44b)
 
 ### [2.0 RC2](https://github.com/autopkg/autopkg/compare/2.0b3...v2.0.1) (January 31, 2020)
 
 CHANGES FROM RC1:
-
 - Fixed some processor docs (https://github.com/autopkg/autopkg/commit/3812ca12a44531c78c869e67fbbd84d7706b8a93)
 - Added in "APLooseVersion", loosely based on Munki's version comparison, to replace previous version comparison semantics. (https://github.com/autopkg/autopkg/commit/7c0676fdfe77f66f261b0df53ec5a792d31c5d3c)
   - This MAY cause a change in behavior for some current version comparisons, but it no longer crashes when comparing
@@ -115,7 +109,6 @@ CHANGES FROM RC1:
 ### [2.0 RC1](https://github.com/autopkg/autopkg/compare/2.0b3...v2.0.1) (December 03, 2019)
 
 CHANGES FROM BETA 3:
-
 - Some fixes around URLGetter's behavior and callsites
 - `URLGetter.execute_curl()` was changed to use `subprocess.run()` instead of `Popen` (https://github.com/autopkg/autopkg/commit/facad8ce48cfb9766578d55823660feb177b3e80)
 - Update URLDownloader variable descriptions to show up better on the wiki (https://github.com/autopkg/autopkg/commit/079c606778a3a4795cd52e4f98a77f5479b36ea9)
@@ -126,7 +119,6 @@ it simple to download a file in a custom processor (this was backported to 1.4.1
 - make_new_release.py produces more friendly console output indicating what stage it's on (https://github.com/autopkg/autopkg/commit/1373b31d407b1a2ae023256aa2d65ef165d5956)
 
 ### [2.0b3](https://github.com/autopkg/autopkg/compare/12249273c23e9c52675ab947024c2ac505080049...2.0b3) (November 25, 2019)
-
 CHANGES FROM BETA 2:
 
 - Thanks to @MichalMMac's heroic efforts, URLGetter is now much easier for other processors to use. There are now two ways a custom processor can download things without needing to write any urllib logic:
@@ -220,13 +212,11 @@ autopkg run -vv Firefox.munki MakeCatalogs.munki
 ```
 
 HOW TO REPORT ISSUES:
-
 Use the "Beta Bug report" GitHub issue template to specifically label the issue as being
 beta only. Please make use of the template to convey all information possible in order
 to reproduce or diagnose the issue as clearly as possible.
 
 SETTING UP AUTOPKG MANUALLY:
-
 If you do not want to use the AutoPkg release installer, you can manually set up an
 AutoPkg 2.0 environment. Setup and place the AutoPkg files as you normally would:
 
@@ -236,7 +226,6 @@ AutoPkg 2.0 environment. Setup and place the AutoPkg files as you normally would
   `sudo chmod -R 755 /Library/AutoPkg/autopkgserver/`
 
 Build a relocatable python bundle:
-
 - Use the CONTRIBUTING guide's instructions on building a relocatable python bundle
   that uses the `requirements.txt` file for pip
 - Move/copy the bundle into /Library/AutoPkg/Python3/Python.framework
@@ -244,7 +233,6 @@ Build a relocatable python bundle:
 ### [1.4.1](https://github.com/autopkg/autopkg/compare/v1.4...v1.4.1) (December 02, 2019)
 
 FIXES:
-
 * URLGetter now has a `download_to_file(url, filename)` function that can be used in
 custom processors. It simply downloads a URL to a specific filename, and raises a
 ProcessorError if it fails for any reason.
@@ -252,11 +240,9 @@ ProcessorError if it fails for any reason.
 ### [1.4](https://github.com/autopkg/autopkg/compare/v1.3.1...v2.0.1) (December 03, 2019)
 
 FIXES:
-
   * DmgMounter now correctly handles APFS disk images, especially with EULAs/SLAs (https://github.com/autopkg/autopkg/commit/4b77f6d5948a2f36258f4695f503513ec7671745)
 
 ADDITIONS:
-
 * The new URLGetter base Processor class has been merged in. It provides a new centralized way to handle fetching and downloading things from the web. In the future, more convenience functions will be added to allow any custom processor to easily fetch web resources without having to write their own urllib/web-handling code.
 * Thanks to @MichalMMac's heroic efforts, URLGetter is now much easier for other processors to use. There are now two ways a custom processor can download things without needing to write any urllib logic:
   * `URLGetter.download_with_curl(curl_command, text=True)` takes a curl command as an argument (a list of strings that is passed to subprocess). You can use this along with the other helper functions to arrange your own curl command with custom headers and arguments, and parse the output.
@@ -292,13 +278,11 @@ FIXES:
   not specified (https://github.com/autopkg/autopkg/commit/02f461cf6f503dfc65151aef5180a882cc6f6f72)
 
 ADDITIONS:
-
 - Preferences can now be provided from an external file using `--prefs`. The input
   file can be either in JSON or plist format, and will be treated identically
   to preferences from macOS. (https://github.com/autopkg/autopkg/commit/7ae2f552535741cb4ee131131d16a1fd93186c14)
 
 IMPROVEMENTS:
-
 - Several unit tests have been added for some core AutoPkg functionality, and
   certain processors.
 - All occurrences of `print()` in the core autopkg script were replaced with `log` and `log_err` (https://github.com/autopkg/autopkg/commit/8300b807e29553be92c8c74894090442c8312b6d)
@@ -380,7 +364,7 @@ FIXES:
 - Trust info is ignored if it is ever present in a recipe which is not an override,
   and warns if any such trust info is found (GH-334)
 - Fix a regression in PlistReader and handling disk images
-- PkgCopier can now mount a disk image in the source path even if its extension is not
+- PkgCopier can now mount a diskimage in the source path even if its extension is not
   `.dmg` (GH-349)
 
 IMPROVEMENTS:
@@ -425,7 +409,7 @@ ADDITIONS:
   previously required for building a package from an application bundle.
 - Support for "rich" recipe lists in property list format, which can specify
   pre/post-processors and additional input variables for that specific run. See the
-  [Running Multiple Recipes article](https://github.com/autopkg/autopkg/wiki/Running-Multiple-Recipes) for more details.
+  [Running Multpiple Recipes article](https://github.com/autopkg/autopkg/wiki/Running-Multiple-Recipes) for more details.
 
 FIXES:
 
@@ -571,7 +555,7 @@ IMPROVEMENTS:
 FIXES:
 
 - Fixes in MunkiImporter's logic when attempting to locate a matching item in a repo.
-- PkgCreator: fix an exception when setting `mode` on a directory (in `chown`, in
+- PkgCreator: fix an exception when setting `mode` on a direcotry (in `chown`, in
   `pkg_request`). (GH-177)
 - BrewCaskInfoProvider now properly interpolates '#{version}' within 'url' strings.
 
@@ -704,8 +688,7 @@ ADDITIONS:
 ### [0.2.8](https://github.com/autopkg/autopkg/compare/v0.2.7...v0.2.8) (January 08, 2014)
 
 FIXES:
-
-- New package release to fix issue with autopkgserver launch daemon plist in 0.2.6 and 0.2.7 package releases.
+- New package release to fix issue with autopkgsever launch daemon plist in 0.2.6 and 0.2.7 package releases.
 
 ### [0.2.7](https://github.com/autopkg/autopkg/compare/v0.2.6...v0.2.7) (January 08, 2014)
 
@@ -810,7 +793,7 @@ CHANGES:
 
 CHANGES:
 
-  - Addresses an issue where creating RecipeOverrides failed if the recipe overrides directory (default: ~/Library/AutoPkg/RecipeOverrides) is missing
+  - Addresses an issue where creating RecipeOverrides failed if the recipe overrides directory (default: ~/Library/AutoPkg/ReceipeOverrides) is missing
 
 ### 0.1.0 (August 23, 2013)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 ### [2.3](https://github.com/autopkg/autopkg/compare/v2.2...HEAD) (Unreleased)
 
-NEW FEATURES
+NEW FEATURES:
 
-AutoPkg now supports recipes in yaml format.
+AutoPkg now supports recipes in yaml format. Yaml recipes tend to be more human-readable than plist recipes, especially for those who don't work with plists on a daily basis.
+
+AutoPkg can produce new recipes in yaml format using `autopkg new-recipe SomeCoolApp.pkg.recipe.yaml` and make overrides in yaml format using `autopkg make-override --format=yaml SomeCoolApp.pkg`. Searching for public yaml recipes on GitHub is also possible using the standard `search` verb.
+
+NOTES FOR RECIPE AUTHORS:
+
+- Because yaml recipes will require AutoPkg 2.3 or later in order to run, and because some members of the AutoPkg community may still be using AutoPkg 1.x, recipe authors are encouraged to be conservative and keep existing public recipes in their current format for a while.
+- If you have both plist and yaml recipes for the same app in your repo, you may experience unexpected behavior now that AutoPkg detects and uses yaml recipes.
 
 CHANGES FROM 2.2:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ### [2.2](https://github.com/autopkg/autopkg/compare/v2.1...v2.2) (August 24, 2020)
 
 NEW FEATURES
+
 MunkiImporter now supports Munki repo plugins, thanks to @tboyko. The default behavior
 is still to use FileRepo as the default local behavior, so existing behavior is
 unchanged. (https://github.com/autopkg/autopkg/pull/654)
 
 
 CHANGES FROM 2.1:
+
 - URLDownloader handles Content-Disposition filenames with quotes correctly (https://github.com/autopkg/autopkg/pull/633)
 - README and CONTRIBUTING guides updated with correct Python 3 framework info (https://github.com/autopkg/autopkg/pull/638)
 - PyYAML updated to 5.3.1 to address PyYAML-CVE-2020-1747 (https://github.com/autopkg/autopkg/pull/642)
@@ -23,6 +25,7 @@ CHANGES FROM 2.1:
 ### [2.1](https://github.com/autopkg/autopkg/compare/v2.0.2...v2.1) (May 19, 2020)
 
 NEW FEATURES
+
 AutoPkg now supports the verbs `list-repos` and `processor-list` for convenience (https://github.com/autopkg/autopkg/pull/628)
 
 `autopkg info --pull`/`-p` now allows you to fetch all parent repos of a recipe
@@ -63,6 +66,7 @@ dynamically fetch parents on-demand, instead of preconfiguring your environment 
 list of known repos.
 
 CHANGES FROM 2.0.2:
+
 - URLGetter can handle parsing headers without an explicit `url` in the environment (https://github.com/autopkg/autopkg/pull/605)
 - FileCreator now has a unit test (https://github.com/autopkg/autopkg/pull/591)
 - AutoPkg warns you more helpfully if you are trying to run it with Python 2 (https://github.com/autopkg/autopkg/pull/610)
@@ -78,12 +82,14 @@ CHANGES FROM 2.0.2:
 ### [2.0.2](https://github.com/autopkg/autopkg/compare/v2.0.1...v2.0.2) (February 05, 2020)
 
 CHANGES FROM RC2:
+
 - Fixed an encoding bug in the make_new_release script (https://github.com/autopkg/autopkg/commit/fca40526a3a19f3e208574be775fa7309244c0d5)
 - Removed some orphaned dead code (https://github.com/autopkg/autopkg/commit/c90e92b1988f347834ed4957cc9108c2b1eef44b)
 
 ### [2.0 RC2](https://github.com/autopkg/autopkg/compare/2.0b3...v2.0.1) (January 31, 2020)
 
 CHANGES FROM RC1:
+
 - Fixed some processor docs (https://github.com/autopkg/autopkg/commit/3812ca12a44531c78c869e67fbbd84d7706b8a93)
 - Added in "APLooseVersion", loosely based on Munki's version comparison, to replace previous version comparison semantics. (https://github.com/autopkg/autopkg/commit/7c0676fdfe77f66f261b0df53ec5a792d31c5d3c)
   - This MAY cause a change in behavior for some current version comparisons, but it no longer crashes when comparing
@@ -92,6 +98,7 @@ CHANGES FROM RC1:
 ### [2.0 RC1](https://github.com/autopkg/autopkg/compare/2.0b3...v2.0.1) (December 03, 2019)
 
 CHANGES FROM BETA 3:
+
 - Some fixes around URLGetter's behavior and callsites
 - `URLGetter.execute_curl()` was changed to use `subprocess.run()` instead of `Popen` (https://github.com/autopkg/autopkg/commit/facad8ce48cfb9766578d55823660feb177b3e80)
 - Update URLDownloader variable descriptions to show up better on the wiki (https://github.com/autopkg/autopkg/commit/079c606778a3a4795cd52e4f98a77f5479b36ea9)
@@ -102,6 +109,7 @@ it simple to download a file in a custom processor (this was backported to 1.4.1
 - make_new_release.py produces more friendly console output indicating what stage it's on (https://github.com/autopkg/autopkg/commit/1373b31d407b1a2ae023256aa2d65ef165d5956)
 
 ### [2.0b3](https://github.com/autopkg/autopkg/compare/12249273c23e9c52675ab947024c2ac505080049...2.0b3) (November 25, 2019)
+
 CHANGES FROM BETA 2:
 
 - Thanks to @MichalMMac's heroic efforts, URLGetter is now much easier for other processors to use. There are now two ways a custom processor can download things without needing to write any urllib logic:
@@ -195,11 +203,13 @@ autopkg run -vv Firefox.munki MakeCatalogs.munki
 ```
 
 HOW TO REPORT ISSUES:
+
 Use the "Beta Bug report" GitHub issue template to specifically label the issue as being
 beta only. Please make use of the template to convey all information possible in order
 to reproduce or diagnose the issue as clearly as possible.
 
 SETTING UP AUTOPKG MANUALLY:
+
 If you do not want to use the AutoPkg release installer, you can manually set up an
 AutoPkg 2.0 environment. Setup and place the AutoPkg files as you normally would:
 
@@ -209,6 +219,7 @@ AutoPkg 2.0 environment. Setup and place the AutoPkg files as you normally would
   `sudo chmod -R 755 /Library/AutoPkg/autopkgserver/`
 
 Build a relocatable python bundle:
+
 - Use the CONTRIBUTING guide's instructions on building a relocatable python bundle
   that uses the `requirements.txt` file for pip
 - Move/copy the bundle into /Library/AutoPkg/Python3/Python.framework
@@ -216,6 +227,7 @@ Build a relocatable python bundle:
 ### [1.4.1](https://github.com/autopkg/autopkg/compare/v1.4...v1.4.1) (December 02, 2019)
 
 FIXES:
+
 * URLGetter now has a `download_to_file(url, filename)` function that can be used in
 custom processors. It simply downloads a URL to a specific filename, and raises a
 ProcessorError if it fails for any reason.
@@ -223,9 +235,11 @@ ProcessorError if it fails for any reason.
 ### [1.4](https://github.com/autopkg/autopkg/compare/v1.3.1...v2.0.1) (December 03, 2019)
 
 FIXES:
+
   * DmgMounter now correctly handles APFS disk images, especially with EULAs/SLAs (https://github.com/autopkg/autopkg/commit/4b77f6d5948a2f36258f4695f503513ec7671745)
 
 ADDITIONS:
+
 * The new URLGetter base Processor class has been merged in. It provides a new centralized way to handle fetching and downloading things from the web. In the future, more convenience functions will be added to allow any custom processor to easily fetch web resources without having to write their own urllib/web-handling code.
 * Thanks to @MichalMMac's heroic efforts, URLGetter is now much easier for other processors to use. There are now two ways a custom processor can download things without needing to write any urllib logic:
   * `URLGetter.download_with_curl(curl_command, text=True)` takes a curl command as an argument (a list of strings that is passed to subprocess). You can use this along with the other helper functions to arrange your own curl command with custom headers and arguments, and parse the output.
@@ -261,11 +275,13 @@ FIXES:
   not specified (https://github.com/autopkg/autopkg/commit/02f461cf6f503dfc65151aef5180a882cc6f6f72)
 
 ADDITIONS:
+
 - Preferences can now be provided from an external file using `--prefs`. The input
   file can be either in JSON or plist format, and will be treated identically
   to preferences from macOS. (https://github.com/autopkg/autopkg/commit/7ae2f552535741cb4ee131131d16a1fd93186c14)
 
 IMPROVEMENTS:
+
 - Several unit tests have been added for some core AutoPkg functionality, and
   certain processors.
 - All occurrences of `print()` in the core autopkg script were replaced with `log` and `log_err` (https://github.com/autopkg/autopkg/commit/8300b807e29553be92c8c74894090442c8312b6d)
@@ -347,7 +363,7 @@ FIXES:
 - Trust info is ignored if it is ever present in a recipe which is not an override,
   and warns if any such trust info is found (GH-334)
 - Fix a regression in PlistReader and handling disk images
-- PkgCopier can now mount a diskimage in the source path even if its extension is not
+- PkgCopier can now mount a disk image in the source path even if its extension is not
   `.dmg` (GH-349)
 
 IMPROVEMENTS:
@@ -392,7 +408,7 @@ ADDITIONS:
   previously required for building a package from an application bundle.
 - Support for "rich" recipe lists in property list format, which can specify
   pre/post-processors and additional input variables for that specific run. See the
-  [Running Multpiple Recipes article](https://github.com/autopkg/autopkg/wiki/Running-Multiple-Recipes) for more details.
+  [Running Multiple Recipes article](https://github.com/autopkg/autopkg/wiki/Running-Multiple-Recipes) for more details.
 
 FIXES:
 
@@ -538,7 +554,7 @@ IMPROVEMENTS:
 FIXES:
 
 - Fixes in MunkiImporter's logic when attempting to locate a matching item in a repo.
-- PkgCreator: fix an exception when setting `mode` on a direcotry (in `chown`, in
+- PkgCreator: fix an exception when setting `mode` on a directory (in `chown`, in
   `pkg_request`). (GH-177)
 - BrewCaskInfoProvider now properly interpolates '#{version}' within 'url' strings.
 
@@ -671,7 +687,8 @@ ADDITIONS:
 ### [0.2.8](https://github.com/autopkg/autopkg/compare/v0.2.7...v0.2.8) (January 08, 2014)
 
 FIXES:
-- New package release to fix issue with autopkgsever launch daemon plist in 0.2.6 and 0.2.7 package releases.
+
+- New package release to fix issue with autopkgserver launch daemon plist in 0.2.6 and 0.2.7 package releases.
 
 ### [0.2.7](https://github.com/autopkg/autopkg/compare/v0.2.6...v0.2.7) (January 08, 2014)
 
@@ -776,7 +793,7 @@ CHANGES:
 
 CHANGES:
 
-  - Addresses an issue where creating RecipeOverrides failed if the recipe overrides directory (default: ~/Library/AutoPkg/ReceipeOverrides) is missing
+  - Addresses an issue where creating RecipeOverrides failed if the recipe overrides directory (default: ~/Library/AutoPkg/RecipeOverrides) is missing
 
 ### 0.1.0 (August 23, 2013)
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -34,6 +34,7 @@ from base64 import b64decode
 from typing import Optional
 from urllib.parse import quote, urlparse
 
+import yaml
 from autopkgcmd import common_parse, gen_common_parser, search_recipes
 from autopkglib import (
     RECIPE_EXTS,
@@ -1708,8 +1709,12 @@ def update_trust_info(argv):
             recipe["ParentRecipeTrustInfo"] = get_trust_info(
                 parent_recipe, search_dirs=search_dirs
             )
-            with open(recipe_path, "wb") as f:
-                plistlib.dump(recipe, f)
+            if recipe_path.endswith(".recipe.yaml"):
+                with open(recipe_path, "wb") as f:
+                    yaml.dump(recipe, f, encoding="utf-8")
+            else:
+                with open(recipe_path, "wb") as f:
+                    plistlib.dump(recipe, f)
             log(f"Wrote updated {recipe_path}")
         else:
             log_err(

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -158,6 +158,7 @@ def find_recipe_by_name(name, search_dirs):
     name = remove_recipe_extension(name)
     # search by "Name", using file/directory hierarchy rules
     for directory in search_dirs:
+        # TODO: Combine with similar code in get_recipe_list()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         patterns = [os.path.join(normalized_dir, f"{name}{ext}") for ext in RECIPE_EXTS]
         patterns.extend(
@@ -1083,6 +1084,7 @@ def get_recipe_list(
 
     recipes = []
     for directory in search_dirs:
+        # TODO: Combine with similar code in find_recipe_by_name()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         if not os.path.isdir(normalized_dir):
             continue

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1826,6 +1826,15 @@ def make_override(argv):
             "its parents is deprecated."
         ),
     )
+    parser.add_option(
+        "--format",
+        action="store",
+        default="plist",
+        help=(
+            "The format of the recipe override to be created. "
+            "Valid options include: 'plist' (default) or 'yaml'"
+        ),
+    )
     (options, arguments) = common_parse(parser, argv)
 
     override_dirs = options.override_dirs or get_override_dirs()
@@ -1912,7 +1921,13 @@ def make_override(argv):
             log_err(f"Could not create {override_dir}: {err}")
             return -1
 
-    override_file = os.path.join(override_dir, f"{override_name}.recipe")
+    # set file path for override
+    if options.format == "yaml":
+        override_file = os.path.join(override_dir, f"{override_name}.recipe.yaml")
+    else:
+        override_file = os.path.join(override_dir, f"{override_name}.recipe")
+
+    # handle existing override at same path
     if os.path.exists(override_file):
         if not options.force:
             log_err(
@@ -1922,8 +1937,14 @@ def make_override(argv):
             )
             return -1
         os.unlink(override_file)
-    with open(override_file, "wb") as f:
-        plistlib.dump(override_dict, f)
+
+    # write override to file
+    if options.format == "yaml":
+        with open(override_file, "wb") as f:
+            yaml.dump(override_dict, f, encoding="utf-8")
+    else:
+        with open(override_file, "wb") as f:
+            plistlib.dump(override_dict, f)
     log(f"Override file saved to {override_file}")
     return 0
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -52,7 +52,7 @@ from autopkglib import (
     log,
     log_err,
     processor_names,
-    recipe_plist_from_file,
+    recipe_from_file,
     set_pref,
     version_equal_or_greater,
 )
@@ -130,7 +130,7 @@ def valid_recipe_plist(recipe_plist):
 def valid_recipe_file(filename):
     """Returns True if filename contains a valid recipe,
     otherwise returns False"""
-    recipe_plist = recipe_plist_from_file(filename)
+    recipe_plist = recipe_from_file(filename)
     return valid_recipe_plist(recipe_plist)
 
 
@@ -145,7 +145,7 @@ def valid_override_plist(recipe_plist):
 def valid_override_file(filename):
     """Returns True if filename contains a valid override,
     otherwise returns False"""
-    override_plist = recipe_plist_from_file(filename)
+    override_plist = recipe_from_file(filename)
     return valid_override_plist(override_plist)
 
 
@@ -354,7 +354,7 @@ def load_recipe(
 
     if recipe_file:
         # read it
-        recipe = recipe_plist_from_file(recipe_file)
+        recipe = recipe_from_file(recipe_file)
 
         # store parent trust info, but only if this is an override
         if recipe_in_override_dir(recipe_file, override_dirs):
@@ -1093,7 +1093,7 @@ def get_recipe_list(
         )
 
         for match in matches:
-            recipe = recipe_plist_from_file(match)
+            recipe = recipe_from_file(match)
             if valid_recipe_plist(recipe):
                 recipe_name = os.path.basename(match)
 
@@ -1117,7 +1117,7 @@ def get_recipe_list(
         for filename in os.listdir(normalized_dir):
             if filename.endswith(".recipe"):
                 pathname = os.path.join(normalized_dir, filename)
-                override = recipe_plist_from_file(pathname)
+                override = recipe_from_file(pathname)
 
                 if valid_override_plist(override):
                     # override points to a valid recipe
@@ -1679,7 +1679,7 @@ def update_trust_info(argv):
             continue
         # normalize recipe path
         recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
-        recipe = recipe_plist_from_file(recipe_path)
+        recipe = recipe_from_file(recipe_path)
         if "ParentRecipe" not in recipe:
             log_err(f"{recipe_name} is not a recipe override and has no parent recipe.")
             log_err(f"Path: {recipe_path}")

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -158,7 +158,7 @@ def find_recipe_by_name(name, search_dirs):
     name = remove_recipe_extension(name)
     # search by "Name", using file/directory hierarchy rules
     for directory in search_dirs:
-        # TODO: Combine with similar code in get_recipe_list()
+        # TODO: Combine with similar code in get_recipe_list() and find_recipe_by_identifier()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         patterns = [os.path.join(normalized_dir, f"{name}{ext}") for ext in RECIPE_EXTS]
         patterns.extend(
@@ -1084,7 +1084,7 @@ def get_recipe_list(
 
     recipes = []
     for directory in search_dirs:
-        # TODO: Combine with similar code in find_recipe_by_name()
+        # TODO: Combine with similar code in find_recipe_by_name() and find_recipe_by_identifier()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         if not os.path.isdir(normalized_dir):
             continue

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -354,8 +354,7 @@ def load_recipe(
 
     if recipe_file:
         # read it
-        with open(recipe_file, "rb") as f:
-            recipe = plistlib.load(f)
+        recipe = recipe_plist_from_file(recipe_file)
 
         # store parent trust info, but only if this is an override
         if recipe_in_override_dir(recipe_file, override_dirs):
@@ -1680,8 +1679,7 @@ def update_trust_info(argv):
             continue
         # normalize recipe path
         recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
-        with open(recipe_path, "rb") as f:
-            recipe = plistlib.load(f)
+        recipe = recipe_plist_from_file(recipe_path)
         if "ParentRecipe" not in recipe:
             log_err(f"{recipe_name} is not a recipe override and has no parent recipe.")
             log_err(f"Path: {recipe_path}")

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1120,16 +1120,16 @@ def get_recipe_list(
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         if not os.path.isdir(normalized_dir):
             continue
-        for filename in os.listdir(normalized_dir):
-            if filename.endswith(".recipe"):
-                pathname = os.path.join(normalized_dir, filename)
-                override = recipe_from_file(pathname)
-
+        patterns = [os.path.join(normalized_dir, f"*{ext}") for ext in RECIPE_EXTS]
+        for pattern in patterns:
+            matches = glob.glob(pattern)
+            for match in matches:
+                override = recipe_from_file(match)
                 if valid_override_dict(override):
-                    # override points to a valid recipe
-                    override_name = os.path.basename(pathname)
+                    override_name = os.path.basename(match)
+
                     override["Name"] = remove_recipe_extension(override_name)
-                    override["Path"] = pathname
+                    override["Path"] = match
                     override["IsOverride"] = True
 
                     if augmented_list and not show_all:

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -107,48 +107,48 @@ def builds_a_package(recipe):
     return recipe_has_step_processor(recipe, "PkgCreator")
 
 
-def valid_recipe_plist_with_keys(recipe_plist, keys_to_verify):
-    """Attempts to read a plist and ensures the keys in
+def valid_recipe_dict_with_keys(recipe_dict, keys_to_verify):
+    """Attempts to read a dict and ensures the keys in
     keys_to_verify exist. Returns False on any failure, True otherwise."""
-    if recipe_plist:
+    if recipe_dict:
         for key in keys_to_verify:
-            if key not in recipe_plist:
+            if key not in recipe_dict:
                 return False
         # if we get here, we found all the keys
         return True
     return False
 
 
-def valid_recipe_plist(recipe_plist):
-    """Returns True if recipe plist is a valid recipe,
+def valid_recipe_dict(recipe_dict):
+    """Returns True if recipe dict is a valid recipe,
     otherwise returns False"""
     return (
-        valid_recipe_plist_with_keys(recipe_plist, ["Input", "Process"])
-        or valid_recipe_plist_with_keys(recipe_plist, ["Input", "Recipe"])
-        or valid_recipe_plist_with_keys(recipe_plist, ["Input", "ParentRecipe"])
+        valid_recipe_dict_with_keys(recipe_dict, ["Input", "Process"])
+        or valid_recipe_dict_with_keys(recipe_dict, ["Input", "Recipe"])
+        or valid_recipe_dict_with_keys(recipe_dict, ["Input", "ParentRecipe"])
     )
 
 
 def valid_recipe_file(filename):
     """Returns True if filename contains a valid recipe,
     otherwise returns False"""
-    recipe_plist = recipe_from_file(filename)
-    return valid_recipe_plist(recipe_plist)
+    recipe_dict = recipe_from_file(filename)
+    return valid_recipe_dict(recipe_dict)
 
 
-def valid_override_plist(recipe_plist):
+def valid_override_dict(recipe_dict):
     """Returns True if the recipe is a valid override,
     otherwise returns False"""
-    return valid_recipe_plist_with_keys(
-        recipe_plist, ["Input", "ParentRecipe"]
-    ) or valid_recipe_plist_with_keys(recipe_plist, ["Input", "Recipe"])
+    return valid_recipe_dict_with_keys(
+        recipe_dict, ["Input", "ParentRecipe"]
+    ) or valid_recipe_dict_with_keys(recipe_dict, ["Input", "Recipe"])
 
 
 def valid_override_file(filename):
     """Returns True if filename contains a valid override,
     otherwise returns False"""
-    override_plist = recipe_from_file(filename)
-    return valid_override_plist(override_plist)
+    override_dict = recipe_from_file(filename)
+    return valid_override_dict(override_dict)
 
 
 def find_recipe_by_name(name, search_dirs):
@@ -334,11 +334,11 @@ def load_recipe(
     auto_pull=False,
 ):
     """Loads a recipe, first locating it by name.
-    If we find one, we load it and return the plist object (which
-    should be functionally equivelent to a dictionary). If an override file is
-    used, it prefers finding the original recipe by identifier rather than
-    name, so that if recipe names shift with updated recipe repos, the
-    override still applies to the recipe from which it was derived."""
+    If we find one, we load it and return the dictionary object. If an
+    override file is used, it prefers finding the original recipe by
+    identifier rather than name, so that if recipe names shift with
+    updated recipe repos, the override still applies to the recipe from
+    which it was derived."""
 
     if override_dirs is None:
         override_dirs = []
@@ -1099,7 +1099,7 @@ def get_recipe_list(
             matches = glob.glob(pattern)
             for match in matches:
                 recipe = recipe_from_file(match)
-                if valid_recipe_plist(recipe):
+                if valid_recipe_dict(recipe):
                     recipe_name = os.path.basename(match)
 
                     recipe["Name"] = remove_recipe_extension(recipe_name)
@@ -1124,7 +1124,7 @@ def get_recipe_list(
                 pathname = os.path.join(normalized_dir, filename)
                 override = recipe_from_file(pathname)
 
-                if valid_override_plist(override):
+                if valid_override_dict(override):
                     # override points to a valid recipe
                     override_name = os.path.basename(pathname)
                     override["Name"] = remove_recipe_extension(override_name)
@@ -1885,19 +1885,19 @@ def make_override(argv):
     reversed_name = ".".join(reversed(override_name.split(".")))
     override_identifier = "local." + reversed_name
 
-    override_plist = {
+    override_dict = {
         "Identifier": override_identifier,
         "Input": recipe["Input"],
         "ParentRecipe": parent_identifier,
     }
 
     # add trust info
-    override_plist["ParentRecipeTrustInfo"] = get_trust_info(
+    override_dict["ParentRecipeTrustInfo"] = get_trust_info(
         recipe, search_dirs=search_dirs
     )
 
-    if "IDENTIFIER" in override_plist["Input"]:
-        del override_plist["Input"]["IDENTIFIER"]
+    if "IDENTIFIER" in override_dict["Input"]:
+        del override_dict["Input"]["IDENTIFIER"]
 
     override_dir = os.path.expanduser(override_dirs[0])
     if not os.path.exists(os.path.join(override_dir)):
@@ -1911,14 +1911,14 @@ def make_override(argv):
     if os.path.exists(override_file):
         if not options.force:
             log_err(
-                f"An override plist already exists at {override_file}, "
+                f"A recipe override already exists at {override_file}, "
                 "will not overwrite it. Use --force to overwrite "
                 "anyway."
             )
             return -1
         os.unlink(override_file)
     with open(override_file, "wb") as f:
-        plistlib.dump(override_plist, f)
+        plistlib.dump(override_dict, f)
     log(f"Override file saved to {override_file}")
     return 0
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2640,7 +2640,7 @@ def new_recipe(argv):
         recipe["ParentRecipe"] = options.parent_identifier
 
     try:
-        if options.format == "yaml":
+        if options.format == "yaml" or filename.endswith(".recipe.yaml"):
             # Yaml recipes require AutoPkg 2.3 or later.
             recipe["MinimumVersion"] = "2.3"
             with open(filename, "wb") as f:

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -152,6 +152,16 @@ def valid_override_file(filename):
     return valid_override_plist(override_plist)
 
 
+def remove_recipe_extension(name):
+    """Removes supported recipe extensions from a filename or path.
+    If the filename or path does not end with any known recipe extension,
+    the name is returned as is."""
+    for ext in RECIPE_EXTS:
+        if name.endswith(ext):
+            return name[: -len(ext)]
+    return name
+
+
 def find_recipe_by_name(name, search_dirs):
     """Search search_dirs for a recipe by file/directory naming rules"""
     if name.endswith(".recipe"):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1029,9 +1029,8 @@ def list_processors(argv):
 
 def make_suggestions_for(search_name):
     """Suggest existing recipes with names similar to search name."""
-    # trim '.recipe' from the end if it exists
-    if os.path.splitext(search_name)[1].lower() == ".recipe":
-        search_name = os.path.splitext(search_name)[0]
+    # trim extension from the end if it exists
+    search_name = remove_recipe_extension(search_name)
     (search_name_base, search_name_ext) = os.path.splitext(search_name.lower())
     recipe_names = [os.path.splitext(item["Name"]) for item in get_recipe_list()]
     recipe_names = list(set(recipe_names))
@@ -1123,7 +1122,7 @@ def get_recipe_list(
                 if valid_override_plist(override):
                     # override points to a valid recipe
                     override_name = os.path.basename(pathname)
-                    override["Name"] = os.path.splitext(override_name)[0]
+                    override["Name"] = remove_recipe_extension(override_name)
                     override["Path"] = pathname
                     override["IsOverride"] = True
 
@@ -1874,8 +1873,8 @@ def make_override(argv):
         )
         return 1
 
-    override_name = (
-        options.name or os.path.splitext(os.path.basename(recipe["RECIPE_PATH"]))[0]
+    override_name = options.name or remove_recipe_extension(
+        os.path.basename(recipe["RECIPE_PATH"])
     )
 
     reversed_name = ".".join(reversed(override_name.split(".")))
@@ -1902,10 +1901,6 @@ def make_override(argv):
         except OSError as err:
             log_err(f"Could not create {override_dir}: {err}")
             return -1
-
-    override_name = (
-        options.name or os.path.splitext(os.path.basename(recipe["RECIPE_PATH"]))[0]
-    )
 
     override_file = os.path.join(override_dir, f"{override_name}.recipe")
     if os.path.exists(override_file):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -52,6 +52,7 @@ from autopkglib import (
     log,
     log_err,
     processor_names,
+    recipe_plist_from_file,
     set_pref,
     version_equal_or_greater,
 )
@@ -102,19 +103,6 @@ def has_check_phase(recipe):
 def builds_a_package(recipe):
     """Does this recipe build any packages?"""
     return recipe_has_step_processor(recipe, "PkgCreator")
-
-
-def recipe_plist_from_file(filename):
-    """Create a recipe plist from a file. Handle exceptions and log"""
-    if os.path.isfile(filename):
-        try:
-            # make sure we can read it
-            with open(filename, "rb") as f:
-                recipe_plist = plistlib.load(f)
-        except Exception as err:
-            log_err(f"WARNING: plist error for {filename}: {err}")
-            return
-        return recipe_plist
 
 
 def valid_recipe_plist_with_keys(recipe_plist, keys_to_verify):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -164,17 +164,16 @@ def remove_recipe_extension(name):
 
 def find_recipe_by_name(name, search_dirs):
     """Search search_dirs for a recipe by file/directory naming rules"""
-    if name.endswith(".recipe"):
-        # drop ".recipe" from the end of the name because we're
-        # going to add it back on...
-        name = os.path.splitext(name)[0]
+    # drop extension from the end of the name because we're
+    # going to add it back on...
+    name = remove_recipe_extension(name)
     # search by "Name", using file/directory hierarchy rules
     for directory in search_dirs:
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
-        patterns = [
-            os.path.join(normalized_dir, f"{name}.recipe"),
-            os.path.join(normalized_dir, f"*/{name}.recipe"),
-        ]
+        patterns = [os.path.join(normalized_dir, f"{name}{ext}") for ext in RECIPE_EXTS]
+        patterns.extend(
+            [os.path.join(normalized_dir, f"*/{name}{ext}") for ext in RECIPE_EXTS]
+        )
         for pattern in patterns:
             matches = glob.glob(pattern)
             for match in matches:

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -920,7 +920,7 @@ def get_info(argv):
         "--pull",
         action="store_true",
         help=(
-            "Pull the parent repos if they can't be found in the search path."
+            "Pull the parent repos if they can't be found in the search path. "
             "Implies agreement to search GitHub."
         ),
     )
@@ -1814,7 +1814,7 @@ def make_override(argv):
         "--pull",
         action="store_true",
         help=(
-            "Pull the parent repos if they can't be found in the search path."
+            "Pull the parent repos if they can't be found in the search path. "
             "Implies agreement to search GitHub."
         ),
     )

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2604,7 +2604,15 @@ def new_recipe(argv):
     parser.add_option(
         "-p", "--parent-identifier", help="Parent recipe identifier for this recipe."
     )
-
+    parser.add_option(
+        "--format",
+        action="store",
+        default="plist",
+        help=(
+            "The format of the new recipe to be created. "
+            "Valid options include: 'plist' (default) or 'yaml'"
+        ),
+    )
     (options, arguments) = common_parse(parser, argv)
 
     if len(arguments) != 1:
@@ -2632,8 +2640,14 @@ def new_recipe(argv):
         recipe["ParentRecipe"] = options.parent_identifier
 
     try:
-        with open(filename, "wb") as f:
-            plistlib.dump(recipe, f)
+        if options.format == "yaml":
+            # Yaml recipes require AutoPkg 2.3 or later.
+            recipe["MinimumVersion"] = "2.3"
+            with open(filename, "wb") as f:
+                yaml.dump(recipe, f, encoding="utf-8")
+        else:
+            with open(filename, "wb") as f:
+                plistlib.dump(recipe, f)
         log(f"Saved new recipe to {filename}")
     except Exception as err:
         log_err(f"Failed to write recipe: {err}")

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2620,7 +2620,7 @@ def new_recipe(argv):
         "Description": "Recipe description",
         "Identifier": identifier,
         "Input": {"NAME": name},
-        "MiniumumVersion": "1.0",
+        "MinimumVersion": "1.0",
         "Process": [
             {
                 "Arguments": {"Argument1": "Value1", "Argument2": "Value2"},

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1088,27 +1088,30 @@ def get_recipe_list(
             continue
 
         # find all top-level recipes and recipes one level down
-        matches = glob.glob(os.path.join(normalized_dir, "*.recipe")) + glob.glob(
-            os.path.join(normalized_dir, "*/*.recipe")
+        patterns = [os.path.join(normalized_dir, f"*{ext}") for ext in RECIPE_EXTS]
+        patterns.extend(
+            [os.path.join(normalized_dir, f"*/*{ext}") for ext in RECIPE_EXTS]
         )
 
-        for match in matches:
-            recipe = recipe_from_file(match)
-            if valid_recipe_plist(recipe):
-                recipe_name = os.path.basename(match)
+        for pattern in patterns:
+            matches = glob.glob(pattern)
+            for match in matches:
+                recipe = recipe_from_file(match)
+                if valid_recipe_plist(recipe):
+                    recipe_name = os.path.basename(match)
 
-                recipe["Name"] = os.path.splitext(recipe_name)[0]
-                recipe["Path"] = match
+                    recipe["Name"] = remove_recipe_extension(recipe_name)
+                    recipe["Path"] = match
 
-                # If a top level "Identifier" key is not discovered,
-                # this will copy an IDENTIFIER key in the "Input"
-                # entry to the top level of the recipe dictionary.
-                if "Identifier" not in recipe:
-                    identifier = get_identifier(recipe)
-                    if identifier:
-                        recipe["Identifier"] = identifier
+                    # If a top level "Identifier" key is not discovered,
+                    # this will copy an IDENTIFIER key in the "Input"
+                    # entry to the top level of the recipe dictionary.
+                    if "Identifier" not in recipe:
+                        identifier = get_identifier(recipe)
+                        if identifier:
+                            recipe["Identifier"] = identifier
 
-                recipes.append(recipe)
+                    recipes.append(recipe)
 
     for directory in override_dirs:
         normalized_dir = os.path.abspath(os.path.expanduser(directory))

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -520,7 +520,7 @@ class GitError(Exception):
 
 def run_git(git_options_and_arguments, git_directory=None):
     """Run a git command and return its output if successful;
-       raise GitError if unsuccessful."""
+    raise GitError if unsuccessful."""
     gitcmd = git_cmd()
     if not gitcmd:
         raise GitError("ERROR: git is not installed!")
@@ -1960,7 +1960,7 @@ def parse_recipe_list(filename):
 
 def run_recipes(argv):
     """Run one or more recipes. If called with 'install' verb, run .install
-       recipe"""
+    recipe"""
     verb = argv[1]
     parser = gen_common_parser()
     if verb == "install":

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -36,6 +36,7 @@ from urllib.parse import quote, urlparse
 
 from autopkgcmd import common_parse, gen_common_parser, search_recipes
 from autopkglib import (
+    RECIPE_EXTS,
     AutoPackager,
     AutoPackagerError,
     PreferenceError,
@@ -53,6 +54,7 @@ from autopkglib import (
     log_err,
     processor_names,
     recipe_from_file,
+    remove_recipe_extension,
     set_pref,
     version_equal_or_greater,
 )
@@ -69,9 +71,6 @@ if sys.platform != "darwin":
 
 # Catch Python 2 wrappers with an early f-string. Message must be on a single line.
 _ = f"""{sys.version_info.major} It looks like you're running the autopkg tool with an incompatible version of Python. Please update your script to use autopkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with autopkg 2. """  # noqa
-
-# Supported recipe extensions
-RECIPE_EXTS = (".recipe", ".recipe.plist", ".recipe.yaml")
 
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70
@@ -150,16 +149,6 @@ def valid_override_file(filename):
     otherwise returns False"""
     override_plist = recipe_from_file(filename)
     return valid_override_plist(override_plist)
-
-
-def remove_recipe_extension(name):
-    """Removes supported recipe extensions from a filename or path.
-    If the filename or path does not end with any known recipe extension,
-    the name is returned as is."""
-    for ext in RECIPE_EXTS:
-        if name.endswith(ext):
-            return name[: -len(ext)]
-    return name
 
 
 def find_recipe_by_name(name, search_dirs):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -70,6 +70,9 @@ if sys.platform != "darwin":
 # Catch Python 2 wrappers with an early f-string. Message must be on a single line.
 _ = f"""{sys.version_info.major} It looks like you're running the autopkg tool with an incompatible version of Python. Please update your script to use autopkg's included Python (/usr/local/autopkg/python). AutoPkgr users please note that AutoPkgr 1.5.1 and earlier is NOT compatible with autopkg 2. """  # noqa
 
+# Supported recipe extensions
+RECIPE_EXTS = (".recipe", ".recipe.plist", ".recipe.yaml")
+
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70
 

--- a/Code/autopkglib/DeprecationWarning.py
+++ b/Code/autopkglib/DeprecationWarning.py
@@ -19,7 +19,7 @@ upcoming removal of a recipe."""
 
 import os
 
-from autopkglib import Processor
+from autopkglib import Processor, remove_recipe_extension
 
 __all__ = ["DeprecationWarning"]
 
@@ -47,8 +47,7 @@ class DeprecationWarning(Processor):
         )
         self.output(warning_message)
         recipe_name = os.path.basename(self.env["RECIPE_PATH"])
-        if recipe_name.endswith(".recipe"):
-            recipe_name = os.path.splitext(recipe_name)[0]
+        recipe_name = remove_recipe_extension(recipe_name)
         self.env["deprecation_summary_result"] = {
             "summary_text": "The following recipes have deprecation warnings:",
             "report_fields": ["name", "warning"],

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -374,10 +374,10 @@ def get_identifier(recipe):
 
 
 def get_identifier_from_recipe_file(filename):
-    """Attempts to read plist file filename and get the
+    """Attempts to read filename and get the
     identifier. Otherwise, returns None."""
-    recipe_plist = recipe_from_file(filename)
-    return get_identifier(recipe_plist)
+    recipe_dict = recipe_from_file(filename)
+    return get_identifier(recipe_dict)
 
 
 def find_recipe_by_identifier(identifier, search_dirs):
@@ -709,7 +709,7 @@ class AutoPackager:
             print(msg)
 
     def get_recipe_identifier(self, recipe):
-        """Return the identifier given an input recipe plist."""
+        """Return the identifier given an input recipe dict."""
         identifier = recipe.get("Identifier") or recipe["Input"].get("IDENTIFIER")
         if not identifier:
             log_err("ID NOT FOUND")

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -31,6 +31,7 @@ from typing import IO, Any, Dict, List, Optional, Union
 
 import appdirs
 import pkg_resources
+import yaml
 
 # Type for methods that accept either a filesystem path or a file-like object.
 FileOrPath = Union[IO, str, bytes, int]
@@ -320,16 +321,29 @@ def get_all_prefs():
 
 
 def recipe_from_file(filename):
-    """Create a recipe plist from a file. Handle exceptions and log"""
-    if os.path.isfile(filename):
+    """Create a recipe dictionary from a file. Handle exceptions and log"""
+    if not os.path.isfile(filename):
+        return
+
+    if filename.endswith(".yaml"):
         try:
-            # make sure we can read it
+            # try to read it as yaml
             with open(filename, "rb") as f:
-                recipe_plist = plistlib.load(f)
+                recipe_dict = yaml.load(f, Loader=yaml.FullLoader)
+            return recipe_dict
+        except Exception as err:
+            log_err(f"WARNING: yaml error for {filename}: {err}")
+            return
+
+    else:
+        try:
+            # try to read it as a plist
+            with open(filename, "rb") as f:
+                recipe_dict = plistlib.load(f)
+            return recipe_dict
         except Exception as err:
             log_err(f"WARNING: plist error for {filename}: {err}")
             return
-        return recipe_plist
 
 
 def get_identifier(recipe):

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -120,6 +120,9 @@ BUNDLE_ID = "com.github.autopkg"
 
 RE_KEYREF = re.compile(r"%(?P<key>[a-zA-Z_][a-zA-Z_0-9]*)%")
 
+# Supported recipe extensions
+RECIPE_EXTS = (".recipe", ".recipe.plist", ".recipe.yaml")
+
 
 class PreferenceError(Exception):
     """Preference exception"""
@@ -318,6 +321,16 @@ def get_all_prefs():
     """Return a dict (or an empty dict) with the contents of all
     preferences in the domain."""
     return globalPreferences.get_all_prefs()
+
+
+def remove_recipe_extension(name):
+    """Removes supported recipe extensions from a filename or path.
+    If the filename or path does not end with any known recipe extension,
+    the name is returned as is."""
+    for ext in RECIPE_EXTS:
+        if name.endswith(ext):
+            return name[: -len(ext)]
+    return name
 
 
 def recipe_from_file(filename):

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -319,6 +319,19 @@ def get_all_prefs():
     return globalPreferences.get_all_prefs()
 
 
+def recipe_plist_from_file(filename):
+    """Create a recipe plist from a file. Handle exceptions and log"""
+    if os.path.isfile(filename):
+        try:
+            # make sure we can read it
+            with open(filename, "rb") as f:
+                recipe_plist = plistlib.load(f)
+        except Exception as err:
+            log_err(f"WARNING: plist error for {filename}: {err}")
+            return
+        return recipe_plist
+
+
 def get_identifier(recipe):
     """Return identifier from recipe dict. Tries the Identifier
     top-level key and falls back to the legacy key location."""

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -349,13 +349,7 @@ def get_identifier(recipe):
 def get_identifier_from_recipe_file(filename):
     """Attempts to read plist file filename and get the
     identifier. Otherwise, returns None."""
-    recipe_plist = {}
-    try:
-        # make sure we can read it
-        with open(filename, "rb") as f:
-            recipe_plist = plistlib.load(f)
-    except Exception as err:
-        log_err(f"WARNING: plist error for {filename}: {err}")
+    recipe_plist = recipe_plist_from_file(filename)
     return get_identifier(recipe_plist)
 
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -384,6 +384,7 @@ def find_recipe_by_identifier(identifier, search_dirs):
     """Search search_dirs for a recipe with the given
     identifier"""
     for directory in search_dirs:
+        # TODO: Combine with similar code in get_recipe_list() and find_recipe_by_name()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         patterns = [os.path.join(normalized_dir, f"*{ext}") for ext in RECIPE_EXTS]
         patterns.extend(

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -385,10 +385,10 @@ def find_recipe_by_identifier(identifier, search_dirs):
     identifier"""
     for directory in search_dirs:
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
-        patterns = [
-            os.path.join(normalized_dir, "*.recipe"),
-            os.path.join(normalized_dir, "*/*.recipe"),
-        ]
+        patterns = [os.path.join(normalized_dir, f"*{ext}") for ext in RECIPE_EXTS]
+        patterns.extend(
+            [os.path.join(normalized_dir, f"*/*{ext}") for ext in RECIPE_EXTS]
+        )
         for pattern in patterns:
             matches = glob.glob(pattern)
             for match in matches:

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -716,7 +716,7 @@ class AutoPackager:
             # build a pseudo-identifier based on the recipe pathname
             recipe_path = self.env.get("RECIPE_PATH")
             # get rid of filename extension
-            recipe_path = os.path.splitext(recipe_path)[0]
+            recipe_path = remove_recipe_extension(recipe_path)
             path_parts = recipe_path.split("/")
             identifier = "-".join(path_parts)
         return identifier

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -319,7 +319,7 @@ def get_all_prefs():
     return globalPreferences.get_all_prefs()
 
 
-def recipe_plist_from_file(filename):
+def recipe_from_file(filename):
     """Create a recipe plist from a file. Handle exceptions and log"""
     if os.path.isfile(filename):
         try:
@@ -349,7 +349,7 @@ def get_identifier(recipe):
 def get_identifier_from_recipe_file(filename):
     """Attempts to read plist file filename and get the
     identifier. Otherwise, returns None."""
-    recipe_plist = recipe_plist_from_file(filename)
+    recipe_plist = recipe_from_file(filename)
     return get_identifier(recipe_plist)
 
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -20,7 +20,7 @@ These tasks typically involve at least several of the following steps:
 
 Often these tasks follow similar patterns for each individual application, and when managing many applications this becomes a daily task full of sub-tasks that one must remember (and/or maintain documentation for) about exactly what had to be done for a successful deployment of every update for every managed piece of software.
 
-With AutoPkg, we define these steps in a "Recipe" plist-based format, run automatically instead of by hand, and shared with others.
+With AutoPkg, we define these steps in a "Recipe" file in plist or yaml format, run automatically instead of by hand, and shared with others.
 
 
 Installation


### PR DESCRIPTION
## Overview

**This PR adds native support for recipes in yaml format.**

(Includes the changes originally proposed in #617, and adds `make-override`, `new-recipe`, and `search` yaml support.)

The primary benefit of yaml recipes is readability. For people who don't already spend a lot of time looking at plists, yaml recipes are much easier to parse at a glance. Some examples of yaml recipes are already present in @grahampugh's [recipe repo](https://github.com/autopkg/grahampugh-recipes/tree/master/YAML), and I think the difference is clear:

![Image 1](https://user-images.githubusercontent.com/7801391/100529340-6c347080-319b-11eb-9f43-6535f07319d6.png)

Aside from the significant reduction in lines needed, there's also no need to escape characters through XML, as demonstrated in the URLTextSearcher regex pattern in the example above.

A secondary benefit of this change is that it includes a lot of the work required to support other recipe formats (e.g. json) in the future.

## Suggested timing

Because the addition of a new recipe format is a major feature addition and requires careful testing, I would propose targeting **AutoPkg 2.3** for this merge, with at least one release candidate before the final release.

## Order of dictionary keys

As with plists, the order of keys in a dictionary does not matter, and creating yaml files programmatically usually results in alphabetic key order. But unlike plists, yaml dictionaries in an array (e.g. processors) have less visual separation from each other due to the lack of indentation, so the key order may affect readability more dramatically than in plists.

Ensuring that the Processor key comes before the Arguments key in processor dictionaries improves how yaml recipes can be scanned by humans. The difference can easily be seen here (arrow indicate the direction of scan when reading the recipe):

![Image 3 001](https://user-images.githubusercontent.com/7801391/100529358-984ff180-319b-11eb-9dc1-e81a069669d2.jpeg)

In case recipe authors prefer to put the Processor key first when converting from plist, I've updated @grahampugh's plist-yaml-plist project to do just that: <https://github.com/grahampugh/plist-yaml-plist/pull/2>

## Recipe filename extensions

With this change comes a design decision about recipe filename extensions. I've chosen to infer recipe format using a **.recipe.yaml** extension instead of trying to parse files with the .recipe extension multiple ways. This requires recipe authors to ensure that yaml recipe filenames end with .recipe.yaml. Recipes that end in .recipe will continue to be treated like plists. (A new .recipe.plist extension is also allowable.)

The extension ".yaml" was chosen over ".yml" at the suggestion of the [yaml.org FAQ](https://yaml.org/faq.html).

## String types

Yaml requires extra caution on the part of recipe authors, due to the way it infers some data types. For example, this version will be treated as a string:

```
MinimumVersion: 1.4.1
```

But this version will be treated as a float, causing problems downstream:

```
MinimumVersion: 2.3
```

The solution is to ensure that such strings are surrounded by single or double quotes when creating recipes manually:

```
MinimumVersion: '2.3'
```

Once this PR is approved and merged, the recipe format wiki page should be updated to include a recommendation to that effect.

## A note on GitHub search

GitHub does not support compound extensions (e.g. .recipe.yaml) in search queries. In order to add support for showing yaml recipes in GitHub search results, a two-step approach was necessary:

1. Include .recipe, .plist, and .yaml file extensions in the initial GitHub query
2. Filter the resulting filenames down to only .recipe, .recipe.plist, and .recipe.yaml files

This way, non-recipe files like .pre-commit-config.yaml and Info.plist will not appear in results.

## Guidance for recipe authors

I would propose including two notes specifically for recipe authors in the changelog and release notes, as follows:

> • Because yaml recipes will require AutoPkg 2.3 or later in order to run, and because some members of the AutoPkg community may still be using AutoPkg 1.x, recipe authors are encouraged to be conservative and keep existing public recipes in their current format for a while.

> • If you have both plist and yaml recipes for the same app in your repo, you may experience unexpected behavior now that AutoPkg detects and uses yaml recipes.

## Unresolved issues

A few minor issues are not addressed by this PR, but I wanted to note them here for future work:

- There is code in the get_recipe_list, find_recipe_by_identifier, and find_recipe_by_name functions that can probably be combined. I've added a TODO comment to mark each instance.
- Yaml-related documentation will need to be written for the wiki.
- Out of scope for now: support for yaml in places other than recipes (e.g. prefs input, report output).

--------------------------------------------------------------------------------

## Functional Testing

### Testing summary

Test                       | .recipe | .recipe.plist | .recipe.yaml
-------------------------- | ------- | ------------- | ------------
Recipe info                | ✅ 1a    | ✅ 1b          | ✅ 1c
Recipe suggestion          | ✅ 2a    | ✅ 2b          | ✅ 2c
Make plist override        | ✅ 3a    | ✅ 3b          | ✅ 3c
Make yaml override         | ✅ 4a    | ✅ 4b          | ✅ 4c
List-recipes               | ✅ 5a    | ✅ 5b          | ✅ 5c
Override verify trust info | ✅ 6a    | ✅ 6b          | ✅ 6c
Trust information update   | ✅ 7a    | ✅ 7b          | ✅ 7c
Recipe run                 | ✅ 8a    | ✅ 8b          | ✅ 8c
Override run               | ✅ 9a    | ✅ 9b          | ✅ 9c
Install verb               | ✅ 10a   | ✅ 10b         | ✅ 10c
Recipe audit               | ✅ 11a   | ✅ 11b         | ✅ 11c
New recipe                 | ✅ 12a   | ✅ 12b         | ✅ 12c
Search for recipe          | ✅ 13a   | ✅ 13b         | ✅ 13c

See detailed output in corresponding test numbers below.

### Testing setup

The `yaml3` branch of the AutoPkg repo was used on a fresh Mac (no pre-existing AutoPkg or Munki preference files):

```
% defaults delete com.github.autopkg
% ./autopkg version
2.3
```

Three recipe repos were added:

```
% ./autopkg repo-add recipes homebysix-recipes grahampugh-recipes
WARNING: Did not load any default preferences.
Attempting git clone...

Adding ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes to RECIPE_SEARCH_DIRS...
Attempting git clone...

Adding ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes to RECIPE_SEARCH_DIRS...
Attempting git clone...

Adding ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes to RECIPE_SEARCH_DIRS...
Updated search path:
  '.'
  '~/Library/AutoPkg/Recipes'
  '/Library/AutoPkg/Recipes'
  '~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes'
  '~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes'
  '~/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes'
```

The homebysix-recipes repo testing was performed on commit [a66f0f1](https://github.com/autopkg/homebysix-recipes/tree/a66f0f175251e7b66e94bd167ef67244996c94da). This commit includes .recipe.yaml recipes for [Coppice](https://github.com/autopkg/homebysix-recipes/tree/a66f0f175251e7b66e94bd167ef67244996c94da/Coppice) and .recipe.plist recipes for [Fruity](https://github.com/autopkg/homebysix-recipes/tree/a66f0f175251e7b66e94bd167ef67244996c94da/Fruity).

```
% git -C ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes checkout a66f0f1
Note: switching to 'a66f0f1'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at a66f0f1 Add Coppice recipes (in yaml format for testing)
```

The preferences file at **~/Library/Preferences/com.github.autopkg.plist** appears as follows:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>RECIPE_REPOS</key>
    <dict>
        <key>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes</key>
        <dict>
            <key>URL</key>
            <string>https://github.com/autopkg/grahampugh-recipes</string>
        </dict>
        <key>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes</key>
        <dict>
            <key>URL</key>
            <string>https://github.com/autopkg/homebysix-recipes</string>
        </dict>
        <key>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes</key>
        <dict>
            <key>URL</key>
            <string>https://github.com/autopkg/recipes</string>
        </dict>
    </dict>
    <key>RECIPE_SEARCH_DIRS</key>
    <array>
        <string>.</string>
        <string>~/Library/AutoPkg/Recipes</string>
        <string>/Library/AutoPkg/Recipes</string>
        <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes</string>
        <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes</string>
        <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes</string>
    </array>
</dict>
</plist>
```

Now we're ready to test.

### Test 1a: Recipe info, .recipe:

```
% ./autopkg info BBEdit.pkg        
Description:         Downloads the latest BBEdit and creates a package.
Identifier:          com.github.autopkg.pkg.BBEdit
Munki import recipe: False
Has check phase:     True
Builds package:      True
Recipe file path:    ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BBEdit.pkg.recipe
Parent recipe(s):    ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BBEdit.download.recipe
Input values:
 'NAME': 'BBEdit'
```

### Test 1b: Recipe info, .recipe.plist:

```
% ./autopkg info Fruity.pkg        
Description:         Downloads the latest version of Fruity and creates a package.
Identifier:          com.github.homebysix.pkg.Fruity
Munki import recipe: False
Has check phase:     True
Builds package:      False
Recipe file path:    ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Fruity/Fruity.pkg.recipe.plist
Parent recipe(s):    ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Fruity/Fruity.download.recipe.plist
Input values:
 'NAME': 'Fruity'
```

### Test 1c: Recipe info, .recipe.yaml:

```
% ./autopkg info Coppice.pkg
Description:         Downloads the latest version of Coppice and creates a package.
Identifier:          com.github.homebysix.pkg.Coppice
Munki import recipe: False
Has check phase:     True
Builds package:      False
Recipe file path:    ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Coppice/Coppice.pkg.recipe.yaml
Parent recipe(s):    ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Coppice/Coppice.download.recipe.yaml
Input values:
 'NAME': 'Coppice'
```

### Test 2a: Recipe suggestion, .recipe:

```
% ./autopkg info BBBEdit.pkg   
Didn't find a recipe for BBBEdit.pkg.
Maybe you meant BBEdit.pkg?
Search GitHub AutoPkg repos for a BBBEdit.pkg recipe? [y/n]: n
No valid recipe found for BBBEdit.pkg
```

### Test 2b: Recipe suggestion, .recipe.plist:

```
% ./autopkg info Fruityy.pkg
Didn't find a recipe for Fruityy.pkg.
Maybe you meant Fruity.pkg?
Search GitHub AutoPkg repos for a Fruityy.pkg recipe? [y/n]: n
No valid recipe found for Fruityy.pkg
```

### Test 2c: Recipe suggestion, .recipe.yaml:

```
% ./autopkg info Copppice.pkg
Didn't find a recipe for Copppice.pkg.
Maybe you meant Coppice.pkg?
Search GitHub AutoPkg repos for a Copppice.pkg recipe? [y/n]: n
No valid recipe found for Copppice.pkg
```

### Test 3a: Make plist override from .recipe:

```
% ./autopkg make-override BBEdit.pkg
Override file saved to ~/Library/AutoPkg/RecipeOverrides/BBEdit.pkg.recipe
```

```
% cat ~/Library/AutoPkg/RecipeOverrides/BBEdit.pkg.recipe
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Identifier</key>
    <string>local.pkg.BBEdit</string>
    <key>Input</key>
    <dict>
        <key>NAME</key>
        <string>BBEdit</string>
    </dict>
    <key>ParentRecipe</key>
    <string>com.github.autopkg.pkg.BBEdit</string>
    <key>ParentRecipeTrustInfo</key>
    <dict>
        <key>non_core_processors</key>
        <dict>
            <key>BarebonesURLProvider</key>
            <dict>
                <key>git_hash</key>
                <string>a46693f4b0f0176bc1ee07496c223cfca41b1348</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BarebonesURLProvider.py</string>
                <key>sha256_hash</key>
                <string>9d057626a1fa54ab487d0e7372fb97366cbad5c64b17a12bdd730f60563527f6</string>
            </dict>
        </dict>
        <key>parent_recipes</key>
        <dict>
            <key>com.github.autopkg.download.bbedit</key>
            <dict>
                <key>git_hash</key>
                <string>55e47128864841e568cf20ccd2b852fea48faa50</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BBEdit.download.recipe</string>
                <key>sha256_hash</key>
                <string>6d8e8c3699f23f9c0511f6e2d6a14c7400b890a729f688014adb287d3666eb03</string>
            </dict>
            <key>com.github.autopkg.pkg.BBEdit</key>
            <dict>
                <key>git_hash</key>
                <string>6920d9ea839b56e5b6f4d2764f1a100b6398c895</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BBEdit.pkg.recipe</string>
                <key>sha256_hash</key>
                <string>6811ef469f31b297534dbbdd75e48c58bd68d64fa63a00d41a70c0a2db60cc8b</string>
            </dict>
        </dict>
    </dict>
</dict>
</plist>
```

### Test 3b: Make plist override from .recipe.plist:

```
% ./autopkg make-override Fruity.pkg                                 
Override file saved to ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe
```

```
% cat ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Identifier</key>
    <string>local.pkg.Fruity</string>
    <key>Input</key>
    <dict>
        <key>NAME</key>
        <string>Fruity</string>
    </dict>
    <key>ParentRecipe</key>
    <string>com.github.homebysix.pkg.Fruity</string>
    <key>ParentRecipeTrustInfo</key>
    <dict>
        <key>non_core_processors</key>
        <dict/>
        <key>parent_recipes</key>
        <dict>
            <key>com.github.homebysix.download.Fruity</key>
            <dict>
                <key>git_hash</key>
                <string>928a314c82b51eaa45b24cac693b68fdb58c804a</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Fruity/Fruity.download.recipe.plist</string>
                <key>sha256_hash</key>
                <string>447c0a9631fd4f4517dd5e6f07b15a9210f22eaf56921b652fe84d9661f7df90</string>
            </dict>
            <key>com.github.homebysix.pkg.Fruity</key>
            <dict>
                <key>git_hash</key>
                <string>928a314c82b51eaa45b24cac693b68fdb58c804a</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Fruity/Fruity.pkg.recipe.plist</string>
                <key>sha256_hash</key>
                <string>a8631b94408b6488641437782b756f45931d9ab72cc74f0e382a5324aea0a56e</string>
            </dict>
        </dict>
    </dict>
</dict>
</plist>
```

### Test 3c: Make plist override from .recipe.yaml:

```
% ./autopkg make-override Coppice.pkg                                
Override file saved to ~/Library/AutoPkg/RecipeOverrides/Coppice.pkg.recipe
```

```
% cat ~/Library/AutoPkg/RecipeOverrides/Coppice.pkg.recipe
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Identifier</key>
    <string>local.pkg.Coppice</string>
    <key>Input</key>
    <dict>
        <key>NAME</key>
        <string>Coppice</string>
    </dict>
    <key>ParentRecipe</key>
    <string>com.github.homebysix.pkg.Coppice</string>
    <key>ParentRecipeTrustInfo</key>
    <dict>
        <key>non_core_processors</key>
        <dict/>
        <key>parent_recipes</key>
        <dict>
            <key>com.github.homebysix.download.Coppice</key>
            <dict>
                <key>git_hash</key>
                <string>a66f0f175251e7b66e94bd167ef67244996c94da</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Coppice/Coppice.download.recipe.yaml</string>
                <key>sha256_hash</key>
                <string>14ed3b2ec69eb78aa76a45312200a17b663044c05134fb3b9692638ea10800c0</string>
            </dict>
            <key>com.github.homebysix.pkg.Coppice</key>
            <dict>
                <key>git_hash</key>
                <string>a66f0f175251e7b66e94bd167ef67244996c94da</string>
                <key>path</key>
                <string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Coppice/Coppice.pkg.recipe.yaml</string>
                <key>sha256_hash</key>
                <string>f58fefee1b927136b24932b3d4f3c04ebe89ee8d371063bb008d633c81e2bf4f</string>
            </dict>
        </dict>
    </dict>
</dict>
</plist>
```

### Test 4a: Make yaml override from .recipe:

```
% ./autopkg make-override BBEdit.pkg --format=yaml                   
Override file saved to ~/Library/AutoPkg/RecipeOverrides/BBEdit.pkg.recipe.yaml
```

```
% cat ~/Library/AutoPkg/RecipeOverrides/BBEdit.pkg.recipe.yaml
Identifier: local.pkg.BBEdit
Input:
  NAME: BBEdit
ParentRecipe: com.github.autopkg.pkg.BBEdit
ParentRecipeTrustInfo:
  non_core_processors:
    BarebonesURLProvider:
      git_hash: a46693f4b0f0176bc1ee07496c223cfca41b1348
      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BarebonesURLProvider.py
      sha256_hash: 9d057626a1fa54ab487d0e7372fb97366cbad5c64b17a12bdd730f60563527f6
  parent_recipes:
    com.github.autopkg.download.bbedit:
      git_hash: 55e47128864841e568cf20ccd2b852fea48faa50
      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BBEdit.download.recipe
      sha256_hash: 6d8e8c3699f23f9c0511f6e2d6a14c7400b890a729f688014adb287d3666eb03
    com.github.autopkg.pkg.BBEdit:
      git_hash: 6920d9ea839b56e5b6f4d2764f1a100b6398c895
      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BBEdit.pkg.recipe
      sha256_hash: 6811ef469f31b297534dbbdd75e48c58bd68d64fa63a00d41a70c0a2db60cc8b
```

### Test 4b: Make yaml override from .recipe.plist:

```
% ./autopkg make-override Fruity.pkg --format=yaml                
Override file saved to ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe.yaml
```

```
% cat ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe.yaml
Identifier: local.pkg.Fruity
Input:
  NAME: Fruity
ParentRecipe: com.github.homebysix.pkg.Fruity
ParentRecipeTrustInfo:
  non_core_processors: {}
  parent_recipes:
    com.github.homebysix.download.Fruity:
      git_hash: 928a314c82b51eaa45b24cac693b68fdb58c804a
      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Fruity/Fruity.download.recipe.plist
      sha256_hash: 447c0a9631fd4f4517dd5e6f07b15a9210f22eaf56921b652fe84d9661f7df90
    com.github.homebysix.pkg.Fruity:
      git_hash: 928a314c82b51eaa45b24cac693b68fdb58c804a
      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Fruity/Fruity.pkg.recipe.plist
      sha256_hash: a8631b94408b6488641437782b756f45931d9ab72cc74f0e382a5324aea0a56e
```

### Test 4c: Make yaml override from .recipe.yaml:

```
% ./autopkg make-override Coppice.pkg --format=yaml                 
Override file saved to ~/Library/AutoPkg/RecipeOverrides/Coppice.pkg.recipe.yaml
```

```
% cat ~/Library/AutoPkg/RecipeOverrides/Coppice.pkg.recipe.yaml
Identifier: local.pkg.Coppice
Input:
  NAME: Coppice
ParentRecipe: com.github.homebysix.pkg.Coppice
ParentRecipeTrustInfo:
  non_core_processors: {}
  parent_recipes:
    com.github.homebysix.download.Coppice:
      git_hash: a66f0f175251e7b66e94bd167ef67244996c94da
      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Coppice/Coppice.download.recipe.yaml
      sha256_hash: 14ed3b2ec69eb78aa76a45312200a17b663044c05134fb3b9692638ea10800c0
    com.github.homebysix.pkg.Coppice:
      git_hash: a66f0f175251e7b66e94bd167ef67244996c94da
      path: ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Coppice/Coppice.pkg.recipe.yaml
      sha256_hash: f58fefee1b927136b24932b3d4f3c04ebe89ee8d371063bb008d633c81e2bf4f
```

### Test 5a: List-recipes, .recipe:

```
% ./autopkg list-recipes | grep BBEdit    
BBEdit.download
BBEdit.install
BBEdit.munki
BBEdit.pkg
```

### Test 5b: List-recipes, .recipe.plist:

```
% ./autopkg list-recipes | grep Fruity
Fruity.download
Fruity.install
Fruity.munki
Fruity.pkg
```

### Test 5c: List-recipes, .recipe.yaml:

```
% ./autopkg list-recipes | grep Coppice
Coppice.download
Coppice.install
Coppice.munki
Coppice.pkg
```

### Test 6a: Override verify trust info, .recipe:

Clean up plist overrides first so we can ensure we're testing the yaml overrides:

```
% rm -fv ~/Library/AutoPkg/RecipeOverrides/BBEdit.pkg.recipe.yaml
~/Library/AutoPkg/RecipeOverrides/BBEdit.pkg.recipe.yaml
```

```
% ./autopkg verify-trust-info BBEdit.pkg    
BBEdit.pkg: OK
```

### Test 6b: Override verify trust info, .recipe.plist:

```
% rm -fv ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe.yaml
~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe.yaml
```

```
% mv ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe.plist
```

```
% ./autopkg verify-trust-info Fruity.pkg    
Fruity.pkg: OK
```

### Test 6c: Override verify trust info, .recipe.yaml:

```
% rm -fv ~/Library/AutoPkg/RecipeOverrides/Coppice.pkg.recipe
~/Library/AutoPkg/RecipeOverrides/Coppice.pkg.recipe
```

```
% ./autopkg verify-trust-info Coppice.pkg    
Coppice.pkg: OK
```

### Test 7a: Trust information update, .recipe:

```
% sed -i '' 's/6811/xxxx/g' ~/Library/AutoPkg/RecipeOverrides/BBEdit.pkg.recipe
% ./autopkg verify-trust-info BBEdit.pkg
BBEdit.pkg: FAILED
```

```
% ./autopkg update-trust-info BBEdit.pkg
Wrote updated ~/Library/AutoPkg/RecipeOverrides/BBEdit.pkg.recipe
% ./autopkg verify-trust-info BBEdit.pkg
BBEdit.pkg: OK
```

### Test 7b: Trust information update, .recipe.plist:

```
% sed -i '' 's/a863/xxxx/g' ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe.plist
% ./autopkg verify-trust-info Fruity.pkg                                            
Fruity.pkg: FAILED
```

```
% ./autopkg update-trust-info Fruity.pkg
Wrote updated ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe.plist
% ./autopkg verify-trust-info Fruity.pkg
Fruity.pkg: OK
```

### Test 7c: Trust information update, .recipe.yaml:

```
% sed -i '' 's/f58f/xxxx/g' ~/Library/AutoPkg/RecipeOverrides/Coppice.pkg.recipe.yaml
% ./autopkg verify-trust-info Coppice.pkg                                            
Coppice.pkg: FAILED
```

```
% ./autopkg update-trust-info Coppice.pkg
Wrote updated ~/Library/AutoPkg/RecipeOverrides/Coppice.pkg.recipe.yaml
% ./autopkg verify-trust-info Coppice.pkg
Coppice.pkg: OK
```

### Test 8a: Recipe run, .recipe:

```
% ./autopkg run -vv BBEdit.download      
Processing BBEdit.download...
WARNING: BBEdit.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
BarebonesURLProvider
{'Input': {'product_name': 'bbedit'}}
BarebonesURLProvider: Found URL https://s3.amazonaws.com/BBSW-download/BBEdit_13.5.2.dmg
{'Output': {'minimum_os_version': '10.14.2',
            'url': 'https://s3.amazonaws.com/BBSW-download/BBEdit_13.5.2.dmg',
            'version': '13.5.2'}}
URLDownloader
{'Input': {'filename': 'BBEdit.dmg',
           'url': 'https://s3.amazonaws.com/BBSW-download/BBEdit_13.5.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 09 Nov 2020 21:50:36 GMT
URLDownloader: Storing new ETag header: "8c09b172688ef4f2444f3b5031a76e7f-2"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.download.bbedit/downloads/BBEdit.dmg
{'Output': {'download_changed': True,
            'etag': '"8c09b172688ef4f2444f3b5031a76e7f-2"',
            'last_modified': 'Mon, 09 Nov 2020 21:50:36 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.download.bbedit/downloads/BBEdit.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.download.bbedit/downloads/BBEdit.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.download.bbedit/downloads/BBEdit.dmg/BBEdit.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.barebones.bbedit" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = W52GZAXT98)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.download.bbedit/downloads/BBEdit.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.vxUSj8/BBEdit.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.vxUSj8/BBEdit.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.vxUSj8/BBEdit.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.download.bbedit/receipts/BBEdit-receipt-20201128-144219.plist

The following new items were downloaded:
    Download Path                                                                              
    -------------                                                                              
    ~/Library/AutoPkg/Cache/com.github.autopkg.download.bbedit/downloads/BBEdit.dmg
```

### Test 8b: Recipe run, .recipe.plist:

```
% ./autopkg run -vv Fruity.download
Processing Fruity.download...
WARNING: Fruity.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Fruity.dmg',
           'url': 'https://www.borgcreative.com/fruity/Fruity.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 26 Nov 2020 06:45:28 GMT
URLDownloader: Storing new ETag header: "5fbf4f08-5b9cff"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.download.Fruity/downloads/Fruity.dmg
{'Output': {'download_changed': True,
            'etag': '"5fbf4f08-5b9cff"',
            'last_modified': 'Thu, 26 Nov 2020 06:45:28 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Fruity/downloads/Fruity.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Fruity/downloads/Fruity.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Fruity/receipts/Fruity-receipt-20201128-144251.plist

The following new items were downloaded:
    Download Path                                                                                
    -------------                                                                                
    ~/Library/AutoPkg/Cache/com.github.homebysix.download.Fruity/downloads/Fruity.dmg
```

### Test 8c: Recipe run, .recipe.yaml:

```
% ./autopkg run -vv Coppice.download
Processing Coppice.download...
WARNING: Coppice.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://mcubedsw.com/appcast/coppice'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 14
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2020.1
SparkleUpdateInfoProvider: Found URL https://mcubedsw.com/appcast/coppice/download/2020.1
{'Output': {'url': 'https://mcubedsw.com/appcast/coppice/download/2020.1',
            'version': '2020.1'}}
URLDownloader
{'Input': {'filename': 'Coppice-2020.1.dmg',
           'url': 'https://mcubedsw.com/appcast/coppice/download/2020.1'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.download.Coppice/downloads/Coppice-2020.1.dmg
{'Output': {'download_changed': True,
            'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Coppice/downloads/Coppice-2020.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Coppice/downloads/Coppice-2020.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Coppice/downloads/Coppice-2020.1.dmg/Coppice.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.mcubedsw.Coppice" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = K3K39KWKBV)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.download.Coppice/downloads/Coppice-2020.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.tLKaLh/Coppice.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.tLKaLh/Coppice.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.tLKaLh/Coppice.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Coppice/receipts/Coppice-receipt-20201128-144329.plist

The following new items were downloaded:
    Download Path                                                                                         
    -------------                                                                                         
    ~/Library/AutoPkg/Cache/com.github.homebysix.download.Coppice/downloads/Coppice-2020.1.dmg
```

### Test 9a: Override run, .recipe:

NOTE: A `Bad file descriptor` warning occurs in tests 9a, 9b, 9c, and 10a, but this warning doesn't appear to be related to the changes in this PR.

```
% ./autopkg run -vv BBEdit.pkg      
Processing BBEdit.pkg...
BarebonesURLProvider
{'Input': {'product_name': 'bbedit'}}
BarebonesURLProvider: Found URL https://s3.amazonaws.com/BBSW-download/BBEdit_13.5.2.dmg
{'Output': {'minimum_os_version': '10.14.2',
            'url': 'https://s3.amazonaws.com/BBSW-download/BBEdit_13.5.2.dmg',
            'version': '13.5.2'}}
URLDownloader
{'Input': {'filename': 'BBEdit.dmg',
           'url': 'https://s3.amazonaws.com/BBSW-download/BBEdit_13.5.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 09 Nov 2020 21:50:36 GMT
URLDownloader: Storing new ETag header: "8c09b172688ef4f2444f3b5031a76e7f-2"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg
{'Output': {'download_changed': True,
            'etag': '"8c09b172688ef4f2444f3b5031a76e7f-2"',
            'last_modified': 'Mon, 09 Nov 2020 21:50:36 GMT',
            'pathname': '~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg/BBEdit.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.barebones.bbedit" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = W52GZAXT98)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.lj1o4I/BBEdit.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.lj1o4I/BBEdit.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.lj1o4I/BBEdit.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg
AppDmgVersioner: BundleID: com.barebones.bbedit
AppDmgVersioner: Version: 13.5.2
{'Output': {'app_name': 'BBEdit.app',
            'bundleid': 'com.barebones.bbedit',
            'version': '13.5.2'}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/local.pkg.BBEdit/BBEdit'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/local.pkg.BBEdit/BBEdit
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/local.pkg.BBEdit/BBEdit/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/local.pkg.BBEdit/BBEdit/Applications/BBEdit.app',
           'source_path': '~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg/BBEdit.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg, dmg: .dmg/, dmg_source_path: BBEdit.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg
Copier: Copied /private/tmp/dmg.erx01G/BBEdit.app to ~/Library/AutoPkg/Cache/local.pkg.BBEdit/BBEdit/Applications/BBEdit.app
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'com.barebones.bbedit.pkg',
                           'options': 'purge_ds_store',
                           'pkgdir': '~/Library/AutoPkg/Cache/local.pkg.BBEdit',
                           'scripts': 'BBEdit_Scripts'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'com.barebones.bbedit.pkg',
                                                    'pkg_path': '~/Library/AutoPkg/Cache/local.pkg.BBEdit/BBEdit-13.5.2.pkg',
                                                    'version': '13.5.2'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '~/Library/AutoPkg/Cache/local.pkg.BBEdit/BBEdit-13.5.2.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/local.pkg.BBEdit/receipts/BBEdit-receipt-20201128-144425.plist

The following new items were downloaded:
    Download Path                                                            
    -------------                                                            
    ~/Library/AutoPkg/Cache/local.pkg.BBEdit/downloads/BBEdit.dmg  

The following packages were built:
    Identifier                Version  Pkg Path                                                              
    ----------                -------  --------                                                              
    com.barebones.bbedit.pkg  13.5.2   ~/Library/AutoPkg/Cache/local.pkg.BBEdit/BBEdit-13.5.2.pkg
```

### Test 9b: Override run, .recipe.plist:

```
% ./autopkg run -vv Fruity.pkg                                
Processing Fruity.pkg...
URLDownloader
{'Input': {'filename': 'Fruity.dmg',
           'url': 'https://www.borgcreative.com/fruity/Fruity.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 26 Nov 2020 06:45:28 GMT
URLDownloader: Storing new ETag header: "5fbf4f08-5b9cff"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/local.pkg.Fruity/downloads/Fruity.dmg
{'Output': {'download_changed': True,
            'etag': '"5fbf4f08-5b9cff"',
            'last_modified': 'Thu, 26 Nov 2020 06:45:28 GMT',
            'pathname': '~/Library/AutoPkg/Cache/local.pkg.Fruity/downloads/Fruity.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/local.pkg.Fruity/downloads/Fruity.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/local.pkg.Fruity/downloads/Fruity.dmg
AppPkgCreator: Using path '/private/tmp/dmg.3TBYZm/Fruity.app' matched from globbed '/private/tmp/dmg.3TBYZm/*.app'.
AppPkgCreator: Version: 1.9.6
AppPkgCreator: BundleID: com.BORG.Fruity
AppPkgCreator: Copied /private/tmp/dmg.3TBYZm/Fruity.app to ~/Library/AutoPkg/Cache/local.pkg.Fruity/payload/Applications/Fruity.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.BORG.Fruity',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/local.pkg.Fruity/Fruity-1.9.6.pkg',
                                                        'version': '1.9.6'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.9.6'}}
Receipt written to ~/Library/AutoPkg/Cache/local.pkg.Fruity/receipts/Fruity-receipt-20201128-144538.plist

The following new items were downloaded:
    Download Path                                                            
    -------------                                                            
    ~/Library/AutoPkg/Cache/local.pkg.Fruity/downloads/Fruity.dmg  

The following packages were built:
    Identifier       Version  Pkg Path                                                             
    ----------       -------  --------                                                             
    com.BORG.Fruity  1.9.6    ~/Library/AutoPkg/Cache/local.pkg.Fruity/Fruity-1.9.6.pkg
```

### Test 9c: Override run, .recipe.yaml:

```
% ./autopkg run -vv Coppice.pkg
Processing Coppice.pkg...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://mcubedsw.com/appcast/coppice'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 14
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2020.1
SparkleUpdateInfoProvider: Found URL https://mcubedsw.com/appcast/coppice/download/2020.1
{'Output': {'url': 'https://mcubedsw.com/appcast/coppice/download/2020.1',
            'version': '2020.1'}}
URLDownloader
{'Input': {'filename': 'Coppice-2020.1.dmg',
           'url': 'https://mcubedsw.com/appcast/coppice/download/2020.1'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/local.pkg.Coppice/downloads/Coppice-2020.1.dmg
{'Output': {'download_changed': True,
            'pathname': '~/Library/AutoPkg/Cache/local.pkg.Coppice/downloads/Coppice-2020.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/local.pkg.Coppice/downloads/Coppice-2020.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/local.pkg.Coppice/downloads/Coppice-2020.1.dmg/Coppice.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.mcubedsw.Coppice" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = K3K39KWKBV)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/local.pkg.Coppice/downloads/Coppice-2020.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.nfCj1R/Coppice.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.nfCj1R/Coppice.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.nfCj1R/Coppice.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2020.1'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/local.pkg.Coppice/downloads/Coppice-2020.1.dmg
AppPkgCreator: Using path '/private/tmp/dmg.cqxLio/Coppice.app' matched from globbed '/private/tmp/dmg.cqxLio/*.app'.
AppPkgCreator: BundleID: com.mcubedsw.Coppice
AppPkgCreator: Copied /private/tmp/dmg.cqxLio/Coppice.app to ~/Library/AutoPkg/Cache/local.pkg.Coppice/payload/Applications/Coppice.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.mcubedsw.Coppice',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/local.pkg.Coppice/Coppice-2020.1.pkg',
                                                        'version': '2020.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2020.1'}}
Receipt written to ~/Library/AutoPkg/Cache/local.pkg.Coppice/receipts/Coppice-receipt-20201128-144629.plist

The following new items were downloaded:
    Download Path                                                                     
    -------------                                                                     
    ~/Library/AutoPkg/Cache/local.pkg.Coppice/downloads/Coppice-2020.1.dmg  

The following packages were built:
    Identifier            Version  Pkg Path                                                                
    ----------            -------  --------                                                                
    com.mcubedsw.Coppice  2020.1   ~/Library/AutoPkg/Cache/local.pkg.Coppice/Coppice-2020.1.pkg
```

### Test 10a: Install verb, .recipe:

```
% ./autopkg install -vv BBEdit                                                 
Processing BBEdit.install...
WARNING: BBEdit.install is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
BarebonesURLProvider
{'Input': {'product_name': 'bbedit'}}
BarebonesURLProvider: Found URL https://s3.amazonaws.com/BBSW-download/BBEdit_13.5.2.dmg
{'Output': {'minimum_os_version': '10.14.2',
            'url': 'https://s3.amazonaws.com/BBSW-download/BBEdit_13.5.2.dmg',
            'version': '13.5.2'}}
URLDownloader
{'Input': {'filename': 'BBEdit.dmg',
           'url': 'https://s3.amazonaws.com/BBSW-download/BBEdit_13.5.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 09 Nov 2020 21:50:36 GMT
URLDownloader: Storing new ETag header: "8c09b172688ef4f2444f3b5031a76e7f-2"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg
{'Output': {'download_changed': True,
            'etag': '"8c09b172688ef4f2444f3b5031a76e7f-2"',
            'last_modified': 'Mon, 09 Nov 2020 21:50:36 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg/BBEdit.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.barebones.bbedit" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = W52GZAXT98)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.5Jd30C/BBEdit.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.5Jd30C/BBEdit.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.5Jd30C/BBEdit.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg
AppDmgVersioner: BundleID: com.barebones.bbedit
AppDmgVersioner: Version: 13.5.2
{'Output': {'app_name': 'BBEdit.app',
            'bundleid': 'com.barebones.bbedit',
            'version': '13.5.2'}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit/Applications
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit/Applications/BBEdit.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg/BBEdit.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg, dmg: .dmg/, dmg_source_path: BBEdit.app
Copier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg
Copier: Copied /private/tmp/dmg.2tvyB9/BBEdit.app to ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit/Applications/BBEdit.app
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'com.barebones.bbedit.pkg',
                           'options': 'purge_ds_store',
                           'pkgdir': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit',
                           'scripts': 'BBEdit_Scripts'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'com.barebones.bbedit.pkg',
                                                    'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit-13.5.2.pkg',
                                                    'version': '13.5.2'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit-13.5.2.pkg'}}
Installer
{'Input': {'download_changed': True,
           'new_package_request': True,
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit-13.5.2.pkg'}}
Installer: Connecting
Installer: Sending installation request
Installer: STATUS:installer: Package name is BBEdit-13.5.2
Installer: STATUS:installer: Upgrading at base path /
Installer: STATUS:installer:PHASE:Preparing for installation…
Installer: STATUS:installer:PHASE:Preparing the disk…
Installer: STATUS:installer:PHASE:Preparing BBEdit-13.5.2…
Installer: STATUS:installer:PHASE:Waiting for other installations to complete…
Installer: STATUS:installer:PHASE:Configuring the installation…
Installer: STATUS:installer:STATUS:
Installer: STATUS:installer:%20.452108
Installer: STATUS:installer:PHASE:Writing files…
Installer: STATUS:installer:%47.150998
Installer: STATUS:installer:PHASE:Removing old files…
Installer: STATUS:installer:%84.913806
Installer: STATUS:installer:PHASE:Running package scripts…
Installer: STATUS:installer:PHASE:Validating packages…
Installer: STATUS:installer:%97.750000
Installer: STATUS:installer:STATUS:
Installer: STATUS:installer:PHASE:Finishing the Installation…
Installer: STATUS:installer:STATUS:
Installer: STATUS:installer:%100.000000
Installer: STATUS:installer:PHASE:The software was successfully installed.
Installer: STATUS:installer: The upgrade was successful.
Installer: Disconnecting
Installer: Result: DONE
{'Output': {'install_result': 'DONE',
            'installer_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit-13.5.2.pkg'},
                                         'summary_text': 'The following pkgs '
                                                         'were successfully '
                                                         'installed:'}}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/receipts/BBEdit-receipt-20201128-144903.plist

The following new items were downloaded:
    Download Path                                                                             
    -------------                                                                             
    ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/downloads/BBEdit.dmg  

The following packages were built:
    Identifier                Version  Pkg Path                                                                               
    ----------                -------  --------                                                                               
    com.barebones.bbedit.pkg  13.5.2   ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit-13.5.2.pkg  

The following pkgs were successfully installed:
    Pkg Path                                                                               
    --------                                                                               
    ~/Library/AutoPkg/Cache/com.github.autopkg.install.BBEdit/BBEdit-13.5.2.pkg
```

### Test 10b: Install verb, .recipe.plist:

```
% ./autopkg install -vv Fruity
Processing Fruity.install...
WARNING: Fruity.install is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Fruity.dmg',
           'url': 'https://www.borgcreative.com/fruity/Fruity.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 26 Nov 2020 06:45:28 GMT
URLDownloader: Storing new ETag header: "5fbf4f08-5b9cff"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.install.Fruity/downloads/Fruity.dmg
{'Output': {'download_changed': True,
            'etag': '"5fbf4f08-5b9cff"',
            'last_modified': 'Thu, 26 Nov 2020 06:45:28 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.install.Fruity/downloads/Fruity.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.install.Fruity/downloads/Fruity.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
InstallFromDMG
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.homebysix.install.Fruity/downloads/Fruity.dmg',
           'download_changed': True,
           'items_to_copy': [{'destination_path': '/Applications',
                              'source_item': 'Fruity.app'}]}}
InstallFromDMG: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.install.Fruity/downloads/Fruity.dmg
InstallFromDMG: Connecting
InstallFromDMG: Sending installation request
InstallFromDMG: STATUS:Copying Fruity.app to /Applications/Fruity.app
InstallFromDMG: Disconnecting
InstallFromDMG: Result: DONE
{'Output': {'install_from_dmg_summary_result': {'data': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.homebysix.install.Fruity/downloads/Fruity.dmg'},
                                                'summary_text': 'Items from '
                                                                'the following '
                                                                'disk images '
                                                                'were '
                                                                'successfully '
                                                                'installed:'},
            'install_result': 'DONE'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.install.Fruity/receipts/Fruity-receipt-20201128-144933.plist

The following new items were downloaded:
    Download Path                                                                               
    -------------                                                                               
    ~/Library/AutoPkg/Cache/com.github.homebysix.install.Fruity/downloads/Fruity.dmg  

Items from the following disk images were successfully installed:
    Dmg Path                                                                                    
    --------                                                                                    
    ~/Library/AutoPkg/Cache/com.github.homebysix.install.Fruity/downloads/Fruity.dmg
```

### Test 10c: Install verb, .recipe.yaml:

```
% ./autopkg install -vv Coppice
Processing Coppice.install...
WARNING: Coppice.install is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://mcubedsw.com/appcast/coppice'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 14
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2020.1
SparkleUpdateInfoProvider: Found URL https://mcubedsw.com/appcast/coppice/download/2020.1
{'Output': {'url': 'https://mcubedsw.com/appcast/coppice/download/2020.1',
            'version': '2020.1'}}
URLDownloader
{'Input': {'filename': 'Coppice-2020.1.dmg',
           'url': 'https://mcubedsw.com/appcast/coppice/download/2020.1'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg
{'Output': {'download_changed': True,
            'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg/Coppice.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.mcubedsw.Coppice" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = K3K39KWKBV)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.0kAHli/Coppice.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.0kAHli/Coppice.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.0kAHli/Coppice.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
InstallFromDMG
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg',
           'download_changed': True,
           'items_to_copy': [{'destination_path': '/Applications',
                              'source_item': 'Coppice.app'}]}}
InstallFromDMG: Mounted disk image ~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg
InstallFromDMG: Connecting
InstallFromDMG: Sending installation request
InstallFromDMG: STATUS:Copying Coppice.app to /Applications/Coppice.app
InstallFromDMG: Disconnecting
InstallFromDMG: Result: DONE
{'Output': {'install_from_dmg_summary_result': {'data': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg'},
                                                'summary_text': 'Items from '
                                                                'the following '
                                                                'disk images '
                                                                'were '
                                                                'successfully '
                                                                'installed:'},
            'install_result': 'DONE'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/receipts/Coppice-receipt-20201128-145021.plist

The following new items were downloaded:
    Download Path                                                                                        
    -------------                                                                                        
    ~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg  

Items from the following disk images were successfully installed:
    Dmg Path                                                                                             
    --------                                                                                             
    ~/Library/AutoPkg/Cache/com.github.homebysix.install.Coppice/downloads/Coppice-2020.1.dmg
```

### Test 11a: Recipe audit, .recipe:

```
% ./autopkg audit BBEdit.pkg
BBEdit.pkg
    File path:        ~/Library/AutoPkg/RecipeOverrides/BBEdit.pkg.recipe
    Parent recipe(s): ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BBEdit.pkg.recipe
                      ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Barebones/BBEdit.download.recipe
    The following processors are non-core and can execute arbitrary code, performing any action.
    Be sure you understand what the processor does and/or you trust its source:
        BarebonesURLProvider
    The following processors make modifications and their use in this recipe should be more closely inspected:
        PkgCreator
        Copier
```

### Test 11b: Recipe audit, .recipe.plist:

```
% ./autopkg audit Fruity.pkg
Fruity.pkg
    File path:        ~/Library/AutoPkg/RecipeOverrides/Fruity.pkg.recipe.plist
    Parent recipe(s): ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Fruity/Fruity.pkg.recipe.plist
                      ~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/Fruity/Fruity.download.recipe.plist
    Missing CodeSignatureVerifier
```

### Test 11c: Recipe audit, .recipe.yaml:

```
% ./autopkg audit Coppice.pkg
Coppice.pkg: no audit flags triggered.
```

### Test 12a: New recipe, .recipe:

```
% ./autopkg new-recipe Test.pkg.recipe     
Saved new recipe to Test.pkg.recipe
```

```
% cat Test.pkg.recipe
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Description</key>
    <string>Recipe description</string>
    <key>Identifier</key>
    <string>local.Test</string>
    <key>Input</key>
    <dict>
        <key>NAME</key>
        <string>Test</string>
    </dict>
    <key>MinimumVersion</key>
    <string>1.0</string>
    <key>Process</key>
    <array>
        <dict>
            <key>Arguments</key>
            <dict>
                <key>Argument1</key>
                <string>Value1</string>
                <key>Argument2</key>
                <string>Value2</string>
            </dict>
            <key>Processor</key>
            <string>ProcessorName</string>
        </dict>
    </array>
</dict>
</plist>
```

### Test 12b: New recipe, .recipe.plist:

```
% ./autopkg new-recipe Test.pkg.recipe.plist
Saved new recipe to Test.pkg.recipe.plist
```

```
% cat Test.pkg.recipe.plist       
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Description</key>
    <string>Recipe description</string>
    <key>Identifier</key>
    <string>local.Test</string>
    <key>Input</key>
    <dict>
        <key>NAME</key>
        <string>Test</string>
    </dict>
    <key>MinimumVersion</key>
    <string>1.0</string>
    <key>Process</key>
    <array>
        <dict>
            <key>Arguments</key>
            <dict>
                <key>Argument1</key>
                <string>Value1</string>
                <key>Argument2</key>
                <string>Value2</string>
            </dict>
            <key>Processor</key>
            <string>ProcessorName</string>
        </dict>
    </array>
</dict>
</plist>
```

### Test 12c: New recipe, .recipe.yaml:

Method 1, using filename extension:

```
% ./autopkg new-recipe Test1.pkg.recipe.yaml   
Saved new recipe to Test1.pkg.recipe.yaml
```

```
% cat Test1.pkg.recipe.yaml       
Description: Recipe description
Identifier: local.Test1
Input:
  NAME: Test1
MinimumVersion: '2.3'
Process:
- Arguments:
    Argument1: Value1
    Argument2: Value2
  Processor: ProcessorName
```

Method 2: using `--format=yaml`:

```
% ./autopkg new-recipe Test2 --format=yaml                
Saved new recipe to Test2
```

```
% cat Test2
Description: Recipe description
Identifier: local.Test2
Input:
  NAME: Test2
MinimumVersion: '2.3'
Process:
- Arguments:
    Argument1: Value1
    Argument2: Value2
  Processor: ProcessorName
```

### Test 13a: Search for recipe, .recipe:

```
% ./autopkg search Thunderbird            

Name                                Repo                     Path                                    
----                                ----                     ----                                    
GPGSuiteUniversal.munki.recipe      gerardkok-recipes        GPGTools/GPGSuiteUniversal.munki.recipe
GPGSuite.munki.recipe               gerardkok-recipes        GPGTools/GPGSuite.munki.recipe          
Thunderbird-Win.download.recipe     hansen-m-recipes         Mozilla/Thunderbird-Win.download.recipe
Thunderbird.jss.recipe              jss-recipes              Thunderbird/Thunderbird.jss.recipe      
OpenSC.munki.recipe                 n8felton-recipes         OpenSC/OpenSC.munki.recipe              
Thunderbird.filewave.recipe         peshay-recipes           Mozilla/Thunderbird.filewave.recipe     
Thunderbird.munki.recipe            recipes                  Mozilla/Thunderbird.munki.recipe        
Thunderbird.pkg.recipe              recipes                  Mozilla/Thunderbird.pkg.recipe          
Thunderbird.download.recipe         recipes                  Mozilla/Thunderbird.download.recipe     
Enigmail.download.recipe            tallfunnyjew-recipes     Enigmail/Enigmail.download.recipe       

To add a new recipe repo, use 'autopkg repo-add <repo name>'
```

### Test 13b: Search for recipe, .recipe.plist:

```
% ./autopkg search Fruity

Name                             Repo                  Path                                    
----                             ----                  ----                                    
Fruity.download.recipe.plist     homebysix-recipes     Fruity/Fruity.download.recipe.plist     
Fruity.install.recipe.plist      homebysix-recipes     Fruity/Fruity.install.recipe.plist      
Fruity.pkg.recipe.plist          homebysix-recipes     Fruity/Fruity.pkg.recipe.plist          
Fruity.munki.recipe.plist        homebysix-recipes     Fruity/Fruity.munki.recipe.plist        

To add a new recipe repo, use 'autopkg repo-add <repo name>'
```

### Test 13c: Search for recipe, .recipe.yaml:

```
% ./autopkg search Coppice

Name                             Repo                  Path                                    
----                             ----                  ----                                    
Coppice.download.recipe.yaml     homebysix-recipes     Coppice/Coppice.download.recipe.yaml    
Coppice.install.recipe.yaml      homebysix-recipes     Coppice/Coppice.install.recipe.yaml     
Coppice.munki.recipe.yaml        homebysix-recipes     Coppice/Coppice.munki.recipe.yaml       
Coppice.pkg.recipe.yaml          homebysix-recipes     Coppice/Coppice.pkg.recipe.yaml         

To add a new recipe repo, use 'autopkg repo-add <repo name>'
```
