### PR TITLE
Update FileFinder.py

### DIFF
--- a/Code/autopkglib/FileFinder.py
+++ b/Code/autopkglib/FileFinder.py
@@ -50,6 +50,7 @@ class FileFinder(DmgMounter):
     output_variables = {
         "found_filename": {"description": "Full path of found filename"},
         "dmg_found_filename": {"description": "DMG-relative path of found filename"},
+        "found_basename": {"description": "Basename of found filename"},
     }
 
     description = __doc__
@@ -96,6 +97,15 @@ class FileFinder(DmgMounter):
                 self.output(
                     f"DMG-relative file match: '{self.env['dmg_found_filename']}'"
                 )
+
+            if match.endswith('/'):
+                self.env["found_basename"] = os.path.basename(match.lstrip("/"))
+            else:
+                self.env["found_basename"] = os.path.basename(match)
+            self.output(
+                f"Basename match: '{self.env['found_basename']}'"
+            )
+
         finally:
             if dmg:
                 self.unmount(dmg_path)


### PR DESCRIPTION
Adds new output variable,  found_basename.

This returns the basename of found_filename.

Excerpt:
```
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload/Tableau Prep Builder 2021.1.app' from globbed '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload/Tableau*.app'
FileFinder: Basename match: 'Tableau Prep Builder 2021.1.app'
{'Output': {'found_basename': 'Tableau Prep Builder 2021.1.app',
            'found_filename': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload/Tableau '
                              'Prep Builder 2021.1.app'}}
```

