### PR TITLE
Strip newlines from token file

### DIFF
--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -64,7 +64,7 @@ class GitHubSession(URLGetter):
         if not token and os.path.exists(token_path):
             try:
                 with open(token_path, "r") as tokenf:
-                    token = tokenf.read()
+                    token = tokenf.read().rstrip("\n")
             except OSError as err:
                 log_err(f"Couldn't read token file at {token_path}! Error: {err}")
                 token = None

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -64,7 +64,7 @@ class GitHubSession(URLGetter):
         if not token and os.path.exists(token_path):
             try:
                 with open(token_path, "r") as tokenf:
-                    token = tokenf.read().rstrip("\n")
+                    token = tokenf.read().rstrip()
             except OSError as err:
                 log_err(f"Couldn't read token file at {token_path}! Error: {err}")
                 token = None

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -64,7 +64,7 @@ class GitHubSession(URLGetter):
         if not token and os.path.exists(token_path):
             try:
                 with open(token_path, "r") as tokenf:
-                    token = tokenf.read().rstrip()
+                    token = tokenf.read().strip()
             except OSError as err:
                 log_err(f"Couldn't read token file at {token_path}! Error: {err}")
                 token = None


### PR DESCRIPTION
Strip any newlines from the end of the .autopkg_gh_token file. I've also tested it with two newlines.

Reproducde the issue by appending a newline (or two) to ~/.autopkg_gh_token and then run `autopkg info` on the recipe of your choice.

`Code/autopkg info Boot2Docker.munki
Didn't find a recipe for Boot2Docker.munki.
Search GitHub AutoPkg repos for a Boot2Docker.munki recipe? [y/n]: y
Traceback (most recent call last):
  File "/Users/jotai/git/autopkg/Code/autopkglib/URLGetter.py", line 177, in execute_curl
    errors=errors,
  File "/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/bin/curl', '--location', '--silent', '--show-error', '--fail', '--dump-header', '-', '-X', 'GET', '--header', 'User-Agent: AutoPkg', '--header', 'Accept: application/vnd.github.v3.text-match+json', '--header', 'Authorization: token ghp_mymadeuptokenplaceholder\n', '--url', 'https://api.github.com/search/code?q=Boot2Docker.munki+extension:recipe+extension:plist+extension:yaml+user:autopkg+in:path,file&per_page=100', '--output', '/var/folders/97/dpdljdldj3tq6b37wvqmdljsj000gp/T/tmpc1dsoej0c8']' returned non-zero exit status 52.`