### PR TITLE
Adjust GitHubReleasesInfoProvider to accommodate extra leading dot in version tags

### DIFF
--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -193,7 +193,7 @@ class GitHubReleasesInfoProvider(Processor):
         tag = self.selected_release["tag_name"]
         # Versioned tags usually start with 'v'
         if tag.startswith("v"):
-            tag = tag[1:]
+            tag = tag.lstrip("v.")
         self.env["version"] = tag
 
         # Record release notes

--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -175,17 +175,6 @@ class GitHubReleasesInfoProvider(Processor):
             f"'{self.selected_release['name']}'"
         )
 
-    def process_release_asset(self):
-        """Extract what we need from the release and chosen asset, set env
-        variables"""
-        tag = self.selected_release["tag_name"]
-        # Versioned tags usually start with 'v'
-        if tag.startswith("v"):
-            tag = tag[1:]
-
-        self.env["url"] = self.selected_asset["browser_download_url"]
-        self.env["version"] = tag
-
     def main(self):
         # Get our list of releases
         releases = self.get_releases(self.env["github_repo"])

--- a/Code/tests/test_githubreleasesinfoprovider.py
+++ b/Code/tests/test_githubreleasesinfoprovider.py
@@ -11,6 +11,7 @@ class TestGitHubReleasesInfoProvider(unittest.TestCase):
     """Test class for GitHubReleasesInfoProvider Processor."""
 
     def setUp(self):
+        self.vers_pattern = r"\d[\d\.]+"
         self.base_env = {
             "CURL_PATH": "/usr/bin/curl",
             "GITHUB_URL": "https://api.github.com",
@@ -45,7 +46,7 @@ class TestGitHubReleasesInfoProvider(unittest.TestCase):
         test_env.update(self.base_env)
         self.processor.env = test_env
         self.processor.main()
-        m = re.match(r"\d\.[\d\.]+", test_env["version"])
+        m = re.match(self.vers_pattern, test_env["version"])
         self.assertIsNotNone(m)
 
     def test_returns_version_from_tag2(self):
@@ -55,7 +56,7 @@ class TestGitHubReleasesInfoProvider(unittest.TestCase):
         test_env.update(self.base_env)
         self.processor.env = test_env
         self.processor.main()
-        m = re.match(r"\d\.[\d\.]+", test_env["version"])
+        m = re.match(self.vers_pattern, test_env["version"])
         self.assertIsNotNone(m)
 
     def test_returns_url(self):

--- a/Code/tests/test_githubreleasesinfoprovider.py
+++ b/Code/tests/test_githubreleasesinfoprovider.py
@@ -1,0 +1,71 @@
+#!/usr/local/autopkg/python
+
+import re
+import unittest
+
+from autopkglib import ProcessorError
+from autopkglib.GitHubReleasesInfoProvider import GitHubReleasesInfoProvider
+
+
+class TestGitHubReleasesInfoProvider(unittest.TestCase):
+    """Test class for GitHubReleasesInfoProvider Processor."""
+
+    def setUp(self):
+        self.base_env = {
+            "CURL_PATH": "/usr/bin/curl",
+            "GITHUB_URL": "https://api.github.com",
+            "GITHUB_TOKEN_PATH": "~/.autopkg_gh_token",
+        }
+        self.processor = GitHubReleasesInfoProvider()
+
+    def tearDown(self):
+        pass
+
+    def test_raise_if_no_repo(self):
+        """Raise an exception if missing a critical input variable."""
+        test_env = {"github_repo": ""}
+        test_env.update(self.base_env)
+        self.processor.env = test_env
+        with self.assertRaises(ProcessorError):
+            self.processor.main()
+
+    def test_no_fail_if_good_env(self):
+        """The processor should not raise any exceptions if run normally."""
+        test_env = {"github_repo": "autopkg/autopkg"}
+        test_env.update(self.base_env)
+        self.processor.env = test_env
+        try:
+            self.processor.main()
+        except ProcessorError:
+            self.fail()
+
+    def test_returns_version_from_tag1(self):
+        """The processor should return a version derived from a tag."""
+        test_env = {"github_repo": "autopkg/autopkg"}
+        test_env.update(self.base_env)
+        self.processor.env = test_env
+        self.processor.main()
+        m = re.match(r"\d\.[\d\.]+", test_env["version"])
+        self.assertIsNotNone(m)
+
+    def test_returns_version_from_tag2(self):
+        """The processor should return a version derived from a tag, even if
+        the tag has an extra leading dot."""
+        test_env = {"github_repo": "macadmins/nudge"}
+        test_env.update(self.base_env)
+        self.processor.env = test_env
+        self.processor.main()
+        m = re.match(r"\d\.[\d\.]+", test_env["version"])
+        self.assertIsNotNone(m)
+
+    def test_returns_url(self):
+        """The processor should return a URL."""
+        test_env = {"github_repo": "autopkg/autopkg"}
+        test_env.update(self.base_env)
+        self.processor.env = test_env
+        self.processor.main()
+        self.assertIsNotNone(test_env["url"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR aims to solve https://github.com/autopkg/autopkg/issues/746, in which GitHubReleasesInfoProvider provides an incorrect `version` output for tags that start with `v.` instead of just `v` (as is the case with [Nudge](https://github.com/macadmins/nudge/tags)).

I've also added a couple very rudimentary unit tests for the GitHubReleasesInfoProvider processor, including a test for the fix above.

I'll update this PR soon with test results and verbose output verifying expected behavior.