### PR TITLE
Decode binary extended attribute strings in URLDownloader

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -113,7 +113,7 @@ class URLDownloader(URLGetter):
         """Get a named xattr from a file. Return None if not present."""
 
         if attr in xattr.listxattr(self.env["pathname"]):
-            return xattr.getxattr(self.env["pathname"], attr)
+            return xattr.getxattr(self.env["pathname"], attr).decode()
         return None
 
     def prepare_base_curl_cmd(self):


### PR DESCRIPTION
This change is meant to resolve https://github.com/autopkg/autopkg/issues/713, wherein evaluation of `etag` and `last-modified` headers fail due to comparison of binary strings to text strings.

This `.decode()` was present in AutoPkg 2.2, but was removed in 5ba42491feb9a255c23ed0bf0eb221b9292aa382.

AutoPkg run output follows:

## Resolution of unnecessary re-download

1. First run of Chrome download:

        % ./Code/autopkg run -vvcq GoogleChrome.download
        Processing GoogleChrome.download...
        WARNING: GoogleChrome.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
        URLDownloader
        {'Input': {'filename': 'GoogleChrome.dmg',
                   'url': 'https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg'}}
        URLDownloader: No value supplied for prefetch_filename, setting default value of: False
        URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
        URLDownloader: Storing new Last-Modified header: Sat, 13 Feb 2021 05:20:45 GMT
        URLDownloader: Storing new ETag header: "85fb96"
        URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg
        {'Output': {'download_changed': True,
                    'etag': '"85fb96"',
                    'last_modified': 'Sat, 13 Feb 2021 05:20:45 GMT',
                    'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg',
                    'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg'},
                                                      'summary_text': 'The following '
                                                                      'new items were '
                                                                      'downloaded:'}}}
        EndOfCheckPhase
        {'Input': {}}
        {'Output': {}}
        Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/receipts/GoogleChrome-receipt-20210220-162512.plist

        The following new items were downloaded:
            Download Path
            -------------
            ~/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg

1. Second run (using cache instead of re-downloading):

        % ./Code/autopkg run -vvcq GoogleChrome.download
        Processing GoogleChrome.download...
        WARNING: GoogleChrome.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
        URLDownloader
        {'Input': {'filename': 'GoogleChrome.dmg',
                   'url': 'https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg'}}
        URLDownloader: No value supplied for prefetch_filename, setting default value of: False
        URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
        URLDownloader: Item at URL is unchanged.
        URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg
        {'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/downloads/GoogleChrome.dmg'}}
        EndOfCheckPhase
        {'Input': {}}
        {'Output': {}}
        Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.download.googlechrome/receipts/GoogleChrome-receipt-20210220-162624.plist

        Nothing downloaded, packaged or imported.

## Resolution of failed re-download

1. First run of NativeConnect download:

        % ./Code/autopkg run -vvcq NativeConnect.download
        Processing NativeConnect.download...
        WARNING: NativeConnect.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
        URLTextSearcher
        {'Input': {'re_pattern': '"id":(\\d+),',
                   'result_output_var_name': 'release_id',
                   'url': 'https://install.appcenter.ms/api/v0.1/apps/vadim.shpakovski/nativeconnect/distribution_groups/public/public_releases'}}
        URLTextSearcher: Found matching text (release_id): 237
        {'Output': {'release_id': '237'}}
        URLTextSearcher
        {'Input': {'re_pattern': '"download_url":"(https:\\/\\/.+\\.app\\.zip\\?.+)","install_url":',
                   'result_output_var_name': 'url',
                   'url': 'https://install.appcenter.ms/api/v0.1/apps/vadim.shpakovski/nativeconnect/distribution_groups/public/releases/237'}}
        URLTextSearcher: Found matching text (url): https://appcenter-filemanagement-distrib1ede6f06e.azureedge.net/7925c789-5201-447b-859b-c006058ef156/NativeConnect-1.2.11-457D2D2.app.zip?sv=2019-02-02&sr=c&sig=dpItr%2F7yg%2F4KklhL8iJDf5iES77FNzbLFwIfBhHrL44%3D&se=2021-02-21T11%3A33%3A40Z&sp=r
        {'Output': {'url': 'https://appcenter-filemanagement-distrib1ede6f06e.azureedge.net/7925c789-5201-447b-859b-c006058ef156/NativeConnect-1.2.11-457D2D2.app.zip?sv=2019-02-02&sr=c&sig=dpItr%2F7yg%2F4KklhL8iJDf5iES77FNzbLFwIfBhHrL44%3D&se=2021-02-21T11%3A33%3A40Z&sp=r'}}
        URLDownloader
        {'Input': {'filename': 'NativeConnect.zip',
                   'url': 'https://appcenter-filemanagement-distrib1ede6f06e.azureedge.net/7925c789-5201-447b-859b-c006058ef156/NativeConnect-1.2.11-457D2D2.app.zip?sv=2019-02-02&sr=c&sig=dpItr%2F7yg%2F4KklhL8iJDf5iES77FNzbLFwIfBhHrL44%3D&se=2021-02-21T11%3A33%3A40Z&sp=r'}}
        URLDownloader: No value supplied for prefetch_filename, setting default value of: False
        URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
        URLDownloader: Storing new Last-Modified header: Mon, 07 Sep 2020 08:33:09 GMT
        URLDownloader: Storing new ETag header: "0x8D85308A674FEA4"
        URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.download.NativeConnect/downloads/NativeConnect.zip
        {'Output': {'download_changed': True,
                    'etag': '"0x8D85308A674FEA4"',
                    'last_modified': 'Mon, 07 Sep 2020 08:33:09 GMT',
                    'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.NativeConnect/downloads/NativeConnect.zip',
                    'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.NativeConnect/downloads/NativeConnect.zip'},
                                                      'summary_text': 'The following '
                                                                      'new items were '
                                                                      'downloaded:'}}}
        EndOfCheckPhase
        {'Input': {}}
        {'Output': {}}
        Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.NativeConnect/receipts/NativeConnect-receipt-20210220-162704.plist

        The following new items were downloaded:
            Download Path
            -------------
            ~/Library/AutoPkg/Cache/com.github.homebysix.download.NativeConnect/downloads/NativeConnect.zip

