### PR TITLE
Update DmgMounter.py

### DIFF
--- a/Code/autopkglib/DmgMounter.py
+++ b/Code/autopkglib/DmgMounter.py
@@ -116,7 +116,7 @@ class DmgMounter(Processor):
                     "attach",
                     "-plist",
                     "-mountrandom",
-                    "/private/tmp",
+                    "/Volumes",
                     "-nobrowse",
                     pathname,
                 ),


### PR DESCRIPTION
on macOS Big Sur attempting to mount a DMG with hdiutil at /private/tmp throws an error 
"hdiutil: attach failed - no mountable file systems"

(Example of current command format /usr/bin/hdiutil attach -mountrandom /private/tmp -nobrowse ~/Documents/test.dmg)

Mounting at /Volumes seems to fix this issue. I've opened a ticket with AppleCare Enterprise support on the underlying issue with hdiutil. 