### PR TITLE
Dev fix get token newline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ sudo ln -s /Users/Shared/Python3/Python.framework/Versions/3.7/bin/python3 /usr/
 ## Use pre-commit to set automatic commit requirements
 
 This project makes use of [pre-commit](https://pre-commit.com/) to do automatic
-lint and style checing on every commit containing Python files.
+lint and style checking on every commit containing Python files.
 
 To install the pre-commit hook, run the executable from your Python 3 framework
 while in your current autopkg git checkout:

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2312,6 +2312,9 @@ def run_recipes(argv):
                     result = item["Output"][key]
                     summary_text = result.get("summary_text", "")
                     data = result.get("data")
+                    if not data:
+                        log("WARNING: %s has no data. Skipping." % key)
+                        continue
                     if key not in summary_results:
                         summary_results[key] = {}
                         summary_results[key]["summary_text"] = summary_text

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2313,7 +2313,12 @@ def run_recipes(argv):
                     summary_text = result.get("summary_text", "")
                     data = result.get("data")
                     if not data:
-                        log("WARNING: %s has no data. Skipping." % key)
+                        log(
+                            'WARNING: Cannot display summary result because "%s" does not have a '
+                            '"data" dictionary. See wiki for more information: '
+                            "https://github.com/autopkg/autopkg/wiki/Processor-Summary-Reporting"
+                            % key
+                        )
                         continue
                     if key not in summary_results:
                         summary_results[key] = {}

--- a/Code/autopkglib/AppPkgCreator.py
+++ b/Code/autopkglib/AppPkgCreator.py
@@ -98,7 +98,7 @@ class AppPkgCreator(DmgMounter, PkgCreator):
         """Build a packaging request, send it to the autopkgserver and get the
         constructed package."""
 
-        # clear any pre-exising summary result
+        # clear any pre-existing summary result
         if "app_pkg_creator_summary_result" in self.env:
             del self.env["app_pkg_creator_summary_result"]
 

--- a/Code/autopkglib/InstallFromDMG.py
+++ b/Code/autopkglib/InstallFromDMG.py
@@ -64,7 +64,7 @@ class InstallFromDMG(DmgMounter):
 
     def install(self):
         """Build an ItemCopier request, send it to autopkginstalld"""
-        # clear any pre-exising summary result
+        # clear any pre-existing summary result
         if "install_from_dmg_summary_result" in self.env:
             del self.env["install_from_dmg_summary_result"]
 

--- a/Code/autopkglib/Installer.py
+++ b/Code/autopkglib/Installer.py
@@ -68,7 +68,7 @@ class Installer(DmgMounter):
 
     def install(self):
         """Build an installation request, send it to autopkginstalld"""
-        # clear any pre-exising summary result
+        # clear any pre-existing summary result
         if "installer_summary_result" in self.env:
             del self.env["installer_summary_result"]
 

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -296,7 +296,7 @@ class MunkiImporter(Processor):
         self.output(f'        plugin: {self.env["MUNKI_REPO_PLUGIN"]}')
         self.output(f'          repo: {self.env["MUNKI_REPO"]}')
 
-        # clear any pre-exising summary result
+        # clear any pre-existing summary result
         if "munki_importer_summary_result" in self.env:
             del self.env["munki_importer_summary_result"]
         # Generate arguments for makepkginfo.

--- a/Code/autopkglib/PkgCopier.py
+++ b/Code/autopkglib/PkgCopier.py
@@ -53,7 +53,7 @@ class PkgCopier(Copier):
     }
 
     def main(self):
-        # clear any pre-exising summary result
+        # clear any pre-existing summary result
         if "pkg_copier_summary_result" in self.env:
             del self.env["pkg_copier_summary_result"]
 

--- a/Code/autopkglib/PkgCreator.py
+++ b/Code/autopkglib/PkgCreator.py
@@ -160,7 +160,7 @@ class PkgCreator(Processor):
         """Build a packaging request, send it to the autopkgserver and get the
         constructed package."""
 
-        # clear any pre-exising summary result
+        # clear any pre-existing summary result
         if "pkg_creator_summary_result" in self.env:
             del self.env["pkg_creator_summary_result"]
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -36,7 +36,7 @@ import yaml
 # Type for methods that accept either a filesystem path or a file-like object.
 FileOrPath = Union[IO, str, bytes, int]
 
-# Type for ubiquitus dictionary type used throughout autopkg.
+# Type for ubiquitous dictionary type used throughout autopkg.
 # Most commonly for `input_variables` and friends. It also applies to virtually all
 # usages of plistlib results as well.
 VarDict = Dict[str, Any]
@@ -439,7 +439,7 @@ def update_data(a_dict, key, value):
             for index in range(len(item)):
                 item[index] = do_variable_substitution(item[index])
         elif isinstance(item, (dict, NSDictionary)):
-            # Modify a copy of the orginal
+            # Modify a copy of the original
             if isinstance(item, dict):
                 item_copy = item.copy()
             else:

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -64,7 +64,7 @@ class GitHubSession(URLGetter):
         if not token and os.path.exists(token_path):
             try:
                 with open(token_path, "r") as tokenf:
-                    token = tokenf.read()
+                    token = tokenf.read().rstrip("\n")
             except OSError as err:
                 log_err(f"Couldn't read token file at {token_path}! Error: {err}")
                 token = None

--- a/Code/autopkgserver/autopkginstalld
+++ b/Code/autopkgserver/autopkginstalld
@@ -218,7 +218,7 @@ def main(argv):
     wheel_gid = 0
     admin_gid = 80
 
