### PR TITLE
add check for supported_architectures in MunkiImporter - dev branch

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -364,7 +364,8 @@ class MunkiImporter(Processor):
         else:
             matchingitem = self._find_matching_pkginfo(library, pkginfo)
 
-        if matchingitem:
+        if matchingitem and (matchingitem.get("supported_architectures") ==
+                             pkginfo.get("supported_architectures")):
             self.env["pkginfo_repo_path"] = ""
             self.env["pkg_repo_path"] = os.path.join(
                 self.env["MUNKI_REPO"], "pkgs", matchingitem["installer_item_location"]


### PR DESCRIPTION
This is a redo of https://github.com/autopkg/autopkg/pull/756 that uses the `dev` branch as the base and not `master`

This adds a simple check for `supported_architectures`.

I've checked the following cases

1. Running this on a munki recipe that doesn't have this key. Item was previously imported, but I don't think it matters
```
autopkg run Nudge.munki
Processing Nudge.munki...

Nothing downloaded, packaged or imported.
```

2. Running this for the first time on a recipe designed for Intel
```
autopkg run Docker-x86_64.munki
Processing Docker-x86_64.munki...

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                                   Pkg Repo Path                                Icon Repo Path  
    ----    -------  --------  ------------                                   -------------                                --------------  
    Docker  3.5.2    alpha     applications/Docker/Docker/Docker-3.5.2.plist  applications/Docker/Docker/Docker-3.5.2.dmg
```

3. Running this for a second time on the Intel recipe after makecatalogs
```
autopkg run Docker-x86_64.munki
Processing Docker-x86_64.munki...

Nothing downloaded, packaged or imported.
```

4. Running this for the first time on a recipe designed for Apple Silicon (with Intel recipe already imported)
```
autopkg run Docker-arm64.munki 
Processing Docker-arm64.munki...

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                                      Pkg Repo Path                                   Icon Repo Path  
    ----    -------  --------  ------------                                      -------------                                   --------------  
    Docker  3.5.2    alpha     applications/Docker/Docker/Docker-3.5.2__1.plist  applications/Docker/Docker/Docker-3.5.2__1.dmg
```

As you can see the filename appends `__1`. I think that's unavoidable and doesn't matter for this use case.

5. Running this for a second time on the Apple Silicon recipe after makecatalogs
```
autopkg run Docker-arm64.munki
Processing Docker-arm64.munki...

Nothing downloaded, packaged or imported.
```