### PR TITLE
Require "data" dictionary for processor summary results

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2312,6 +2312,9 @@ def run_recipes(argv):
                     result = item["Output"][key]
                     summary_text = result.get("summary_text", "")
                     data = result.get("data")
+                    if not data:
+                        log("WARNING: %s has no data. Skipping." % key)
+                        continue
                     if key not in summary_results:
                         summary_results[key] = {}
                         summary_results[key]["summary_text"] = summary_text

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2313,7 +2313,12 @@ def run_recipes(argv):
                     summary_text = result.get("summary_text", "")
                     data = result.get("data")
                     if not data:
-                        log("WARNING: %s has no data. Skipping." % key)
+                        log(
+                            'WARNING: Cannot display summary result because "%s" does not have a '
+                            '"data" dictionary. See wiki for more information: '
+                            "https://github.com/autopkg/autopkg/wiki/Processor-Summary-Reporting"
+                            % key
+                        )
                         continue
                     if key not in summary_results:
                         summary_results[key] = {}


### PR DESCRIPTION
@macmule pointed out that neither the documentation nor the code says a "data" dictionary is required for summary results, and yet if the dictionary is omitted a KeyError occurs.

This PR updates autopkg to explicitly require a "data" dictionary for processor summary results. If no dictionary is provided, a warning is printed and the summary result is skipped.

Upon merging, the [Processor Summary Reporting](https://github.com/autopkg/autopkg/wiki/Processor-Summary-Reporting) wiki page will also be updated to reflect this requirement.

Using an example processor that doesn't define a "data" dictionary:

```
        self.env["example_summary_result"] = {
            "summary_text": "This is an example summary result.",
        }
```

Here's a snippet of an autopkg run before the change:

```
% ./autopkg/code/autopkg run -vvq ViennaRSS/Vienna.download.recipe --report-plist /tmp/report.plist
Processing ViennaRSS/Vienna.download.recipe...
WARNING: ViennaRSS/Vienna.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
[...snip...]
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Vienna/receipts/Vienna.download-receipt-20210411-130155.plist

This is an example summary result.
Traceback (most recent call last):
  File "./autopkg/code/autopkg", line 2759, in <module>
    sys.exit(main(sys.argv))
  File "./autopkg/code/autopkg", line 2755, in main
    return subcommands[verb]["function"](argv)
  File "./autopkg/code/autopkg", line 2351, in run_recipes
    item.replace("_", " ").title() for item in value["header"]
KeyError: 'header'
```

And after the change:

```
% ./autopkg/code/autopkg run -vvq ViennaRSS/Vienna.download.recipe --report-plist /tmp/report.plist
Processing ViennaRSS/Vienna.download.recipe...
WARNING: ViennaRSS/Vienna.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
[...snip...]
CodeSignatureVerifier: Signature is valid
{'Output': {}}
WARNING: example_summary_result has no data. Skipping.
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Vienna/receipts/Vienna.download-receipt-20210411-130312.plist

Nothing downloaded, packaged or imported.

Report plist saved to /tmp/report.plist.
```

A quick scan of core and custom processors in the autopkg org reveal none that omit the "data" dictionary, so no existing processor summary results should be affected.
