### PR TITLE
Add option in MunkiImporter to set PackageCompleteURL from env["url"]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ autopkgc
 
 # IDE-specific files
 .vscode
+.idea

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -129,6 +129,14 @@ class MunkiImporter(Processor):
             ),
             "required": False,
         },
+        "set_PackageCompleteURL": {
+            "description": (
+                "If set to True, the PackageCompleteURL key for the package will be "
+                "set to the url of the package, so that clients will pull from "
+                "the original source rather than the repository. "
+            ),
+            "required": False,
+        },
     }
     output_variables = {
         "pkginfo_repo_path": {
@@ -357,6 +365,11 @@ class MunkiImporter(Processor):
                         )
                     )
                 item["version_comparison_key"] = self.env["version_comparison_key"]
+
+        # set the PackageCompleteURL to the url from env so that clients pull the
+        # package from the original source, not the repo
+        if self.env.get("set_PackageCompleteURL"):
+            pkginfo["PackageCompleteURL"] = self.env["url"]
 
         # check to see if this item is already in the repo
         if self.env.get("force_munkiimport"):

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -131,9 +131,9 @@ class MunkiImporter(Processor):
         },
         "set_PackageCompleteURL": {
             "description": (
-                "If set to True, the PackageCompleteURL key for the package will be "
+                "If set to True, the PackageCompleteURL key will be "
                 "set to the url of the package, so that clients will pull from "
-                "the original source rather than the repository. "
+                "the original download location rather than the repository. "
             ),
             "required": False,
         },


### PR DESCRIPTION
This is so that the munki clients will pull packages from the original site, especially useful if your organization has many people who are remote. 