### PR TITLE
Extending the MunkiImporter applist check to match on more criteria

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -210,12 +210,16 @@ class MunkiImporter(Processor):
                 pkginfo_items = pkginfo.copy()
                 # remove _metadata as not present on pkgdb output
                 pkginfo_items.pop('_metadata', None)
+                # remove installer_item_hash as this can differ in pkgdb output
+                pkginfo_items.pop('installer_item_hash', None)
                 # remove installer_item_location as always differs in pkgdb output
                 pkginfo_items.pop('installer_item_location', None)
                 # check each matching item
                 for matching_index in matching_indexes:
                     # make a copy of the pkginfo dict so we can edit as needed
                     pkgdb_items = pkgdb["items"][matching_index].copy()
+                    # remove installer_item_hash as this can differ in pkginfo output
+                    pkgdb_items.pop('installer_item_hash', None)
                     # remove installer_item_location as always differs in pkginfo output
                     pkgdb_items.pop('installer_item_location', None)
                     # check installs to see if indeed a match, returning if a match is found
@@ -223,6 +227,13 @@ class MunkiImporter(Processor):
                         return pkgdb["items"][list(matching_indexes)[0]]
             # if we have an appslist but no match, return to import item
             return None
+        
+        # match hashes for the pkg or dmg
+        if "installer_item_hash" in pkginfo:
+            matchingindexes = pkgdb["hashes"].get(pkginfo["installer_item_hash"])
+            if matchingindexes:
+                # we have an item with the exact same checksum hash in the repo
+                return pkgdb["items"][matchingindexes[0]]
 
         # fall back to matching against receipts
         matching_indexes = []

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -210,18 +210,20 @@ class MunkiImporter(Processor):
                 pkginfo_items = pkginfo.copy()
                 # remove _metadata as not present on pkgdb output
                 pkginfo_items.pop('_metadata', None)
-                # remove installer_item_hash as this can differ in pkgdb output
+                # remove installer_item_*'s as can differ for legit reasons between
+                # pkginfo and pkgdb
                 pkginfo_items.pop('installer_item_hash', None)
-                # remove installer_item_location as always differs in pkgdb output
                 pkginfo_items.pop('installer_item_location', None)
+                pkginfo_items.pop('installer_item_size', None)
                 # check each matching item
                 for matching_index in matching_indexes:
                     # make a copy of the pkginfo dict so we can edit as needed
                     pkgdb_items = pkgdb["items"][matching_index].copy()
-                    # remove installer_item_hash as this can differ in pkginfo output
+                    # remove installer_item_*'s as can differ for legit reasons between
+                    # pkginfo and pkgdb
                     pkgdb_items.pop('installer_item_hash', None)
-                    # remove installer_item_location as always differs in pkginfo output
                     pkgdb_items.pop('installer_item_location', None)
+                    pkgdb_items.pop('installer_item_size', None)
                     # check installs to see if indeed a match, returning if a match is found
                     if pkginfo_items == pkgdb_items:
                         return pkgdb["items"][list(matching_indexes)[0]]

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -175,12 +175,6 @@ class MunkiImporter(Processor):
             return None
 
         pkgdb = repo_library.make_catalog_db()
