### PR TITLE
Enable --help argument for list-processors verb

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1035,6 +1035,7 @@ def list_processors(argv):
     verb = argv[1]
     parser = gen_common_parser()
     parser.set_usage(f"Usage: %prog {verb} [options]\n" "List the core Processors.")
+    _ = common_parse(parser, argv)[0]
 
     print("\n".join(sorted(processor_names())))
 


### PR DESCRIPTION
This change allows the `list-processors` verb to respect the `--help` argument like other verbs do.

Before:

```
% ./Code/autopkg list-processors --help
AppDmgVersioner
AppPkgCreator
BrewCaskInfoProvider
CURLDownloader
CURLTextSearcher
ChocolateyPackager
CodeSignatureVerifier
Copier
DeprecationWarning
DmgCreator
DmgMounter
EndOfCheckPhase
FileCreator
FileFinder
FileMover
FlatPkgPacker
FlatPkgUnpacker
GitHubReleasesInfoProvider
InstallFromDMG
Installer
MunkiCatalogBuilder
MunkiImporter
MunkiInfoCreator
MunkiInstallsItemsCreator
MunkiPkginfoMerger
MunkiSetDefaultCatalog
PackageRequired
PathDeleter
PkgCopier
PkgCreator
PkgExtractor
PkgInfoCreator
PkgPayloadUnpacker
PkgRootCreator
PlistEditor
PlistReader
SignToolVerifier
SparkleUpdateInfoProvider
StopProcessingIf
Symlinker
URLDownloader
URLGetter
URLTextSearcher
Unarchiver
Versioner
```

After:

```
% ./Code/autopkg list-processors --help
Usage: autopkg list-processors [options]
List the core Processors.

Options:
  -h, --help         show this help message and exit
  --prefs=FILE_PATH  
```

Output without `--help` remains unchanged:

```
% ./Code/autopkg list-processors                                  
AppDmgVersioner
AppPkgCreator
BrewCaskInfoProvider
CURLDownloader
CURLTextSearcher
ChocolateyPackager
CodeSignatureVerifier
Copier
DeprecationWarning
DmgCreator
DmgMounter
EndOfCheckPhase
FileCreator
FileFinder
FileMover
FlatPkgPacker
FlatPkgUnpacker
GitHubReleasesInfoProvider
InstallFromDMG
Installer
MunkiCatalogBuilder
MunkiImporter
MunkiInfoCreator
MunkiInstallsItemsCreator
MunkiPkginfoMerger
MunkiSetDefaultCatalog
PackageRequired
PathDeleter
PkgCopier
PkgCreator
PkgExtractor
PkgInfoCreator
PkgPayloadUnpacker
PkgRootCreator
PlistEditor
PlistReader
SignToolVerifier
SparkleUpdateInfoProvider
StopProcessingIf
Symlinker
URLDownloader
URLGetter
URLTextSearcher
Unarchiver
Versioner
```