1. Second run (using cache instead of re-downloading):

        % ./Code/autopkg run -vvcq NativeConnect.download
        Processing NativeConnect.download...
        WARNING: NativeConnect.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
        URLTextSearcher
        {'Input': {'re_pattern': '"id":(\\d+),',
                   'result_output_var_name': 'release_id',
                   'url': 'https://install.appcenter.ms/api/v0.1/apps/vadim.shpakovski/nativeconnect/distribution_groups/public/public_releases'}}
        URLTextSearcher: Found matching text (release_id): 237
        {'Output': {'release_id': '237'}}
        URLTextSearcher
        {'Input': {'re_pattern': '"download_url":"(https:\\/\\/.+\\.app\\.zip\\?.+)","install_url":',
                   'result_output_var_name': 'url',
                   'url': 'https://install.appcenter.ms/api/v0.1/apps/vadim.shpakovski/nativeconnect/distribution_groups/public/releases/237'}}
        URLTextSearcher: Found matching text (url): https://appcenter-filemanagement-distrib1ede6f06e.azureedge.net/7925c789-5201-447b-859b-c006058ef156/NativeConnect-1.2.11-457D2D2.app.zip?sv=2019-02-02&sr=c&sig=dpItr%2F7yg%2F4KklhL8iJDf5iES77FNzbLFwIfBhHrL44%3D&se=2021-02-21T11%3A33%3A40Z&sp=r
        {'Output': {'url': 'https://appcenter-filemanagement-distrib1ede6f06e.azureedge.net/7925c789-5201-447b-859b-c006058ef156/NativeConnect-1.2.11-457D2D2.app.zip?sv=2019-02-02&sr=c&sig=dpItr%2F7yg%2F4KklhL8iJDf5iES77FNzbLFwIfBhHrL44%3D&se=2021-02-21T11%3A33%3A40Z&sp=r'}}
        URLDownloader
        {'Input': {'filename': 'NativeConnect.zip',
                   'url': 'https://appcenter-filemanagement-distrib1ede6f06e.azureedge.net/7925c789-5201-447b-859b-c006058ef156/NativeConnect-1.2.11-457D2D2.app.zip?sv=2019-02-02&sr=c&sig=dpItr%2F7yg%2F4KklhL8iJDf5iES77FNzbLFwIfBhHrL44%3D&se=2021-02-21T11%3A33%3A40Z&sp=r'}}
        URLDownloader: No value supplied for prefetch_filename, setting default value of: False
        URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
        URLDownloader: Item at URL is unchanged.
        URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.NativeConnect/downloads/NativeConnect.zip
        {'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.NativeConnect/downloads/NativeConnect.zip'}}
        EndOfCheckPhase
        {'Input': {}}
        {'Output': {}}
        Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.NativeConnect/receipts/NativeConnect-receipt-20210220-162804.plist

        Nothing downloaded, packaged or imported.

## No regressions in behavior from 2.2

I ran a selection of 100 random recipes from the autopkg org repos, twice using the master branch and twice using the changes from this PR. The exit codes are listed below — the goal is not to ensure that the runs all exit zero, but rather to ensure that the exit codes before the change remain consistent with the exit codes after the change. All were consistent.

