### PR TITLE
Use `argv[0]` for permissions checking

### DIFF
--- a/Code/autopkgserver/autopkginstalld
+++ b/Code/autopkgserver/autopkginstalld
@@ -218,7 +218,7 @@ def main(argv):
     wheel_gid = 0
     admin_gid = 80
 
-    exepath = os.path.realpath(os.path.abspath(__file__))
+    exepath = os.path.realpath(os.path.abspath(sys.argv[0]))
     path_ok = True
     while True:
         info = os.stat(exepath)

--- a/Code/autopkgserver/autopkgserver
+++ b/Code/autopkgserver/autopkgserver
@@ -329,7 +329,7 @@ def main(argv):
     wheel_gid = 0
     admin_gid = 80
 
-    exepath = os.path.realpath(os.path.abspath(__file__))
+    exepath = os.path.realpath(os.path.abspath(sys.argv[0]))
     path_ok = True
     while True:
         info = os.stat(exepath)


### PR DESCRIPTION
Using `__file__` to get the real path of the executing source doesn't
work when the source is inside a pex archive. This change allows both
`autopkgserver` and `autopkginstalld` to be run from pex archives.