Full autopkg run -vv output:
```
Processing /Users/ben/Git/other-recipes/its-unibas-recipes/TableauPrep/TableauPrep.munki.recipe...
WARNING: /Users/ben/Git/other-recipes/its-unibas-recipes/TableauPrep/TableauPrep.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'TableauPrep.dmg',
           'url': 'https://www.tableau.com/downloads/prep/mac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Tableau '
                                        'Software, LLC (QJ4XPRK37C)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg/Tableau '
                         'Prep Builder.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Tableau Prep Builder.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-03-26 17:48:01 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)
CodeSignatureVerifier:        Expires: 2025-05-30 14:49:09 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            A8 6F 53 17 62 1F D4 C7 F5 1B 2A 5A 9C 2A 1B B9 29 AF B3 79 DF 18
CodeSignatureVerifier:            48 1D 35 5A EE 9F 21 02 EC 82
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg/Tableau '
                            'Prep Builder.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.1doQUC/Tableau Prep Builder.pkg to /Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/unpack/Tableau '
                               'App.pkg/payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/unpack/Tableau App.pkg/payload to /Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload
{'Output': {}}
FileFinder
{'Input': {'pattern': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload/Tableau*.app'}}
FileFinder: No value supplied for find_method, setting default value of: glob
FileFinder: Found file match: '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload/Tableau Prep Builder 2021.1.app' from globbed '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload/Tableau*.app'
FileFinder: Basename match: 'Tableau Prep Builder 2021.1.app'
{'Output': {'found_basename': 'Tableau Prep Builder 2021.1.app',
            'found_filename': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload/Tableau '
                              'Prep Builder 2021.1.app'}}
PlistReader
{'Input': {'info_path': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload/Tableau '
                        'Prep Builder 2021.1.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: /Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/payload/Tableau Prep Builder 2021.1.app/Contents/Info.plist
PlistReader: Assigning value of '2021.1.3' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '2021.1.3'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '2021.1.3'},
           'pkginfo': {'blocking_applications': ['TableauPrep'],
                       'catalogs': ['testing'],
                       'description': 'Tableau Prep is a self-service data '
                                      'preparation tool with Tableau Prep '
                                      'Builder and Prep Conductor.',
                       'display_name': 'Tableau Prep',
                       'installer_choices_xml': [{'attributeSetting': 1,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'com.tableausoftware.desktop.app'},
                                                 {'attributeSetting': 0,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'com.tableausoftware.desktopShortcut'}],
                       'name': 'TableauPrep',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '2021.1.3'} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['TableauPrep'],
                        'catalogs': ['testing'],
                        'description': 'Tableau Prep is a self-service data '
                                       'preparation tool with Tableau Prep '
                                       'Builder and Prep Conductor.',
                        'display_name': 'Tableau Prep',
                        'installer_choices_xml': [{'attributeSetting': 1,
                                                   'choiceAttribute': 'selected',
                                                   'choiceIdentifier': 'com.tableausoftware.desktop.app'},
                                                  {'attributeSetting': 0,
                                                   'choiceAttribute': 'selected',
                                                   'choiceIdentifier': 'com.tableausoftware.desktopShortcut'}],
                        'name': 'TableauPrep',
                        'unattended_install': True,
                        'version': '2021.1.3'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/downloads/TableauPrep.dmg',
           'pkginfo': {'blocking_applications': ['TableauPrep'],
                       'catalogs': ['testing'],
                       'description': 'Tableau Prep is a self-service data '
                                      'preparation tool with Tableau Prep '
                                      'Builder and Prep Conductor.',
                       'display_name': 'Tableau Prep',
                       'installer_choices_xml': [{'attributeSetting': 1,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'com.tableausoftware.desktop.app'},
                                                 {'attributeSetting': 0,
                                                  'choiceAttribute': 'selected',
                                                  'choiceIdentifier': 'com.tableausoftware.desktopShortcut'}],
                       'name': 'TableauPrep',
                       'unattended_install': True,
                       'version': '2021.1.3'},
           'repo_subdirectory': 'apps/TableauPrep'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/TableauPrep/TableauPrep-2021.1.3__2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/TableauPrep/TableauPrep-2021.1.3__2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'TableauPrep',
                                                       'pkg_repo_path': 'apps/TableauPrep/TableauPrep-2021.1.3__2.dmg',
                                                       'pkginfo_path': 'apps/TableauPrep/TableauPrep-2021.1.3__2.plist',
                                                       'version': '2021.1.3'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 5, 10, 18, 52, 50),
                                         'munki_version': '5.3.0.4335',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'blocking_applications': ['TableauPrep'],
                           'catalogs': ['testing'],
                           'description': 'Tableau Prep is a self-service data '
                                          'preparation tool with Tableau Prep '
                                          'Builder and Prep Conductor.',
                           'display_name': 'Tableau Prep',
                           'installed_size': 1720685,
                           'installer_choices_xml': [{'attributeSetting': 1,
                                                      'choiceAttribute': 'selected',
                                                      'choiceIdentifier': 'com.tableausoftware.desktop.app'},
                                                     {'attributeSetting': 0,
                                                      'choiceAttribute': 'selected',
                                                      'choiceIdentifier': 'com.tableausoftware.desktopShortcut'}],
                           'installer_item_hash': '265467d610b70c5e3cb01d80af8d27a3431b7f986cb06afaa133145f617a3d66',
                           'installer_item_location': 'apps/TableauPrep/TableauPrep-2021.1.3__2.dmg',
                           'installer_item_size': 791009,
                           'minimum_os_version': '10.5.0',
                           'name': 'TableauPrep',
                           'receipts': [{'installed_size': 129,
                                         'packageid': 'com.tableausoftware.FLEXNet.11.16.2',
                                         'version': '11.16.2'},
                                        {'installed_size': 1717792,
                                         'packageid': 'com.tableausoftware.Maestro.app',
                                         'version': '21.13.21.0326.1015'},
                                        {'installed_size': 2764,
                                         'packageid': 'com.tableausoftware.postgresql',
                                         'version': '9.6.500'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '2021.1.3'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/TableauPrep/TableauPrep-2021.1.3__2.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/TableauPrep/TableauPrep-2021.1.3__2.plist'}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/ch.unibas.its.git.mcs.munki.tableau-prep/receipts/TableauPrep.munki-receipt-20210510-195251.plist

The following new items were imported into Munki:
    Name         Version   Catalogs  Pkginfo Path                                    Pkg Repo Path                                 Icon Repo Path
    ----         -------   --------  ------------                                    -------------                                 --------------
    TableauPrep  2021.1.3  testing   apps/TableauPrep/TableauPrep-2021.1.3__2.plist  apps/TableauPrep/TableauPrep-2021.1.3__2.dmg
```