### PR TITLE
Update unit tests for platform detection

### DIFF
--- a/Code/tests/test_autopkglib.py
+++ b/Code/tests/test_autopkglib.py
@@ -139,77 +139,73 @@ class TestAutoPkg(unittest.TestCase):
     def tearDown(self):
         pass
 
-    @patch("autopkglib.platform.platform")
-    def test_is_mac_returns_true_on_mac(self, mock_platform):
+    @patch("autopkglib.sys")
+    def test_is_mac_returns_true_on_mac(self, mock_sys):
         """On macOS, is_mac() should return True."""
-        mock_platform.return_value = "Darwin-somethingsomething"
+        mock_sys.platform = "Darwin-somethingsomething"
         result = autopkglib.is_mac()
         self.assertEqual(result, True)
 
-    @patch("autopkglib.platform.platform")
-    def test_is_mac_returns_false_on_not_mac(self, mock_platform):
+    @patch("autopkglib.sys")
+    def test_is_mac_returns_false_on_not_mac(self, mock_sys):
         """On not-macOS, is_mac() should return False."""
-        mock_platform.return_value = "Windows-somethingsomething"
+        mock_sys.platform = "Win32-somethingsomething"
         result = autopkglib.is_mac()
         self.assertEqual(result, False)
 
-    @patch("autopkglib.platform.platform")
-    def test_is_windows_returns_true_on_windows(self, mock_platform):
+    @patch("autopkglib.sys")
+    def test_is_windows_returns_true_on_windows(self, mock_sys):
         """On Windows, is_windows() should return True."""
-        mock_platform.return_value = "Windows-somethingsomething"
+        mock_sys.platform = "Win32-somethingsomething"
         result = autopkglib.is_windows()
         self.assertEqual(result, True)
 
-    @patch("autopkglib.platform.platform")
-    def test_is_windows_returns_false_on_not_windows(self, mock_platform):
+    @patch("autopkglib.sys")
+    def test_is_windows_returns_false_on_not_windows(self, mock_sys):
         """On not-Windows, is_windows() should return False."""
-        mock_platform.return_value = "Darwin-somethingsomething"
+        mock_sys.platform = "Darwin-somethingsomething"
         result = autopkglib.is_windows()
         self.assertEqual(result, False)
 
-    @patch("autopkglib.platform.platform")
-    def test_is_linux_returns_true_on_linux(self, mock_platform):
+    @patch("autopkglib.sys")
+    def test_is_linux_returns_true_on_linux(self, mock_sys):
         """On Linux, is_linux() should return True."""
-        mock_platform.return_value = "Linux-somethingsomething"
+        mock_sys.platform = "Linux-somethingsomething"
         result = autopkglib.is_linux()
         self.assertEqual(result, True)
 
-    @patch("autopkglib.platform.platform")
-    def test_is_linux_returns_false_on_not_linux(self, mock_platform):
+    @patch("autopkglib.sys")
+    def test_is_linux_returns_false_on_not_linux(self, mock_sys):
         """On not-Linux, is_linux() should return False."""
-        mock_platform.return_value = "Windows-somethingsomething"
+        mock_sys.platform = "Win32-somethingsomething"
         result = autopkglib.is_linux()
         self.assertEqual(result, False)
 
-    @patch("autopkglib.platform.platform")
+    @patch("autopkglib.sys")
     @patch("autopkglib.is_executable")
     @patch("autopkglib.os.get_exec_path")
     @patch("autopkglib.os.path")
-    def test_find_binary_windows(
-        self, mock_ospath, mock_getpath, mock_isexe, mock_platform
-    ):
+    def test_find_binary_windows(self, mock_ospath, mock_getpath, mock_isexe, mock_sys):
         # Forcibly use ntpath regardless of platform to test "windows" anywhere.
         import ntpath
 
         mock_ospath.join = ntpath.join
