### PR TITLE
[WIP] Ability to use an external metadata source instead of xattr

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -69,11 +69,13 @@ class URLDownloader(URLGetter):
                 "'prefetch_filename' is useful for URLs with redirects."
             ),
         },
-        "external_metadata_path": {
+        "external_metadata": {
             "default": None,
             "required": False,
             "description": (
-                "Optional json file with ETag and Last-Modified "
+                "Optional dictionary of values that represent "
+                "a Redis connection or a path for a JSON file."
+                "Redis DB or JSON file with ETag and Last-Modified "
                 "that will be used to match with the download " 
                 "in order to determine if URLDownloader has "
                 "to download the file again or not. "
@@ -283,8 +285,8 @@ class URLDownloader(URLGetter):
             # resource not modified
             if self.env["external_metadata_path"]:
                 self.env["download_changed"] = False
-                self.env["stop_processing_recipe"] = True
                 self.output("Item at URL is unchanged.")
+                self.env["stop_processing_recipe"] = True
                 return False
             self.output("Item at URL is unchanged.")
             self.output(f"Using existing {self.env['pathname']}")

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -71,16 +71,19 @@ class URLGetter(Processor):
         headers = {}
         # If the download file already exists, add some headers to the request
         # so we don't retrieve the content if it hasn't changed
-        if self.env["external_metadata_path"]:
-            metadata_object = metadata.Metadata(self.env["external_metadata_path"])
+        if self.env.get("external_metadata") and isinstance(
+            self.env.get("external_metadata"), dict
+        ):
+            metadata_object = metadata.Metadata(self.env.get("external_metadata"))
             etag = metadata_object.getmetadata(filename, self.xattr_etag)
-            last_modified = metadata_object.getmetadata(filename, self.xattr_last_modified)
+            last_modified = metadata_object.getmetadata(
+                filename, self.xattr_last_modified
+            )
             if etag:
                 headers["If-None-Match"] = etag
             if last_modified:
                 headers["If-Modified-Since"] = last_modified
-            return headers
-        if os.path.exists(filename):
+        elif os.path.exists(filename):
             self.existing_file_size = os.path.getsize(filename)
             etag = self.getxattr(self.xattr_etag)
             last_modified = self.getxattr(self.xattr_last_modified)
@@ -88,7 +91,7 @@ class URLGetter(Processor):
                 headers["If-None-Match"] = etag
             if last_modified:
                 headers["If-Modified-Since"] = last_modified
-            return headers
+        return headers
 
     def clear_header(self, header):
         """Clear header dictionary."""

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -939,7 +939,7 @@ def import_processors():
     #
     #    from Bar.Foo import Foo
     #
-    for name in filter(lambda f: f not in ("__init__", "xattr"), processor_files):
+    for name in filter(lambda f: f not in ("__init__", "xattr", "metadata"), processor_files):
         globals()[name] = getattr(
             __import__(__name__ + "." + name, fromlist=[name]), name
         )

--- a/Code/autopkglib/metadata.py
+++ b/Code/autopkglib/metadata.py
@@ -15,71 +15,97 @@
 Module that provides a way to read data from a json object
 """
 import json
-import redis
+from autopkglib import log_err, log
 
-from redis.exceptions import ConnectionError, ResponseError
-from autopkglib import log_err
+try:
+    import redis
+    from redis.exceptions import ConnectionError, ResponseError
+except ImportError:
+    log(
+        "WARNING: In case you want to use an external metadata source "
+        "in order to check for new downloads from a redis database, "
+        "you will need to add redis module to your AutoPkg's Python Framework"
+    )
 
 
 class Metadata:
     def __init__(self, external_metadata):
-        print(external_metadata)
         self.metadata_object = None
-        self.host = external_metadata.get("host")
-        self.port = external_metadata.get("port")
-        self.db = external_metadata.get("db")
-        self.path = external_metadata.get("path")
-        if (
-            self.host and
-            self.port and
-            self.db or
-            self.db == 0
-        ):
+        try:
+            self.host = external_metadata.get("host")
+            self.port = external_metadata.get("port")
+            self.db = external_metadata.get("db")
+            self.path = external_metadata.get("path")
+            if self.host and self.port and self.db or self.db == 0:
+                try:
+                    self.metadata_object = redis.Redis(
+                        host=self.host, port=self.port, db=self.db
+                    )
+                    self.metadata_object.ping()
+                    self.metadata = self.metadata_object
+                except (ConnectionError, ResponseError) as err:
+                    log_err(f"Error connecting to redis db: {err}")
             try:
-                self.metadata_object = redis.Redis(
-                    host=self.host,
-                    port=self.port,
-                    db=self.db
-                )
-                self.metadata_object.ping()
-                self.metadata = self.metadata_object
-            except ConnectionError as err:
-                log_err(f"Error connecting to redis db: {err}")
-                raise
-            except ResponseError as err:
-                log_err(f"Error connecting to redis db: {err}")
-                raise
-        if not isinstance(
-            self.metadata_object, redis.client.Redis
-            ) and self.path:
-            try:
-                with open(self.path, "rb") as json_file:
-                    self.metadata = json.load(json_file)
-            except:
-                self.metadata = dict()
-    
+                if (
+                    not isinstance(self.metadata_object, redis.client.Redis)
+                    and self.path
+                ):
+                    try:
+                        with open(self.path, "rb") as json_file:
+                            self.metadata = json.load(json_file)
+                    except:
+                        self.metadata = dict()
+            except NameError:
+                if self.path:
+                    try:
+                        with open(self.path, "rb") as json_file:
+                            self.metadata = json.load(json_file)
+                    except:
+                        self.metadata = dict()
+        except AttributeError:
+            log_err(
+                f'"external_metadata" input should be of type dict instead of type {type(external_metadata)}'
+            )
+            self.host = self.port = self.db = self.path = self.metadata = None
+
     def getmetadata(self, filename, attribute):
-        if not isinstance(self.metadata_object, redis.client.Redis):
-            try:
-                return self.metadata.get(filename).get(attribute)
-            except AttributeError:
-                return None
+        try:
+            if not isinstance(self.metadata_object, redis.client.Redis) and self.path:
+                try:
+                    return self.metadata.get(filename).get(attribute)
+                except AttributeError:
+                    return None
+        except NameError:
+            if self.path:
+                try:
+                    return self.metadata.get(filename).get(attribute)
+                except AttributeError:
+                    return None
         try:
             return self.metadata.hget(filename, attribute).decode()
         except AttributeError:
             return None
 
     def setmetadata(self, filename, attribute, value):
-        if not isinstance(
-            self.metadata_object, redis.client.Redis
-            ) and self.path:
-            try:
-                self.metadata[filename][attribute] = value
-            except KeyError:
-                self.metadata[filename] = dict()
-                self.metadata[filename][attribute] = value
-            with open(self.path, "w") as json_file:
-                json.dump(self.metadata, json_file)
-            return
-        self.metadata.hset(filename, attribute, value)
-        return
+        try:
+            if not isinstance(self.metadata_object, redis.client.Redis) and self.path:
+                try:
+                    self.metadata[filename][attribute] = value
+                except KeyError:
+                    self.metadata[filename] = dict()
+                    self.metadata[filename][attribute] = value
+                with open(self.path, "w") as json_file:
+                    json.dump(self.metadata, json_file)
+        except NameError:
+            if self.path:
+                try:
+                    self.metadata[filename][attribute] = value
+                except KeyError:
+                    self.metadata[filename] = dict()
+                    self.metadata[filename][attribute] = value
+                with open(self.path, "w") as json_file:
+                    json.dump(self.metadata, json_file)
+        try:
+            self.metadata.hset(filename, attribute, value)
+        except AttributeError:
+            pass

--- a/Code/autopkglib/metadata.py
+++ b/Code/autopkglib/metadata.py
@@ -16,7 +16,6 @@ Module that provides a way to read data from a json object
 """
 import json
 
-from autopkglib import BUNDLE_ID
 
 class Metadata:
     def __init__(self, json_object):

--- a/Code/autopkglib/metadata.py
+++ b/Code/autopkglib/metadata.py
@@ -1,0 +1,42 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Module that provides a way to read data from a json object
+"""
+import json
+
+from autopkglib import BUNDLE_ID
+
+class Metadata:
+    def __init__(self, json_object):
+        self.json_object = json_object
+        try:
+            with open(self.json_object, "rb") as json_file:
+                self.json_data = json.load(json_file)
+        except:
+            self.json_data = dict()
+    
+    def getmetadata(self, filename, metadata):
+        try:
+            return self.json_data.get(filename).get(metadata)
+        except AttributeError:
+            return None
+    def setmetadata(self, filename, metadata, value):
+        try:
+            self.json_data[filename][metadata] = value
+        except KeyError:
+            self.json_data[filename] = dict()
+            self.json_data[filename][metadata] = value
+        with open(self.json_object, "w") as json_file:
+            json.dump(self.json_data, json_file)


### PR DESCRIPTION
Some Autopkg users are using a CI to run their recipes' list and some of them are running each recipe in an ephemeral vm with the cost of a new download every time the recipe runs. With this approach users can define a new input in the URLDownloader processor ("external_metadata_path") to change Autopkg behavior in order to use an external metadata source instead of xattr. When detect the download don't change it sets the env variable `"stop_processing_recipe"` to True.