### PR TITLE
Update AppPkgCreator.py

### DIFF
--- a/Code/autopkglib/AppPkgCreator.py
+++ b/Code/autopkglib/AppPkgCreator.py
@@ -207,6 +207,9 @@ class AppPkgCreator(DmgMounter, PkgCreator):
             self.output("Disconnecting")
             self.disconnect()
 
+        # Tidy up, deleting the payload dir we created earlier.
+        shutil.rmtree(pkgroot)
+
         # Return path to pkg.
         self.env["pkg_path"] = pkg_path
         self.env["app_pkg_creator_summary_result"] = {


### PR DESCRIPTION
Deletes the `payload` dir at the end of creating the pkg.

This dir is created at os.path.join(self.env["RECIPE_CACHE_DIR"], "payload") when creating a pkg.

pkgroot is defined at line 154.