-        mock_platform.return_value = "Windows"
+        mock_sys.platform = "Win32"
         mock_getpath.return_value = [r"C:\Windows\system32", r"C:\CurlInstall"]
         mock_isexe.side_effect = [False, True]
         result = autopkglib.find_binary("curl")
         self.assertEqual(result, r"C:\CurlInstall\curl.exe")
 
-    @patch("autopkglib.platform.platform")
+    @patch("autopkglib.sys")
     @patch("autopkglib.is_executable")
     @patch("autopkglib.os.get_exec_path")
     @patch("autopkglib.os.path")
-    def test_find_binary_posixy(
-        self, mock_ospath, mock_getpath, mock_isexe, mock_platform
-    ):
+    def test_find_binary_posixy(self, mock_ospath, mock_getpath, mock_isexe, mock_sys):
         # Forcibly use posixpath regardless of platform to test "linux/mac" anywhere.
         import posixpath
 
         mock_ospath.join = posixpath.join
-        mock_platform.return_value = "Darwin"
+        mock_sys.platform = "Darwin"
         mock_getpath.return_value = ["/usr/bin", "/usr/local/bin"]
         mock_isexe.side_effect = [True, False]
         result = autopkglib.find_binary("curl")

--- a/Code/tests/test_preferences.py
+++ b/Code/tests/test_preferences.py
@@ -45,7 +45,7 @@ class TestPreferences(unittest.TestCase):
 
     def setUp(self):
         self._workdir = TemporaryDirectory()
-        self.mock_platform = patch("autopkglib.platform.platform").start()
+        self.mock_platform = patch("autopkglib.sys.platform").start()
         # Force loading to go through the file-backed path by default.
         self.mock_platform.return_value = "__HighlyUnlikely-Platform-Name__"
 


### PR DESCRIPTION
AutoPkg's platform detection was changed from `platform.platform()` to `sys.platform` in https://github.com/autopkg/autopkg/commit/8ec51f0cf517eaa472c9147a5cd3fb29225107f5. This PR updates the unit tests to match this change.

Test results:

```
% /usr/local/autopkg/python -m unittest -v tests.test_autopkglib
test_find_binary_posixy (tests.test_autopkglib.TestAutoPkg) ... ok
test_find_binary_windows (tests.test_autopkglib.TestAutoPkg) ... ok
test_get_identifier_from_recipe_file_returns_identifier (tests.test_autopkglib.TestAutoPkg)
get_identifier_from_recipe_file should return identifier. ... ok
test_get_identifier_from_recipe_file_returns_none (tests.test_autopkglib.TestAutoPkg)
get_identifier_from_recipe_file should return None if no identifier. ... WARNING: plist error for fake: __enter__
ok
test_get_identifier_returns_identifier (tests.test_autopkglib.TestAutoPkg)
get_identifier should return the identifier. ... ok
test_get_identifier_returns_none (tests.test_autopkglib.TestAutoPkg)
get_identifier should return None if no identifier is found. ... ok
test_is_linux_returns_false_on_not_linux (tests.test_autopkglib.TestAutoPkg)
On not-Linux, is_linux() should return False. ... ok
test_is_linux_returns_true_on_linux (tests.test_autopkglib.TestAutoPkg)
On Linux, is_linux() should return True. ... ok
test_is_mac_returns_false_on_not_mac (tests.test_autopkglib.TestAutoPkg)
On not-macOS, is_mac() should return False. ... ok
test_is_mac_returns_true_on_mac (tests.test_autopkglib.TestAutoPkg)
On macOS, is_mac() should return True. ... ok
test_is_windows_returns_false_on_not_windows (tests.test_autopkglib.TestAutoPkg)
On not-Windows, is_windows() should return False. ... ok
test_is_windows_returns_true_on_windows (tests.test_autopkglib.TestAutoPkg)
On Windows, is_windows() should return True. ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.028s

OK
```

There is still an issue with the test_preferences.py as of this branch, but I'm limiting the scope here to the platform detection change.