### PR TITLE
Update MunkiImporter.py

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -388,7 +388,7 @@ class MunkiImporter(Processor):
             uninstall_path = library.copy_pkg_to_repo(
                 pkginfo, self.env.get("uninstaller_pkg_path")
             )
-            pkginfo["uninstaller_item_location"] = uninstall_path
+            pkginfo["uninstaller_item_location"] = uninstall_path.partition("pkgs/")[2]
             pkginfo["uninstallable"] = True
 
         # import icon


### PR DESCRIPTION
Corrects an issue where `uninstaller_item_location` contained the full repo path and not the local path.

Pre this PR:
```
<key>uninstaller_item_location</key>
<string>/Users/Shared/munki_repo/pkgs/apps/Adobe/AdobeIllustrator2021_Uninstall-25.1.0.dmg</string>
```
Post:
```
<key>uninstaller_item_location</key>
<string>apps/Adobe/AdobeIllustrator2021_Uninstall-25.1.0.dmg</string>
```

The incorrect path within the `uninstaller_item_location` then makes makecatalogs warn etc... so this corrects