### PR TITLE
Fix handling of scp syntax for git urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### [2.3](https://github.com/autopkg/autopkg/compare/v2.2...HEAD) (Unreleased)
+### [2.3](https://github.com/autopkg/autopkg/compare/v2.2...v2.3) (March 01, 2021)
 
 NEW FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### [Unreleased](https://github.com/autopkg/autopkg/compare/v2.2...HEAD) (Unreleased)
+### [2.3](https://github.com/autopkg/autopkg/compare/v2.2...HEAD) (Unreleased)
 
 NEW FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### [2.3.2](https://github.com/autopkg/autopkg/compare/v2.3.1...HEAD) (Unreleased)
+
 ### [2.3.1](https://github.com/autopkg/autopkg/compare/v2.3...v2.3.1) (March 03, 2021)
 
 FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### [2.3.1](https://github.com/autopkg/autopkg/compare/v2.3...HEAD) (Unreleased)
+### [2.3.1](https://github.com/autopkg/autopkg/compare/v2.3...v2.3.1) (March 03, 2021)
 
 FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### [2.3.1](https://github.com/autopkg/autopkg/compare/v2.3...HEAD) (Unreleased)
+
 ### [2.3](https://github.com/autopkg/autopkg/compare/v2.2...v2.3) (March 01, 2021)
 
 NEW FEATURES:

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -542,7 +542,7 @@ def get_recipe_repo(git_path):
     parts = urlparse(git_path)
     domain_and_port = parts.netloc
     # discard user name if any
-    if domain_and_port.find("@"):
+    if domain_and_port.find("@") >= 0:
         domain_and_port = domain_and_port.split("@", 1)[1]
     # discard port if any
     domain = domain_and_port.split(":")[0]

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -541,6 +541,9 @@ def get_recipe_repo(git_path):
     # figure out a local directory name to clone to
     parts = urlparse(git_path)
     domain_and_port = parts.netloc
+    # discard user name if any
+    if domain_and_port.find("@"):
+        domain_and_port = domain_and_port.split("@", 1)[1]
     # discard port if any
     domain = domain_and_port.split(":")[0]
     reverse_domain = ".".join(reversed(domain.split(".")))
@@ -692,6 +695,7 @@ def expand_repo_url(url):
     'user/reciperepo'         -> 'https://github.com/user/reciperepo'
     'reciperepo'              -> 'https://github.com/autopkg/reciperepo'
     'http://some/repo/url     -> 'http://some/repo/url'
+    'git@server:repo/url      -> 'ssh://git@server/repo/url'
     '/some/path               -> '/some/path'
     '~/some/path              -> '~/some/path'
     """
@@ -703,8 +707,13 @@ def expand_repo_url(url):
         # If the URL looks like a file path, return as is.
         pass
     elif not parsed_url.scheme:
+        if parsed_url.path.find(":") < parsed_url.path.find("/"):
+            # If no URL scheme was given check for scp-like syntax, where there is
+            # no slash before the first colon and convert this to a valid ssh url
+            url = url.replace(":", "/", 1)
+            url = f"ssh://{url}"
         # If no URL scheme was given in the URL, try GitHub URLs
-        if "/" in url:
+        elif "/" in url:
             # If URL looks like 'name/repo' then prepend the base GitHub URL
             url = f"https://github.com/{url}"
         else:
@@ -724,7 +733,7 @@ Download one or more new recipe repos and add it to the search path.
 The 'recipe_repo_url' argument can be of the following forms:
 - repo (implies 'https://github.com/autopkg/repo')
 - user/repo (implies 'https://github.com/user/repo')
-- (http[s]://|git://|user@server:)path/to/any/git/repo
+- (http[s]://|git://|ssh://|user@server:)path/to/any/git/repo
 
 Example: '%prog repo-add recipes'
 ..adds the autopkg/recipes repo from GitHub."""

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -542,7 +542,7 @@ def get_recipe_repo(git_path):
     parts = urlparse(git_path)
     domain_and_port = parts.netloc
     # discard user name if any
-    if domain_and_port.find("@") >= 0:
+    if "@" in domain_and_port:
         domain_and_port = domain_and_port.split("@", 1)[1]
     # discard port if any
     domain = domain_and_port.split(":")[0]
@@ -707,7 +707,9 @@ def expand_repo_url(url):
         # If the URL looks like a file path, return as is.
         pass
     elif not parsed_url.scheme:
-        if parsed_url.path.find(":") < parsed_url.path.find("/"):
+        if ":" in parsed_url.path and parsed_url.path.find(":") < parsed_url.path.find(
+            "/"
+        ):
             # If no URL scheme was given check for scp-like syntax, where there is
             # no slash before the first colon and convert this to a valid ssh url
             url = url.replace(":", "/", 1)

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -707,8 +707,9 @@ def expand_repo_url(url):
         # If the URL looks like a file path, return as is.
         pass
     elif not parsed_url.scheme:
-        if ":" in parsed_url.path and parsed_url.path.find(":") < parsed_url.path.find(
-            "/"
+        if ":" in parsed_url.path and (
+            "/" not in parsed_url.path
+            or parsed_url.path.find(":") < parsed_url.path.find("/")
         ):
             # If no URL scheme was given check for scp-like syntax, where there is
             # no slash before the first colon and convert this to a valid ssh url

--- a/Code/autopkglib/version.plist
+++ b/Code/autopkglib/version.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>Version</key>
-	<string>2.3.1</string>
+	<string>2.3.2</string>
 </dict>
 </plist>

--- a/Code/autopkglib/version.plist
+++ b/Code/autopkglib/version.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>Version</key>
-	<string>2.3</string>
+	<string>2.3.1</string>
 </dict>
 </plist>

--- a/Scripts/make_new_release.py
+++ b/Scripts/make_new_release.py
@@ -255,10 +255,9 @@ def main():
     subprocess.check_call(git_cmd)
     os.chdir(autopkg_root)
 
-    print("** Running AutoPkgGitMaster recipe")
+    print("** Running AutoPkgGitMaster.pkg recipe")
     # running using the system AutoPkg directory so that we ensure we're at the
     # minimum required version to run the AutoPkg recipe
-    print("**Running AutoPkgGitMaster.pkg")
     report_plist_path = tempfile.mkstemp()[1]
     parent_path = os.path.join(os.path.abspath(os.path.dirname(__file__)))
     cmd = [


### PR DESCRIPTION
These changes fix some problems already mentioned in Issue #276. Using the common scp syntax for git urls was not properly processed.

We convert those kind of urls to a proper ssh url, so that

`autopkg repo-add git@privategitserver:namespace/repo.git`

is actually equivalent to

`autopkg repo-add ssh://git@privategitserver/namespace/repo.git`

Furthermore we are removing the username – if present – from the url, to keep the directory path free from (probably unwanted) "@" characters.