-    exepath = os.path.realpath(os.path.abspath(__file__))
+    exepath = os.path.realpath(os.path.abspath(sys.argv[0]))
     path_ok = True
     while True:
         info = os.stat(exepath)

--- a/Code/autopkgserver/autopkgserver
+++ b/Code/autopkgserver/autopkgserver
@@ -329,7 +329,7 @@ def main(argv):
     wheel_gid = 0
     admin_gid = 80
 
-    exepath = os.path.realpath(os.path.abspath(__file__))
+    exepath = os.path.realpath(os.path.abspath(sys.argv[0]))
     path_ok = True
     while True:
         info = os.stat(exepath)

--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -357,7 +357,7 @@ class Packager:
                 os.lchown(chownpath, uid, gid)
                 if chmod_present:
                     self.log.info(f"Setting mode of {entry['path']} to {entry['mode']}")
-                    os.chmod(chownpath, int(entry["mode"], 8))
+                    os.lchmod(chownpath, int(entry["mode"], 8))
             else:
                 for (dirpath, dirnames, filenames) in os.walk(chownpath):
                     try:
@@ -369,7 +369,7 @@ class Packager:
                         try:
                             os.lchown(path, uid, gid)
                             if chmod_present:
-                                os.chmod(path, int(entry["mode"], 8))
+                                os.lchmod(path, int(entry["mode"], 8))
                         except OSError as e:
                             raise PackagerError(f"Can't lchown {path}: {e}")
 

--- a/Scripts/generate_processor_docs.py
+++ b/Scripts/generate_processor_docs.py
@@ -49,9 +49,8 @@ except ImportError:
 def writefile(stringdata, path):
     """Writes string data to path."""
     try:
-        fileobject = open(path, mode="w", buffering=1)
-        print(stringdata.encode("UTF-8"), file=fileobject)
-        fileobject.close()
+        with open(path, mode="w", buffering=1) as fileobject:
+            print(stringdata, file=fileobject)
     except OSError:
         print(f"Couldn't write to {path}", file=fileobject)
 

--- a/Scripts/generate_processor_docs.py
+++ b/Scripts/generate_processor_docs.py
@@ -46,6 +46,13 @@ except ImportError:
 # pylint: enable=import-error
 
 
+# Processors that exist in the codebase but are not yet fully supported.
+EXPERIMENTAL_PROCS = (
+    "ChocolateyPackager",
+    "SignToolVerifier",
+)
+
+
 def writefile(stringdata, path):
     """Writes string data to path."""
     try:
@@ -101,6 +108,8 @@ def generate_sidebar(sidebar_path):
     toc_string = ""
     toc_string += processor_heading + "\n"
     for processor_name in sorted(processor_names(), key=lambda s: s.lower()):
+        if processor_name in EXPERIMENTAL_PROCS:
+            continue
         page_name = f"Processor-{processor_name}"
         page_name.replace(" ", "-")
         toc_string += f"      * [[{processor_name}|{page_name}]]\n"
@@ -180,7 +189,10 @@ def main(_):
     print()
 
     # Generate markdown pages for each processor attributes
-    for processor_name in processor_names():
+    for processor_name in sorted(processor_names(), key=lambda s: s.lower()):
+        if processor_name in EXPERIMENTAL_PROCS:
+            print(f"Skipping experimental processor {processor_name}")
+            continue
         if options.processor:
             if options.processor != processor_name:
                 continue

--- a/Scripts/generate_processor_docs.py
+++ b/Scripts/generate_processor_docs.py
@@ -176,7 +176,7 @@ def main(_):
     # Grab the version for the commit log.
     version = arguments[0]
 
-    print("Cloning AutoPkg wiki..")
+    print("Cloning AutoPkg wiki...")
     print()
 
     if options.directory:
@@ -184,7 +184,7 @@ def main(_):
     else:
         output_dir = clone_wiki_dir()
 
-    print(f"Cloned to {output_dir}.")
+    print(f"Cloned to {output_dir}")
     print()
     print()
 
@@ -259,7 +259,7 @@ def main(_):
         "Shown above is the commit log for the changes to the wiki markdown. \n"
         "Type 'push' to accept and push the changes to GitHub. The wiki repo \n"
         "local clone can be also inspected at:\n"
-        f"{output_dir}."
+        f"{output_dir}"
     )
 
     push_commit = input()


### PR DESCRIPTION
Strip any newlines from the end of the .autopkg_gh_token file. I've also tested it with two newlines.

Reproducde the issue by appending a newline (or two) to ~/.autopkg_gh_token and then run `autopkg info` on the recipe of your choice.

`Code/autopkg info Boot2Docker.munki
Didn't find a recipe for Boot2Docker.munki.
Search GitHub AutoPkg repos for a Boot2Docker.munki recipe? [y/n]: y
Traceback (most recent call last):
  File "/Users/jotai/git/autopkg/Code/autopkglib/URLGetter.py", line 177, in execute_curl
    errors=errors,
  File "/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/bin/curl', '--location', '--silent', '--show-error', '--fail', '--dump-header', '-', '-X', 'GET', '--header', 'User-Agent: AutoPkg', '--header', 'Accept: application/vnd.github.v3.text-match+json', '--header', 'Authorization: token ghp_mymadeuptokenplaceholder\n', '--url', 'https://api.github.com/search/code?q=Boot2Docker.munki+extension:recipe+extension:plist+extension:yaml+user:autopkg+in:path,file&per_page=100', '--output', '/var/folders/97/dpdljdldj3tq6b37wvqmdljsj000gp/T/tmpc1dsoej0c8']' returned non-zero exit status 52.`