-        # match hashes for the pkg or dmg
-        if "installer_item_hash" in pkginfo:
-            matchingindexes = pkgdb["hashes"].get(pkginfo["installer_item_hash"])
-            if matchingindexes:
-                # we have an item with the exact same checksum hash in the repo
-                return pkgdb["items"][matchingindexes[0]]
 
         # try to match against installed applications
         applist = [
@@ -212,7 +206,23 @@ class MunkiImporter(Processor):
 
             # did we find any matches?
             if matching_indexes:
-                return pkgdb["items"][list(matching_indexes)[0]]
+                # make a copy of the pkginfo dict so we can edit as needed
+                pkginfo_items = pkginfo.copy()
+                # remove _metadata as not present on pkgdb output
+                pkginfo_items.pop('_metadata', None)
+                # remove installer_item_location as always differs in pkgdb output
+                pkginfo_items.pop('installer_item_location', None)
+                # check each matching item
+                for matching_index in matching_indexes:
+                    # make a copy of the pkginfo dict so we can edit as needed
+                    pkgdb_items = pkgdb["items"][matching_index].copy()
+                    # remove installer_item_location as always differs in pkginfo output
+                    pkgdb_items.pop('installer_item_location', None)
+                    # check installs to see if indeed a match, returning if a match is found
+                    if pkginfo_items == pkgdb_items:
+                        return pkgdb["items"][list(matching_indexes)[matching_index]]
+            # if we have an appslist but no match, return to import item
+            return None
 
         # fall back to matching against receipts
         matching_indexes = []

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -220,7 +220,7 @@ class MunkiImporter(Processor):
                     pkgdb_items.pop('installer_item_location', None)
                     # check installs to see if indeed a match, returning if a match is found
                     if pkginfo_items == pkgdb_items:
-                        return pkgdb["items"][list(matching_indexes)[matching_index]]
+                        return pkgdb["items"][list(matching_indexes)[0]]
             # if we have an appslist but no match, return to import item
             return None
 


### PR DESCRIPTION
Currently MunkiImporter's _find_matching_pkginfo def looks for matches based on:

1. matching app_path and app_version - [https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L185-L215](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L185-L215)
2. matching receipts - [https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L217-L239](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L217-L239)
3. matching md5 checksums - [https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L241-L259](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L241-L259)
4. matching files and paths - [https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L261-L281](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L261-L281)

This PR extends the "matching app_path and app_version" check to check against the below from the pkginfo within the AutoPkg created installs and the items record from within the Munki repo:

- autoremove
- blocking_applications
- catalogs
- description
- developer
- display_name
- installed_size
- installer_item_hash
- installer_item_size
- installs
- minimum_os_version
- name
- receipts
- supported_architectures
- unattended_install
- uninstall_method
- uninstallable
- version
- etc...

In fact, it's checking the AutoPkg derived pkginfo, excluding:

-  _metadata  - as not present on Munki repo output
- installer_item_location  - as always differs from Munki repo output due to paths

With the Munki repo ["items"] dict being checked, excluding:

- installer_item_location  - as always differs from Munki repo output due to paths

Any changes between those two dicts means that the item is to be imported.

This allows for apps to be imported with differing architectures, or when only a subtle difference (like CFBundleName).

Below as an example of before the change, where there are 2 Code42.app's and their CFBundleName differs, but version is the same as are the pkg receipts.

The differing CFBundleName's are:

- Code42 - Code42
- CrashPlan for Small Business - CrashPlan for Small Business

```
$ autopkg run -vv ~/Git/other/dataJAR-recipes/Code42/Code42.munki.recipe                                                  
Processing /Users/ben/Git/other/dataJAR-recipes/Code42/Code42.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/Code42/Code42.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Code42.dmg',
           'url': 'https://download.code42.com/installs/agent/latest-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg/Install '
                         'Code42.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install Code42":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-05-24 21:45:33 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2022-03-01 18:01:05 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            1E 54 66 40 7A 2E 59 AB 5F F6 65 01 5A 12 8F EB C1 B8 F7 99 FE E5 
CodeSignatureVerifier:            4C 58 9A 59 D9 3E 47 43 A8 58
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg/Install '
                            'Code42.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.To8qRl/Install Code42.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/pkgroot/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack/code42.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack/code42.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/pkgroot',
           'installs_item_paths': ['/Applications/Code42.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Code42.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                 'CFBundleName': 'Code42',
                                                 'CFBundleShortVersionString': '8.6.1',
                                                 'CFBundleVersion': '3',
                                                 'path': '/Applications/Code42.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                'CFBundleName': 'Code42',
                                                'CFBundleShortVersionString': '8.6.1',
                                                'CFBundleVersion': '3',
                                                'path': '/Applications/Code42.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'Code42Service.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': ' ',
                       'developer': 'Code 42 Software',
                       'display_name': 'Code42',
                       'name': 'Code42',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop', 'CFBundleName': 'Code42', 'CFBundleShortVersionString': '8.6.1', 'CFBundleVersion': '3', 'path': '/Applications/Code42.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Electron Helper '
                                                  '(Renderer).app',
                                                  'Code42.app',
                                                  'Electron Helper (GPU).app',
                                                  'Code42Service.app',
                                                  'Electron Helper '
                                                  '(Plugin).app',
                                                  'Electron Helper.app'],
                        'catalogs': ['testing'],
                        'description': ' ',
                        'developer': 'Code 42 Software',
                        'display_name': 'Code42',
                        'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                      'CFBundleName': 'Code42',
                                      'CFBundleShortVersionString': '8.6.1',
                                      'CFBundleVersion': '3',
                                      'path': '/Applications/Code42.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'Code42',
                        'unattended_install': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/downloads/Code42.dmg',
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'Code42Service.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': ' ',
                       'developer': 'Code 42 Software',
                       'display_name': 'Code42',
                       'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                     'CFBundleName': 'Code42',
                                     'CFBundleShortVersionString': '8.6.1',
                                     'CFBundleVersion': '3',
                                     'path': '/Applications/Code42.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'Code42',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/Code42',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Code42/Code42-8.6.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Code42/Code42-8.6.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Code42',
                                                       'pkg_repo_path': 'apps/Code42/Code42-8.6.1.dmg',
                                                       'pkginfo_path': 'apps/Code42/Code42-8.6.1.plist',
                                                       'version': '8.6.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 6, 9, 8, 8, 41),
                                         'munki_version': '5.3.0.4335',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'blocking_applications': ['Electron Helper '
                                                     '(Renderer).app',
                                                     'Code42.app',
                                                     'Electron Helper '
                                                     '(GPU).app',
                                                     'Code42Service.app',
                                                     'Electron Helper '
                                                     '(Plugin).app',
                                                     'Electron Helper.app'],
                           'catalogs': ['testing'],
                           'description': ' ',
                           'developer': 'Code 42 Software',
                           'display_name': 'Code42',
                           'installed_size': 312674,
                           'installer_item_hash': '2503f3544160cee0ba03fc5abbaef0a7e57c58038c1101744f19587847591c43',
                           'installer_item_location': 'apps/Code42/Code42-8.6.1.dmg',
                           'installer_item_size': 176527,
                           'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                         'CFBundleName': 'Code42',
                                         'CFBundleShortVersionString': '8.6.1',
                                         'CFBundleVersion': '3',
                                         'path': '/Applications/Code42.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'Code42',
                           'receipts': [{'installed_size': 312674,
                                         'packageid': 'com.code42.app.pkg',
                                         'version': '8.6.1'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '8.6.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Code42/Code42-8.6.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Code42/Code42-8.6.1.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/pkgroot/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack/']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/pkgroot/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/unpack/
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Code42/receipts/Code42.munki-receipt-20210609-090841.plist

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                    Pkg Repo Path                 Icon Repo Path  
    ----    -------  --------  ------------                    -------------                 --------------  
    Code42  8.6.1    testing   apps/Code42/Code42-8.6.1.plist  apps/Code42/Code42-8.6.1.dmg                  
$ /usr/local/munki/makecatalogs                                         
Getting list of icons...
Getting list of pkgsinfo...
Getting list of pkgs...
Adding pkgsinfo/apps/Code42/Code42-8.6.1.plist to testing...
Created catalogs/all...
Created catalogs/testing...
$ autopkg run -vv ~/Git/other/dataJAR-recipes/CrashPlan\ for\ Small\ Business/CrashPlan\ for\ Small\ Business.munki.recipe
Processing /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'CrashPlanForSmallBusiness.dmg',
           'url': 'https://download.code42.com/installs/agent/latest-smb-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small '
                        'Business/downloads/CrashPlanForSmallBusiness.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small '
                         'Business/downloads/CrashPlanForSmallBusiness.dmg/Install '
                         'CrashPlan for Small Business.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install CrashPlan for Small Business":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-05-24 21:58:41 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2022-03-01 18:01:05 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            1E 54 66 40 7A 2E 59 AB 5F F6 65 01 5A 12 8F EB C1 B8 F7 99 FE E5 
CodeSignatureVerifier:            4C 58 9A 59 D9 3E 47 43 A8 58
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                            'for Small '
                            'Business/downloads/CrashPlanForSmallBusiness.dmg/Install '
                            'CrashPlan for Small Business.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.yj4egn/Install CrashPlan for Small Business.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                      'for Small Business/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/pkgroot/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack/code42.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/code42.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small Business/pkgroot',
           'installs_item_paths': ['/Applications/Code42.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Code42.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                 'CFBundleName': 'CrashPlan '
                                                                 'for Small '
                                                                 'Business',
                                                 'CFBundleShortVersionString': '8.6.1',
                                                 'CFBundleVersion': '3',
                                                 'path': '/Applications/Code42.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                'CFBundleName': 'CrashPlan for '
                                                                'Small '
                                                                'Business',
                                                'CFBundleShortVersionString': '8.6.1',
                                                'CFBundleVersion': '3',
                                                'path': '/Applications/Code42.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'name': 'CrashPlanForSmallBusiness',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop', 'CFBundleName': 'CrashPlan for Small Business', 'CFBundleShortVersionString': '8.6.1', 'CFBundleVersion': '3', 'path': '/Applications/Code42.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Electron Helper '
                                                  '(Renderer).app',
                                                  'Code42.app',
                                                  'Electron Helper (GPU).app',
                                                  'CrashPlan for Small '
                                                  'BusinessService.app',
                                                  'Electron Helper '
                                                  '(Plugin).app',
                                                  'Electron Helper.app'],
                        'catalogs': ['testing'],
                        'description': 'Enterprise-grade data loss protection '
                                       'at small business prices. CrashPlan® '
                                       'for Small Business makes protecting '
                                       'files on your devices easy.',
                        'developer': 'Code 42 Software',
                        'display_name': 'CrashPlan for Small Business',
                        'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                      'CFBundleName': 'CrashPlan for Small '
                                                      'Business',
                                      'CFBundleShortVersionString': '8.6.1',
                                      'CFBundleVersion': '3',
                                      'path': '/Applications/Code42.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'CrashPlanForSmallBusiness',
                        'unattended_install': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                       'for Small '
                       'Business/downloads/CrashPlanForSmallBusiness.dmg',
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                     'CFBundleName': 'CrashPlan for Small '
                                                     'Business',
                                     'CFBundleShortVersionString': '8.6.1',
                                     'CFBundleVersion': '3',
                                     'path': '/Applications/Code42.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'CrashPlanForSmallBusiness',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/CrashPlanForSmallBusiness',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Item CrashPlanForSmallBusiness.dmg already exists in the munki repo as pkgs/apps/Code42/Code42-8.6.1.dmg.
{'Output': {'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Code42/Code42-8.6.1.dmg'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/pkgroot/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/unpack/']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/receipts/CrashPlan for Small Business.munki-receipt-20210609-090900.plist

Nothing downloaded, packaged or imported.
```

With this PR in place, we can import the "CrashPlan for Small Business" app.. even though it's on disk called Code42.app, and this allows us to make other changes to the metadata of an app and also means we can import.

Below are some examples with different architectures being defined for the "CrashPlan for Small Business" app, with makecatalogs being ran between:

```
$ /usr/local/munki/makecatalogs 
Getting list of icons...
Getting list of pkgsinfo...
Getting list of pkgs...
Adding pkgsinfo/apps/Code42/Code42-8.6.1.plist to testing...
Created catalogs/all...
Created catalogs/testing...
$ autopkg run -vv ~/Git/other/dataJAR-recipes/CrashPlan\ for\ Small\ Business/CrashPlan\ for\ Small\ Business.munki.recipe
Processing /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'CrashPlanForSmallBusiness.dmg',
           'url': 'https://download.code42.com/installs/agent/latest-smb-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small '
                        'Business/downloads/CrashPlanForSmallBusiness.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small '
                         'Business/downloads/CrashPlanForSmallBusiness.dmg/Install '
                         'CrashPlan for Small Business.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install CrashPlan for Small Business":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-05-24 21:58:41 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2022-03-01 18:01:05 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            1E 54 66 40 7A 2E 59 AB 5F F6 65 01 5A 12 8F EB C1 B8 F7 99 FE E5 
CodeSignatureVerifier:            4C 58 9A 59 D9 3E 47 43 A8 58
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                            'for Small '
                            'Business/downloads/CrashPlanForSmallBusiness.dmg/Install '
                            'CrashPlan for Small Business.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.STFoaW/Install CrashPlan for Small Business.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                      'for Small Business/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/pkgroot/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack/code42.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/code42.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small Business/pkgroot',
           'installs_item_paths': ['/Applications/Code42.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Code42.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                 'CFBundleName': 'CrashPlan '
                                                                 'for Small '
                                                                 'Business',
                                                 'CFBundleShortVersionString': '8.6.1',
                                                 'CFBundleVersion': '3',
                                                 'path': '/Applications/Code42.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                'CFBundleName': 'CrashPlan for '
                                                                'Small '
                                                                'Business',
                                                'CFBundleShortVersionString': '8.6.1',
                                                'CFBundleVersion': '3',
                                                'path': '/Applications/Code42.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'name': 'CrashPlanForSmallBusiness',
                       'supported_architectures': ['x86_64'],
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop', 'CFBundleName': 'CrashPlan for Small Business', 'CFBundleShortVersionString': '8.6.1', 'CFBundleVersion': '3', 'path': '/Applications/Code42.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Electron Helper '
                                                  '(Renderer).app',
                                                  'Code42.app',
                                                  'Electron Helper (GPU).app',
                                                  'CrashPlan for Small '
                                                  'BusinessService.app',
                                                  'Electron Helper '
                                                  '(Plugin).app',
                                                  'Electron Helper.app'],
                        'catalogs': ['testing'],
                        'description': 'Enterprise-grade data loss protection '
                                       'at small business prices. CrashPlan® '
                                       'for Small Business makes protecting '
                                       'files on your devices easy.',
                        'developer': 'Code 42 Software',
                        'display_name': 'CrashPlan for Small Business',
                        'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                      'CFBundleName': 'CrashPlan for Small '
                                                      'Business',
                                      'CFBundleShortVersionString': '8.6.1',
                                      'CFBundleVersion': '3',
                                      'path': '/Applications/Code42.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'CrashPlanForSmallBusiness',
                        'supported_architectures': ['x86_64'],
                        'unattended_install': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                       'for Small '
                       'Business/downloads/CrashPlanForSmallBusiness.dmg',
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                     'CFBundleName': 'CrashPlan for Small '
                                                     'Business',
                                     'CFBundleShortVersionString': '8.6.1',
                                     'CFBundleVersion': '3',
                                     'path': '/Applications/Code42.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'CrashPlanForSmallBusiness',
                       'supported_architectures': ['x86_64'],
                       'unattended_install': True},
           'repo_subdirectory': 'apps/CrashPlanForSmallBusiness',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'CrashPlanForSmallBusiness',
                                                       'pkg_repo_path': 'apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.dmg',
                                                       'pkginfo_path': 'apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.plist',
                                                       'version': '8.6.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 6, 9, 10, 40, 12),
                                         'munki_version': '5.3.0.4335',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'blocking_applications': ['Electron Helper '
                                                     '(Renderer).app',
                                                     'Code42.app',
                                                     'Electron Helper '
                                                     '(GPU).app',
                                                     'CrashPlan for Small '
                                                     'BusinessService.app',
                                                     'Electron Helper '
                                                     '(Plugin).app',
                                                     'Electron Helper.app'],
                           'catalogs': ['testing'],
                           'description': 'Enterprise-grade data loss '
                                          'protection at small business '
                                          'prices. CrashPlan® for Small '
                                          'Business makes protecting files on '
                                          'your devices easy.',
                           'developer': 'Code 42 Software',
                           'display_name': 'CrashPlan for Small Business',
                           'installed_size': 312675,
                           'installer_item_hash': '46217f97c8cb2ac01c61fa249f14f68532c3817fa82ea02c81e7fb583dcc0402',
                           'installer_item_location': 'apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.dmg',
                           'installer_item_size': 176531,
                           'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                         'CFBundleName': 'CrashPlan for Small '
                                                         'Business',
                                         'CFBundleShortVersionString': '8.6.1',
                                         'CFBundleVersion': '3',
                                         'path': '/Applications/Code42.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'CrashPlanForSmallBusiness',
                           'receipts': [{'installed_size': 312675,
                                         'packageid': 'com.code42.app.pkg',
                                         'version': '8.6.1'}],
                           'supported_architectures': ['x86_64'],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '8.6.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/pkgroot/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/unpack/']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/receipts/CrashPlan for Small Business.munki-receipt-20210609-114013.plist

The following new items were imported into Munki:
    Name                       Version  Catalogs  Pkginfo Path                                                          Pkg Repo Path                                                       Icon Repo Path  
    ----                       -------  --------  ------------                                                          -------------                                                       --------------  
    CrashPlanForSmallBusiness  8.6.1    testing   apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.plist  apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.dmg                  
$ /usr/local/munki/makecatalogs                                                                                           
Getting list of icons...
Getting list of pkgsinfo...
Getting list of pkgs...
Adding pkgsinfo/apps/Code42/Code42-8.6.1.plist to testing...
Adding pkgsinfo/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.plist to testing...
Created catalogs/all...
Created catalogs/testing...
$ autopkg run -vv ~/Git/other/dataJAR-recipes/CrashPlan\ for\ Small\ Business/CrashPlan\ for\ Small\ Business.munki.recipe
Processing /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'CrashPlanForSmallBusiness.dmg',
           'url': 'https://download.code42.com/installs/agent/latest-smb-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small '
                        'Business/downloads/CrashPlanForSmallBusiness.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small '
                         'Business/downloads/CrashPlanForSmallBusiness.dmg/Install '
                         'CrashPlan for Small Business.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install CrashPlan for Small Business":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-05-24 21:58:41 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2022-03-01 18:01:05 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            1E 54 66 40 7A 2E 59 AB 5F F6 65 01 5A 12 8F EB C1 B8 F7 99 FE E5 
CodeSignatureVerifier:            4C 58 9A 59 D9 3E 47 43 A8 58
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                            'for Small '
                            'Business/downloads/CrashPlanForSmallBusiness.dmg/Install '
                            'CrashPlan for Small Business.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.dOZ721/Install CrashPlan for Small Business.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                      'for Small Business/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/pkgroot/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack/code42.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/code42.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small Business/pkgroot',
           'installs_item_paths': ['/Applications/Code42.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Code42.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                 'CFBundleName': 'CrashPlan '
                                                                 'for Small '
                                                                 'Business',
                                                 'CFBundleShortVersionString': '8.6.1',
                                                 'CFBundleVersion': '3',
                                                 'path': '/Applications/Code42.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                'CFBundleName': 'CrashPlan for '
                                                                'Small '
                                                                'Business',
                                                'CFBundleShortVersionString': '8.6.1',
                                                'CFBundleVersion': '3',
                                                'path': '/Applications/Code42.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'name': 'CrashPlanForSmallBusiness',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop', 'CFBundleName': 'CrashPlan for Small Business', 'CFBundleShortVersionString': '8.6.1', 'CFBundleVersion': '3', 'path': '/Applications/Code42.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Electron Helper '
                                                  '(Renderer).app',
                                                  'Code42.app',
                                                  'Electron Helper (GPU).app',
                                                  'CrashPlan for Small '
                                                  'BusinessService.app',
                                                  'Electron Helper '
                                                  '(Plugin).app',
                                                  'Electron Helper.app'],
                        'catalogs': ['testing'],
                        'description': 'Enterprise-grade data loss protection '
                                       'at small business prices. CrashPlan® '
                                       'for Small Business makes protecting '
                                       'files on your devices easy.',
                        'developer': 'Code 42 Software',
                        'display_name': 'CrashPlan for Small Business',
                        'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                      'CFBundleName': 'CrashPlan for Small '
                                                      'Business',
                                      'CFBundleShortVersionString': '8.6.1',
                                      'CFBundleVersion': '3',
                                      'path': '/Applications/Code42.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'CrashPlanForSmallBusiness',
                        'supported_architectures': ['arm64'],
                        'unattended_install': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                       'for Small '
                       'Business/downloads/CrashPlanForSmallBusiness.dmg',
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                     'CFBundleName': 'CrashPlan for Small '
                                                     'Business',
                                     'CFBundleShortVersionString': '8.6.1',
                                     'CFBundleVersion': '3',
                                     'path': '/Applications/Code42.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'CrashPlanForSmallBusiness',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True},
           'repo_subdirectory': 'apps/CrashPlanForSmallBusiness',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'CrashPlanForSmallBusiness',
                                                       'pkg_repo_path': 'apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.dmg',
                                                       'pkginfo_path': 'apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.plist',
                                                       'version': '8.6.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 6, 9, 10, 40, 33),
                                         'munki_version': '5.3.0.4335',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'blocking_applications': ['Electron Helper '
                                                     '(Renderer).app',
                                                     'Code42.app',
                                                     'Electron Helper '
                                                     '(GPU).app',
                                                     'CrashPlan for Small '
                                                     'BusinessService.app',
                                                     'Electron Helper '
                                                     '(Plugin).app',
                                                     'Electron Helper.app'],
                           'catalogs': ['testing'],
                           'description': 'Enterprise-grade data loss '
                                          'protection at small business '
                                          'prices. CrashPlan® for Small '
                                          'Business makes protecting files on '
                                          'your devices easy.',
                           'developer': 'Code 42 Software',
                           'display_name': 'CrashPlan for Small Business',
                           'installed_size': 312675,
                           'installer_item_hash': '46217f97c8cb2ac01c61fa249f14f68532c3817fa82ea02c81e7fb583dcc0402',
                           'installer_item_location': 'apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.dmg',
                           'installer_item_size': 176531,
                           'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                         'CFBundleName': 'CrashPlan for Small '
                                                         'Business',
                                         'CFBundleShortVersionString': '8.6.1',
                                         'CFBundleVersion': '3',
                                         'path': '/Applications/Code42.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'CrashPlanForSmallBusiness',
                           'receipts': [{'installed_size': 312675,
                                         'packageid': 'com.code42.app.pkg',
                                         'version': '8.6.1'}],
                           'supported_architectures': ['arm64'],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '8.6.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/pkgroot/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/unpack/']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/receipts/CrashPlan for Small Business.munki-receipt-20210609-114034.plist

The following new items were imported into Munki:
    Name                       Version  Catalogs  Pkginfo Path                                                             Pkg Repo Path                                                          Icon Repo Path  
    ----                       -------  --------  ------------                                                             -------------                                                          --------------  
    CrashPlanForSmallBusiness  8.6.1    testing   apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.plist  apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.dmg                  
$ /usr/local/munki/makecatalogs                                                                                           
Getting list of icons...
Getting list of pkgsinfo...
Getting list of pkgs...
Adding pkgsinfo/apps/Code42/Code42-8.6.1.plist to testing...
Adding pkgsinfo/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.plist to testing...
Adding pkgsinfo/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.plist to testing...
Created catalogs/all...
Created catalogs/testing...
$ autopkg run -vv ~/Git/other/dataJAR-recipes/CrashPlan\ for\ Small\ Business/CrashPlan\ for\ Small\ Business.munki.recipe
Processing /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'CrashPlanForSmallBusiness.dmg',
           'url': 'https://download.code42.com/installs/agent/latest-smb-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small '
                        'Business/downloads/CrashPlanForSmallBusiness.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small '
                         'Business/downloads/CrashPlanForSmallBusiness.dmg/Install '
                         'CrashPlan for Small Business.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install CrashPlan for Small Business":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-05-24 21:58:41 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2022-03-01 18:01:05 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            1E 54 66 40 7A 2E 59 AB 5F F6 65 01 5A 12 8F EB C1 B8 F7 99 FE E5 
CodeSignatureVerifier:            4C 58 9A 59 D9 3E 47 43 A8 58
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                            'for Small '
                            'Business/downloads/CrashPlanForSmallBusiness.dmg/Install '
                            'CrashPlan for Small Business.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.8AAOdh/Install CrashPlan for Small Business.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                      'for Small Business/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/pkgroot/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack/code42.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/code42.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small Business/pkgroot',
           'installs_item_paths': ['/Applications/Code42.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Code42.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                 'CFBundleName': 'CrashPlan '
                                                                 'for Small '
                                                                 'Business',
                                                 'CFBundleShortVersionString': '8.6.1',
                                                 'CFBundleVersion': '3',
                                                 'path': '/Applications/Code42.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                'CFBundleName': 'CrashPlan for '
                                                                'Small '
                                                                'Business',
                                                'CFBundleShortVersionString': '8.6.1',
                                                'CFBundleVersion': '3',
                                                'path': '/Applications/Code42.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'name': 'CrashPlanForSmallBusiness',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop', 'CFBundleName': 'CrashPlan for Small Business', 'CFBundleShortVersionString': '8.6.1', 'CFBundleVersion': '3', 'path': '/Applications/Code42.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Electron Helper '
                                                  '(Renderer).app',
                                                  'Code42.app',
                                                  'Electron Helper (GPU).app',
                                                  'CrashPlan for Small '
                                                  'BusinessService.app',
                                                  'Electron Helper '
                                                  '(Plugin).app',
                                                  'Electron Helper.app'],
                        'catalogs': ['testing'],
                        'description': 'Enterprise-grade data loss protection '
                                       'at small business prices. CrashPlan® '
                                       'for Small Business makes protecting '
                                       'files on your devices easy.',
                        'developer': 'Code 42 Software',
                        'display_name': 'CrashPlan for Small Business',
                        'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                      'CFBundleName': 'CrashPlan for Small '
                                                      'Business',
                                      'CFBundleShortVersionString': '8.6.1',
                                      'CFBundleVersion': '3',
                                      'path': '/Applications/Code42.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'CrashPlanForSmallBusiness',
                        'supported_architectures': ['arm64'],
                        'unattended_install': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                       'for Small '
                       'Business/downloads/CrashPlanForSmallBusiness.dmg',
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                     'CFBundleName': 'CrashPlan for Small '
                                                     'Business',
                                     'CFBundleShortVersionString': '8.6.1',
                                     'CFBundleVersion': '3',
                                     'path': '/Applications/Code42.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'CrashPlanForSmallBusiness',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True},
           'repo_subdirectory': 'apps/CrashPlanForSmallBusiness',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Item CrashPlanForSmallBusiness.dmg already exists in the munki repo as pkgs/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.dmg.
{'Output': {'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.dmg'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/pkgroot/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/unpack/']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/receipts/CrashPlan for Small Business.munki-receipt-20210609-114049.plist

Nothing downloaded, packaged or imported.
```

And the below is where the "name" has been changed, which is something we do for the different licensing around Microsoft apps:

```
$ autopkg run -vv ~/Git/other/dataJAR-recipes/CrashPlan\ for\ Small\ Business/CrashPlan\ for\ Small\ Business.munki.recipe
Processing /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'CrashPlanForSmallBusiness-TEST.dmg',
           'url': 'https://download.code42.com/installs/agent/latest-smb-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 02 Jun 2021 14:39:52 GMT
URLDownloader: Storing new ETag header: "60b79838-ac64c73"
URLDownloader: Downloaded /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness-TEST.dmg
{'Output': {'download_changed': True,
            'etag': '"60b79838-ac64c73"',
            'last_modified': 'Wed, 02 Jun 2021 14:39:52 GMT',
            'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small '
                        'Business/downloads/CrashPlanForSmallBusiness-TEST.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                                                                        'for '
                                                                        'Small '
                                                                        'Business/downloads/CrashPlanForSmallBusiness-TEST.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small '
                         'Business/downloads/CrashPlanForSmallBusiness-TEST.dmg/Install '
                         'CrashPlan for Small Business.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness-TEST.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install CrashPlan for Small Business":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-05-24 21:58:41 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2022-03-01 18:01:05 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            1E 54 66 40 7A 2E 59 AB 5F F6 65 01 5A 12 8F EB C1 B8 F7 99 FE E5 
CodeSignatureVerifier:            4C 58 9A 59 D9 3E 47 43 A8 58
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                            'for Small '
                            'Business/downloads/CrashPlanForSmallBusiness-TEST.dmg/Install '
                            'CrashPlan for Small Business.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness-TEST.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.hdbQwz/Install CrashPlan for Small Business.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                      'for Small Business/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/pkgroot/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack/code42.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/code42.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small Business/pkgroot',
           'installs_item_paths': ['/Applications/Code42.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Code42.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                 'CFBundleName': 'CrashPlan '
                                                                 'for Small '
                                                                 'Business',
                                                 'CFBundleShortVersionString': '8.6.1',
                                                 'CFBundleVersion': '3',
                                                 'path': '/Applications/Code42.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                'CFBundleName': 'CrashPlan for '
                                                                'Small '
                                                                'Business',
                                                'CFBundleShortVersionString': '8.6.1',
                                                'CFBundleVersion': '3',
                                                'path': '/Applications/Code42.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'name': 'CrashPlanForSmallBusiness-TEST',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop', 'CFBundleName': 'CrashPlan for Small Business', 'CFBundleShortVersionString': '8.6.1', 'CFBundleVersion': '3', 'path': '/Applications/Code42.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Electron Helper '
                                                  '(Renderer).app',
                                                  'Code42.app',
                                                  'Electron Helper (GPU).app',
                                                  'CrashPlan for Small '
                                                  'BusinessService.app',
                                                  'Electron Helper '
                                                  '(Plugin).app',
                                                  'Electron Helper.app'],
                        'catalogs': ['testing'],
                        'description': 'Enterprise-grade data loss protection '
                                       'at small business prices. CrashPlan® '
                                       'for Small Business makes protecting '
                                       'files on your devices easy.',
                        'developer': 'Code 42 Software',
                        'display_name': 'CrashPlan for Small Business',
                        'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                      'CFBundleName': 'CrashPlan for Small '
                                                      'Business',
                                      'CFBundleShortVersionString': '8.6.1',
                                      'CFBundleVersion': '3',
                                      'path': '/Applications/Code42.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'CrashPlanForSmallBusiness-TEST',
                        'supported_architectures': ['arm64'],
                        'unattended_install': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                       'for Small '
                       'Business/downloads/CrashPlanForSmallBusiness-TEST.dmg',
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                     'CFBundleName': 'CrashPlan for Small '
                                                     'Business',
                                     'CFBundleShortVersionString': '8.6.1',
                                     'CFBundleVersion': '3',
                                     'path': '/Applications/Code42.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'CrashPlanForSmallBusiness-TEST',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True},
           'repo_subdirectory': 'apps/CrashPlanForSmallBusiness-TEST',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'CrashPlanForSmallBusiness-TEST',
                                                       'pkg_repo_path': 'apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.dmg',
                                                       'pkginfo_path': 'apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.plist',
                                                       'version': '8.6.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 6, 9, 10, 41, 30),
                                         'munki_version': '5.3.0.4335',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'blocking_applications': ['Electron Helper '
                                                     '(Renderer).app',
                                                     'Code42.app',
                                                     'Electron Helper '
                                                     '(GPU).app',
                                                     'CrashPlan for Small '
                                                     'BusinessService.app',
                                                     'Electron Helper '
                                                     '(Plugin).app',
                                                     'Electron Helper.app'],
                           'catalogs': ['testing'],
                           'description': 'Enterprise-grade data loss '
                                          'protection at small business '
                                          'prices. CrashPlan® for Small '
                                          'Business makes protecting files on '
                                          'your devices easy.',
                           'developer': 'Code 42 Software',
                           'display_name': 'CrashPlan for Small Business',
                           'installed_size': 312675,
                           'installer_item_hash': '46217f97c8cb2ac01c61fa249f14f68532c3817fa82ea02c81e7fb583dcc0402',
                           'installer_item_location': 'apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.dmg',
                           'installer_item_size': 176531,
                           'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                         'CFBundleName': 'CrashPlan for Small '
                                                         'Business',
                                         'CFBundleShortVersionString': '8.6.1',
                                         'CFBundleVersion': '3',
                                         'path': '/Applications/Code42.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'CrashPlanForSmallBusiness-TEST',
                           'receipts': [{'installed_size': 312675,
                                         'packageid': 'com.code42.app.pkg',
                                         'version': '8.6.1'}],
                           'supported_architectures': ['arm64'],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '8.6.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/pkgroot/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/unpack/']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/receipts/CrashPlan for Small Business.munki-receipt-20210609-114130.plist

The following new items were downloaded:
    Download Path                                                                                                                                
    -------------                                                                                                                                
    /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness-TEST.dmg  

The following new items were imported into Munki:
    Name                            Version  Catalogs  Pkginfo Path                                                                    Pkg Repo Path                                                                 Icon Repo Path  
    ----                            -------  --------  ------------                                                                    -------------                                                                 --------------  
    CrashPlanForSmallBusiness-TEST  8.6.1    testing   apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.plist  apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.dmg                  
$ /usr/local/munki/makecatalogs                                                                                           
Getting list of icons...
Getting list of pkgsinfo...
Getting list of pkgs...
Adding pkgsinfo/apps/Code42/Code42-8.6.1.plist to testing...
Adding pkgsinfo/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1.plist to testing...
Adding pkgsinfo/apps/CrashPlanForSmallBusiness/CrashPlanForSmallBusiness-8.6.1__1.plist to testing...
Adding pkgsinfo/apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.plist to testing...
Created catalogs/all...
Created catalogs/testing...
$ autopkg run -vv ~/Git/other/dataJAR-recipes/CrashPlan\ for\ Small\ Business/CrashPlan\ for\ Small\ Business.munki.recipe
Processing /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/CrashPlan for Small Business/CrashPlan for Small Business.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'CrashPlanForSmallBusiness-TEST.dmg',
           'url': 'https://download.code42.com/installs/agent/latest-smb-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness-TEST.dmg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small '
                        'Business/downloads/CrashPlanForSmallBusiness-TEST.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Code 42 '
                                        'Software (9YV9435DHD)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small '
                         'Business/downloads/CrashPlanForSmallBusiness-TEST.dmg/Install '
                         'CrashPlan for Small Business.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness-TEST.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install CrashPlan for Small Business":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-05-24 21:58:41 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Code 42 Software (9YV9435DHD)
CodeSignatureVerifier:        Expires: 2022-03-01 18:01:05 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            1E 54 66 40 7A 2E 59 AB 5F F6 65 01 5A 12 8F EB C1 B8 F7 99 FE E5 
CodeSignatureVerifier:            4C 58 9A 59 D9 3E 47 43 A8 58
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                            'for Small '
                            'Business/downloads/CrashPlanForSmallBusiness-TEST.dmg/Install '
                            'CrashPlan for Small Business.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Mounted disk image /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/downloads/CrashPlanForSmallBusiness-TEST.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.OsUrz5/Install CrashPlan for Small Business.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0755'},
           'pkgroot': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                      'for Small Business/pkgroot'}}
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot
PkgRootCreator: Creating Applications
PkgRootCreator: Created /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/pkgroot/Applications',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                               'for Small Business/unpack/code42.pkg/Payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/code42.pkg/Payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/Applications
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                        'for Small Business/pkgroot',
           'installs_item_paths': ['/Applications/Code42.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Code42.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                 'CFBundleName': 'CrashPlan '
                                                                 'for Small '
                                                                 'Business',
                                                 'CFBundleShortVersionString': '8.6.1',
                                                 'CFBundleVersion': '3',
                                                 'path': '/Applications/Code42.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                                'CFBundleName': 'CrashPlan for '
                                                                'Small '
                                                                'Business',
                                                'CFBundleShortVersionString': '8.6.1',
                                                'CFBundleVersion': '3',
                                                'path': '/Applications/Code42.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'name': 'CrashPlanForSmallBusiness-TEST',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.backup42.desktop', 'CFBundleName': 'CrashPlan for Small Business', 'CFBundleShortVersionString': '8.6.1', 'CFBundleVersion': '3', 'path': '/Applications/Code42.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': ['Electron Helper '
                                                  '(Renderer).app',
                                                  'Code42.app',
                                                  'Electron Helper (GPU).app',
                                                  'CrashPlan for Small '
                                                  'BusinessService.app',
                                                  'Electron Helper '
                                                  '(Plugin).app',
                                                  'Electron Helper.app'],
                        'catalogs': ['testing'],
                        'description': 'Enterprise-grade data loss protection '
                                       'at small business prices. CrashPlan® '
                                       'for Small Business makes protecting '
                                       'files on your devices easy.',
                        'developer': 'Code 42 Software',
                        'display_name': 'CrashPlan for Small Business',
                        'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                      'CFBundleName': 'CrashPlan for Small '
                                                      'Business',
                                      'CFBundleShortVersionString': '8.6.1',
                                      'CFBundleVersion': '3',
                                      'path': '/Applications/Code42.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'CrashPlanForSmallBusiness-TEST',
                        'supported_architectures': ['arm64'],
                        'unattended_install': True}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                       'for Small '
                       'Business/downloads/CrashPlanForSmallBusiness-TEST.dmg',
           'pkginfo': {'blocking_applications': ['Electron Helper '
                                                 '(Renderer).app',
                                                 'Code42.app',
                                                 'Electron Helper (GPU).app',
                                                 'CrashPlan for Small '
                                                 'BusinessService.app',
                                                 'Electron Helper (Plugin).app',
                                                 'Electron Helper.app'],
                       'catalogs': ['testing'],
                       'description': 'Enterprise-grade data loss protection '
                                      'at small business prices. CrashPlan® '
                                      'for Small Business makes protecting '
                                      'files on your devices easy.',
                       'developer': 'Code 42 Software',
                       'display_name': 'CrashPlan for Small Business',
                       'installs': [{'CFBundleIdentifier': 'com.backup42.desktop',
                                     'CFBundleName': 'CrashPlan for Small '
                                                     'Business',
                                     'CFBundleShortVersionString': '8.6.1',
                                     'CFBundleVersion': '3',
                                     'path': '/Applications/Code42.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'CrashPlanForSmallBusiness-TEST',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True},
           'repo_subdirectory': 'apps/CrashPlanForSmallBusiness-TEST',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Item CrashPlanForSmallBusiness-TEST.dmg already exists in the munki repo as pkgs/apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.dmg.
{'Output': {'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/CrashPlanForSmallBusiness-TEST/CrashPlanForSmallBusiness-TEST-8.6.1.dmg'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/pkgroot/',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan '
                         'for Small Business/unpack/']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/pkgroot/
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/unpack/
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.CrashPlan for Small Business/receipts/CrashPlan for Small Business.munki-receipt-20210609-114253.plist
```