| Recipe                                                                                                       | master run 1 | master run 2 | PR run 1 | PR run 2 | Consistent |
| ------------------------------------------------------------------------------------------------------------ | :----------: | :----------: | :------: | :------: | :--------: |
| com.github.autopkg.dataJAR-recipes/Polycom Content App/PolycomContentApp.download.recipe                     |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.thenikola-recipes/DiskWave/DiskWave.download.recipe                                       |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.haircut-recipes/VIDVOX/VDMX5.download.recipe                                              |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.arubdesu-recipes/JetBrainsToolbox/JetBrainsToolbox.download.recipe                        |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.joshua-d-miller-recipes/GeoGebra/GeoGebra.download.recipe                                 |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.macprince-recipes/Edovia/Screens 4.download.recipe                                        |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.n8felton-recipes/Weka/Weka.download.recipe                                                |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.rtrouton-recipes/EndNote/EndNoteX9.download.recipe                                        |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.homebysix-recipes/RogueAmoeba/Piezo.download.recipe                                       |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.orbsmiv-recipes/ReaperSWS/ReaperSWS.download.recipe                                       |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.hjuutilainen-recipes/Blender/Blender.download.recipe                                      |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.homebysix-recipes/Tunabelly/TGPro.download.recipe                                         |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.dataJAR-recipes/Apple Mastering Tools/Apple Mastering Tools.download.recipe               |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.keeleysam-recipes/Quicksilver/Quicksilver.download.recipe                                 |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.hansen-m-recipes/MakerBot/MakerBotPrint.download.recipe                                   |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.peshay-recipes/PingPlotter/PingPlotter.download.recipe                                    |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.dataJAR-recipes/Polar FlowSync/FlowSync.download.recipe                                   |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.homebysix-recipes/FoldingText/FoldingText.download.recipe                                 |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.mosen-recipes/JetBrains/PhpStorm.download.recipe                                          |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.homebysix-recipes/RainerBrockerhoff/RBAppCheckerLite.download.recipe                      |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.hjuutilainen-recipes/Packages/Packages.download.recipe                                    |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.jps3-recipes/InVesalius/InVesalius.download.recipe                                        |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.golbiga-recipes/Webex Teams/Webex Teams.download.recipe                                   |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.homebysix-recipes/Kubernetes/kubectl.download.recipe                                      |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.foigus-recipes/Google/GoogleChromeCanary.download.recipe                                  |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.macprince-recipes/DigiDNA/Silicon.download.recipe                                         |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.dataJAR-recipes/Axure RP 8-Trial/Axure RP 8-Trial.download.recipe                         |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.arubdesu-recipes/WWDC/WWDC.download.recipe                                                |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.rustymyers-recipes/Wacom/WacomIntuos-Win.download.recipe                                  |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.andrewvalentine-recipes/Winds/Winds.download.recipe                                       |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.moofit-recipes/Autodesk/AutoCAD.download.recipe                                           |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.peshay-recipes/InstallDiskCreator/InstallDiskCreator.download.recipe                      |      0       |      70      |    0     |    70    |     ✅      |
| com.github.autopkg.apizz-recipes/Modul8/Modul8.download.recipe                                               |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.foigus-recipes/ZevrixSolutions/OutputFactory.download.recipe                              |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.novaksam-recipes/Recipes - Download/TechsmithRelay.download.recipe                        |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.homebysix-recipes/RightFont/RightFont.download.recipe                                     |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.hansen-m-recipes/ProjectLibre/ProjectLibre.download.recipe                                |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.hansen-m-recipes/UnixUtils/7zip-Win.download.recipe                                       |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.nstrauss-recipes/Vendini Box Office/VendiniBoxOffice.download.recipe                      |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.hansen-m-recipes/MacTeX/MacTeX.download.recipe                                            |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.andrewvalentine-recipes/past/past.download.recipe                                         |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.n8felton-recipes/Flixel/Cinemagraph Pro.download.recipe                                   |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.andrewvalentine-recipes/Mounty/Mounty.download.recipe                                     |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.apizz-recipes/Unity/Unity3DDocumentation.download.recipe                                  |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.wardsparadox-recipes/Mayur Pawashe/Komet.download.recipe                                  |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.foigus-recipes/Incident57/Muzzle.download.recipe                                          |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.swy-recipes/Flixel Photos Inc./CinemagraphPro.download.recipe                             |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.eholtam-recipes/AvidCodecsLE/AvidCodecsLE.download.recipe                                 |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.orchard-recipes/Heroku/HerokuToolbelt.download.recipe                                     |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.arubdesu-recipes/RedSweater/MarsEdit.download.recipe                                      |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.dataJAR-recipes/Blue Jeans Scheduler for Mac/Blue Jeans Scheduler for Mac.download.recipe |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.macprince-recipes/Tapbots/Tweetbot.download.recipe                                        |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.its-unibas-recipes/SWITCHdrive/SWITCHdrive.download.recipe                                |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.hjuutilainen-recipes/CheatSheet/CheatSheet.download.recipe                                |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.dataJAR-recipes/Kaspersky Network Agent/Kaspersky Network Agent.download.recipe           |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.n8felton-recipes/MAMP/MAMP.download.recipe                                                |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.bradclare-recipes/FileMaker/FileMakerServer13.download.recipe                             |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.apizz-recipes/Sqwarq/CriticalUpdates.download.recipe                                      |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.rustymyers-recipes/Linden Lab/SecondLife.download.recipe                                  |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.ahousseini-recipes/Chromium/Chromium.download.recipe                                      |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.foigus-recipes/Amazon/KindleCreate.download.recipe                                        |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.aysiu-recipes/ScratchDesktop/ScratchDesktop.download.recipe                               |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.grahampugh-recipes/Rosetta2/Rosetta2.download.recipe                                      |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.ahousseini-recipes/BookWidgets/BookWidgets.download.recipe                                |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.erikng-recipes/Genymobile/Genymotion.download.recipe                                      |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.jazzace-recipes/HairerSoft/AmadeusLite.download.recipe                                    |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.nstrauss-recipes/Restor/Restor.download.recipe                                            |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.dataJAR-recipes/RAW Viewer/RAW Viewer.download.recipe                                     |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.hjuutilainen-recipes/Flowdock/Flowdock.download.recipe                                    |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.recipes/The Unarchiver/TheUnarchiver.download.recipe                                      |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.homebysix-recipes/KeePassX/KeePassX.download.recipe                                       |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.andrewvalentine-recipes/xact/xact.download.recipe                                         |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.rustymyers-recipes/Microsoft/MSdotNetFramework.download.recipe                            |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.andrewzirkel-recipes/NWEA Lockdown Browser/NWEA Lockdown Browser.download.recipe          |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.aysiu-recipes/LockDownBrowser/LockDownBrowser.download.recipe                             |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.mosen-recipes/ItsApparent/BarcodeProducer.download.recipe                                 |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.ygini-recipes/Sconnect/Sconnect.download.recipe                                           |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.homebysix-recipes/Smultron/Smultron.download.recipe                                       |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.dataJAR-recipes/KeeWeb/KeeWeb.download.recipe                                             |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.ahousseini-recipes/Magic Number Machine/Magic Number Machine.download.recipe              |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.gerardkok-recipes/MongoDB/MongoDB.download.recipe                                         |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.n8felton-recipes/AppleJava/AppleJava6.download.recipe                                     |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.MLBZ521-recipes/Matlab/Matlab.download.recipe                                             |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.homebysix-recipes/Clarify/Clarify.download.recipe                                         |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.dataJAR-recipes/MacTeX Ghostscript/MacTeX Ghostscript.download.recipe                     |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.homebysix-recipes/Scherlokk/Scherlokk.download.recipe                                     |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.its-unibas-recipes/MAXQDA/maxqda.download.recipe                                          |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.jazzace-recipes/Sassafras/SassafrasServer.download.recipe                                 |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.apizz-recipes/Midas_M32/MidasM32Edit.download.recipe                                      |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.n8felton-recipes/Microsoft/MicrosoftEdge.download.recipe                                  |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.hansen-m-recipes/MacPorts/MacPorts.download.recipe                                        |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.ahousseini-recipes/CADintoshX/CADintoshX.download.recipe                                  |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.vmiller-recipes/LociTools/LociTools.download.recipe                                       |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.jbaker10-recipes/SmartCardDrivers/scmccid.download.recipe                                 |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.hansen-m-recipes/Adobe/AdobeFlashPlayerActiveX-Win.download.recipe                        |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.jessepeterson-recipes/Extensis/UniversalTypeClient5.download.recipe                       |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.orchard-recipes/mtr/mtr.download.recipe                                                   |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.haircut-recipes/VPT8/VPT8.download.recipe                                                 |      0       |      0       |    0     |    0     |     ✅      |
| com.github.autopkg.jleggat-recipes/libwebp/libwebp.download.recipe                                           |      70      |      70      |    70    |    70    |     ✅      |
| com.github.autopkg.homebysix-recipes/SuperMegaUltraGroovy/TapeDeck.download.recipe                           |      0       |      0       |    0     |    0     |     ✅      |
