### PR TITLE
AppPkgCreator: New Optional Input: version_key

### DIFF
--- a/Code/autopkglib/AppPkgCreator.py
+++ b/Code/autopkglib/AppPkgCreator.py
@@ -56,6 +56,12 @@ class AppPkgCreator(DmgMounter, PkgCreator):
             "description": "Version of the app. If not set, will be extracted from the "
             "CFBundleShortVersionString in the app's Info.plist.",
         },
+        "version_key": {
+            "required": False,
+            "description": "Alternate key from which to get the version of "
+            "the app. If not set or if the key does not exist, will be "
+            "extracted from the CFBundleShortVersionString in the app's Info.plist.",
+        },
         "force_pkg_build": {
             "required": False,
             "description": (
@@ -100,7 +106,10 @@ class AppPkgCreator(DmgMounter, PkgCreator):
         infoplist = self.read_info_plist(app_path)
         if not self.env.get("version"):
             try:
-                self.env["version"] = infoplist["CFBundleShortVersionString"]
+                self.env["version"] = (
+                    infoplist.get(self.env.get("version_key"))
+                    or infoplist["CFBundleShortVersionString"]
+                )
                 self.output(f"Version: {self.env['version']}")
             except BaseException as err:
                 raise ProcessorError(err)

--- a/Code/autopkglib/AppPkgCreator.py
+++ b/Code/autopkglib/AppPkgCreator.py
@@ -58,9 +58,9 @@ class AppPkgCreator(DmgMounter, PkgCreator):
         },
         "version_key": {
             "required": False,
-            "description": "Alternate key from which to get the version of "
-            "the app. If not set or if the key does not exist, will be "
-            "extracted from the CFBundleShortVersionString in the app's Info.plist.",
+            "description": "Alternate key from which to get the app version. "
+            "If not set or if the key does not exist, will be extracted from "
+            "the CFBundleShortVersionString in the app's Info.plist.",
         },
         "force_pkg_build": {
             "required": False,

--- a/Code/autopkglib/AppPkgCreator.py
+++ b/Code/autopkglib/AppPkgCreator.py
@@ -59,8 +59,8 @@ class AppPkgCreator(DmgMounter, PkgCreator):
         "version_key": {
             "required": False,
             "description": "Alternate key from which to get the app version. "
-            "If not set or if the key does not exist, will be extracted from "
-            "the CFBundleShortVersionString in the app's Info.plist.",
+            "If the key does not exist in the app's Info.plist, a "
+            "ProcessorError will be raised.",
         },
         "force_pkg_build": {
             "required": False,
@@ -105,12 +105,19 @@ class AppPkgCreator(DmgMounter, PkgCreator):
         # get version and bundleid
         infoplist = self.read_info_plist(app_path)
         if not self.env.get("version"):
+            # Default to CFBundleShortVersionString if version_key is unset.
+            version_key = self.env.get("version_key", "CFBundleShortVersionString")
             try:
-                self.env["version"] = (
-                    infoplist.get(self.env.get("version_key"))
-                    or infoplist["CFBundleShortVersionString"]
-                )
+                self.env["version"] = infoplist[version_key]
                 self.output(f"Version: {self.env['version']}")
+            # Specific error if the key does not exist.
+            except KeyError:
+                raise ProcessorError(
+                    f"The key '{version_key}' does not exist in the App "
+                    f"Bundle's Info.plist! ({app_path}/Contents/Info.plist) "
+                    f"Please check the recipe and try again."
+                )
+            # Trap all other errors.
             except BaseException as err:
                 raise ProcessorError(err)
         if not self.env.get("bundleid"):


### PR DESCRIPTION
Adding a feature to allow an alternate version key in `Info.plist`. The `.get` method for the `dict` class allows `NoneType` arguments without throwing a `TypeError` exception. So if `version_key` is unset, it will return `None`, which will in turn return `None` on the `.get` for `infoplist`, defaulting to `CFBundleShortVersionString`.

As I will show in further comments/attachments, this will not affect existing recipes.