### PR TITLE
Fix issues related to Windows cURL Compatibility

### DIFF
--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -123,9 +123,7 @@ class URLDownloaderPython(URLDownloader):
                 "last time it was downloaded."
             )
         },
-        "download_info": {
-            "description": "Info from previous or current download."
-        },
+        "download_info": {"description": "Info from previous or current download."},
         "url_downloader_summary_result": {
             "description": "Description of interesting results."
         },
@@ -384,16 +382,19 @@ class URLDownloaderPython(URLDownloader):
         try:
             # save http header info to dict
             download_dictionary["http_headers"] = {}
-            download_dictionary["http_headers"]["Content-Length"] = int(
-                response.headers["content-length"]
-            )
-            download_dictionary["http_headers"]["ETag"] = response.headers["ETag"]
-            download_dictionary["http_headers"]["Last-Modified"] = response.headers[
-                "Last-Modified"
-            ]
-            if download_dictionary["http_headers"]["Content-Length"] != size:
-                # should this be a halting error?
-                self.output("WARNING: file size != content-length header", 0)
+            if "content-length" in response.headers:
+                download_dictionary["http_headers"]["Content-Length"] = int(
+                    response.headers["content-length"]
+                )
+                if download_dictionary["http_headers"]["Content-Length"] != size:
+                    # should this be a halting error?
+                    self.output("WARNING: file size != content-length header", 0)
+            if "ETag" in response.headers:
+                download_dictionary["http_headers"]["ETag"] = response.headers["ETag"]
+            if "Last-Modified" in response.headers:
+                download_dictionary["http_headers"]["Last-Modified"] = response.headers[
+                    "Last-Modified"
+                ]
         except (KeyError, TypeError) as err:
             # probably need to handle a missing header better than this
             self.output(

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -336,6 +336,8 @@ class URLDownloaderPython(URLDownloader):
             self.clear_zero_file(file_save_path)
             return None
 
+        self.output("INFO: Downloading New File")
+
         # download file
         while True:
             chunk = response.read(chunksize)

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -104,9 +104,7 @@ class URLDownloaderPython(URLDownloader):
         },
         "User_Agent": {
             "required": False,
-            "description": (
-                "User Agent Header String to use for download"
-            ),
+            "description": ("User Agent Header String to use for download"),
         },
     }
     output_variables = {
@@ -285,7 +283,7 @@ class URLDownloaderPython(URLDownloader):
         # the following may be required in some cases:
         user_agent_value = self.env.get("User_Agent", None)
         if user_agent_value:
-            req.add_header('User-Agent', user_agent_value)
+            req.add_header("User-Agent", user_agent_value)
         response = urlopen(req, context=self.ssl_context_certifi(),)
         response_headers = response.info()
 

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -181,6 +181,10 @@ class URLDownloaderPython(URLDownloader):
                         return True
                     else:
                         header_matches += 1
+                        if test == "Last-Modified":
+                            self.env["last_modified"] = previous_download_info["http_headers"][test]
+                        if test == "ETag":
+                            self.env["etag"] = previous_download_info["http_headers"][test]
                 except (KeyError, TypeError) as err:
                     self.output(
                         "WARNING: header missing. ({err_type}) {err}".format(
@@ -402,6 +406,10 @@ class URLDownloaderPython(URLDownloader):
         if self.env.get("download_changed", None):
             # store download info for checking for existing download
             self.store_download_info_json(download_dictionary)
+
+            if "http_headers" in download_dictionary:
+                self.env["etag"] = download_dictionary["http_headers"]["ETag"]
+                self.env["last_modified"] = download_dictionary["http_headers"]["Last-Modified"]
 
             # Generate output messages and variables
             self.output(f"Downloaded {self.env['pathname']}")

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -366,6 +366,13 @@ class URLDownloaderPython(URLDownloader):
         filename = self.get_filename()
         if filename is None:
             return
+        
+        # in some cases, the filename could have html parameters after:
+        if "?" in filename:
+            self.output("Removing ? and following characters from filename", 2)
+            # this fix should be applied to URLDownloader.prefetch_filename()
+            filename = filename.split("?",1)[0]
+
         self.env["filename"] = filename
         download_dir = self.get_download_dir()
         self.env["pathname"] = os.path.join(download_dir, filename)

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -147,6 +147,10 @@ class URLDownloaderPython(URLDownloader):
         # get previous info to compare
         previous_download_info = self.get_download_info_json()
 
+        if not previous_download_info:
+            # no previous download info to check against
+            return True
+
         self.output(
             "previous_download_info: \n{previous_download_info}\n".format(
                 previous_download_info=previous_download_info
@@ -154,9 +158,9 @@ class URLDownloaderPython(URLDownloader):
             2,
         )
 
-        if not previous_download_info:
-            # no previous download info to check against
-            return True
+        # store previous download_url in case we don't download again
+        if "download_url" in previous_download_info:
+            self.env["download_url"] = previous_download_info["download_url"]
 
         # check that previous download exits:
         previous_download_path = self.env.get("pathname", None)
@@ -355,7 +359,13 @@ class URLDownloaderPython(URLDownloader):
             download_dictionary["file_sha1"] = hashes[0].hexdigest()
             download_dictionary["file_sha256"] = hashes[1].hexdigest()
             download_dictionary["file_md5"] = hashes[2].hexdigest()
-        download_dictionary["download_url"] = url
+        download_dictionary["url"] = url
+
+        # store new download url:
+        if response.url:
+            download_url = response.url
+            download_dictionary["download_url"] = download_url
+            self.env["download_url"] = download_url
 
         download_version = self.env.get(
             "download_version", self.env.get("version", None)

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -102,6 +102,12 @@ class URLDownloaderPython(URLDownloader):
                 "this package or disk image."
             ),
         },
+        "User_Agent": {
+            "required": False,
+            "description": (
+                "User Agent Header String to use for download"
+            ),
+        },
     }
     output_variables = {
         "pathname": {"description": "Path to the downloaded file."},
@@ -277,7 +283,9 @@ class URLDownloaderPython(URLDownloader):
         # get http headers
         req = Request(url)
         # the following may be required in some cases:
-        # req.add_header('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36')
+        user_agent_value = self.env.get("User_Agent", None)
+        if user_agent_value:
+            req.add_header('User-Agent', user_agent_value)
         response = urlopen(req, context=self.ssl_context_certifi(),)
         response_headers = response.info()
 

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -28,7 +28,7 @@ from autopkglib.URLDownloader import URLDownloader
 __all__ = ["URLDownloaderPython"]
 
 
-class URLDownloaderPython(URLDownloader):  # pylint: disable=invalid-name
+class URLDownloaderPython(URLDownloader):
     """This is meant to be a pure python replacement for URLDownloader
     See: https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/URLDownloader.py
     """
@@ -156,7 +156,7 @@ class URLDownloaderPython(URLDownloader):  # pylint: disable=invalid-name
 
         try:
             # check Content-Length:
-            if (  # pylint: disable=no-else-return
+            if (
                 "Content-Length" in headers_to_test
                 and (
                     int(previous_download_info["http_headers"]["Content-Length"])
@@ -179,7 +179,7 @@ class URLDownloaderPython(URLDownloader):  # pylint: disable=invalid-name
         for test in headers_to_test:
             if test != "Content-Length":
                 try:
-                    if previous_download_info[  # pylint: disable=no-else-return
+                    if previous_download_info[
                         "http_headers"
                     ][test] != header.get(test):
                         self.output("{test} is different".format(test=test), 2)
@@ -229,7 +229,7 @@ class URLDownloaderPython(URLDownloader):  # pylint: disable=invalid-name
 
         return info_json
 
-    def ssl_context_ignore(self):  # pylint: disable=no-self-use
+    def ssl_context_ignore(self):
         """ssl context - ignore SSL validation"""
         # this doesn't need to be a class method
         ctx = ssl.create_default_context()
@@ -238,13 +238,13 @@ class URLDownloaderPython(URLDownloader):  # pylint: disable=invalid-name
         self.output("WARNING: disabling SSL validation is insecure!!!")
         return ctx
 
-    def ssl_context_certifi(self):  # pylint: disable=no-self-use
+    def ssl_context_certifi(self):
         """ssl context using certifi CAs"""
         # this doesn't need to be a class method
         # https://stackoverflow.com/questions/24374400/verifying-https-certificates-with-urllib-request
         return ssl.create_default_context(cafile=certifi.where())
 
-    def download_and_hash(self, file_save_path):  # pylint: disable=too-many-branches
+    def download_and_hash(self, file_save_path):
         """stream down file from url and calculate size & hashes"""
         # it is much more efficient to calculate hashes WHILE downloading
         # this allows the file to be read only once and never from disk

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -160,7 +160,7 @@ class URLDownloaderPython(URLDownloader):
                 int(previous_download_info["http_headers"]["Content-Length"])
                 != int(header.get("Content-Length"))
             ):
-                self.output("Content-Length is different", 2)
+                self.output("Content-Length is different", 1)
                 return True
             else:
                 header_matches += 1
@@ -177,14 +177,18 @@ class URLDownloaderPython(URLDownloader):
             if test != "Content-Length":
                 try:
                     if previous_download_info["http_headers"][test] != header.get(test):
-                        self.output("{test} is different".format(test=test), 2)
+                        self.output("{test} is different".format(test=test), 1)
                         return True
                     else:
                         header_matches += 1
                         if test == "Last-Modified":
-                            self.env["last_modified"] = previous_download_info["http_headers"][test]
+                            self.env["last_modified"] = previous_download_info[
+                                "http_headers"
+                            ][test]
                         if test == "ETag":
-                            self.env["etag"] = previous_download_info["http_headers"][test]
+                            self.env["etag"] = previous_download_info["http_headers"][
+                                test
+                            ]
                 except (KeyError, TypeError) as err:
                     self.output(
                         "WARNING: header missing. ({err_type}) {err}".format(
@@ -274,10 +278,7 @@ class URLDownloaderPython(URLDownloader):
         req = Request(url)
         # the following may be required in some cases:
         # req.add_header('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36')
-        response = urlopen(
-            req,
-            context=self.ssl_context_certifi(),
-        )
+        response = urlopen(req, context=self.ssl_context_certifi(),)
         response_headers = response.info()
 
         self.env["download_changed"] = self.download_changed(response_headers)
@@ -329,7 +330,7 @@ class URLDownloaderPython(URLDownloader):
             ]
             if download_dictionary["http_headers"]["Content-Length"] != size:
                 # should this be a halting error?
-                self.output("WARNING: file size != content-length header")
+                self.output("WARNING: file size != content-length header", 0)
         except (KeyError, TypeError) as err:
             # probably need to handle a missing header better than this
             self.output(
@@ -370,12 +371,12 @@ class URLDownloaderPython(URLDownloader):
         filename = self.get_filename()
         if filename is None:
             return
-        
+
         # in some cases, the filename could have html parameters after:
         if "?" in filename:
-            self.output("Removing ? and following characters from filename", 2)
+            self.output("Removing ? and following characters from filename", 0)
             # this fix should be applied to URLDownloader.prefetch_filename()
-            filename = filename.split("?",1)[0]
+            filename = filename.split("?", 1)[0]
 
         self.env["filename"] = filename
         download_dir = self.get_download_dir()
@@ -396,8 +397,7 @@ class URLDownloaderPython(URLDownloader):
         self.output(
             "download_dictionary: \n{download_dictionary}\n".format(
                 download_dictionary=download_dictionary
-            ),
-            2,
+            )
         )
 
         # clear temp file if 0 size
@@ -409,7 +409,9 @@ class URLDownloaderPython(URLDownloader):
 
             if "http_headers" in download_dictionary:
                 self.env["etag"] = download_dictionary["http_headers"]["ETag"]
-                self.env["last_modified"] = download_dictionary["http_headers"]["Last-Modified"]
+                self.env["last_modified"] = download_dictionary["http_headers"][
+                    "Last-Modified"
+                ]
 
             # Generate output messages and variables
             self.output(f"Downloaded {self.env['pathname']}")

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -413,7 +413,7 @@ class URLDownloaderPython(URLDownloader):
             # store download info for checking for existing download
             self.store_download_info_json(download_dictionary)
 
-            if "http_headers" in download_dictionary:
+            if download_dictionary and "http_headers" in download_dictionary:
                 self.env["etag"] = download_dictionary["http_headers"]["ETag"]
                 self.env["last_modified"] = download_dictionary["http_headers"][
                     "Last-Modified"

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -123,6 +123,9 @@ class URLDownloaderPython(URLDownloader):
                 "last time it was downloaded."
             )
         },
+        "download_info": {
+            "description": "Info from previous or current download."
+        },
         "url_downloader_summary_result": {
             "description": "Description of interesting results."
         },
@@ -150,6 +153,9 @@ class URLDownloaderPython(URLDownloader):
         if not previous_download_info:
             # no previous download info to check against
             return True
+
+        # store previous download info in case we don't download again
+        self.env["download_info"] = previous_download_info
 
         self.output(
             "previous_download_info: \n{previous_download_info}\n".format(
@@ -244,6 +250,8 @@ class URLDownloaderPython(URLDownloader):
         """If file is downloaded, store info"""
         pathname = self.env.get("pathname")
         pathname_info_json = pathname + ".info.json"
+        # put new download info into env:
+        self.env["download_info"] = download_dictionary
         # https://stackoverflow.com/questions/16267767/python-writing-json-to-file
         with open(pathname_info_json, "w") as outfile:
             json.dump(download_dictionary, outfile, indent=4)

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -19,7 +19,7 @@
 import os.path
 import subprocess
 
-from autopkglib import Processor, ProcessorError, find_binary
+from autopkglib import Processor, ProcessorError, find_binary, is_windows
 
 __all__ = ["URLGetter"]
 
@@ -53,7 +53,7 @@ class URLGetter(Processor):
         """Assemble basic curl command and return it."""
         curl_bin_path = self.curl_binary()
         # fix windows default curl support
-        if "Windows\\system32" in curl_bin_path:
+        if is_windows() and "Windows\\system32" in curl_bin_path:
             return [curl_bin_path, "--location"]
         return [curl_bin_path, "--compressed", "--location"]
 

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -53,7 +53,7 @@ class URLGetter(Processor):
         """Assemble basic curl command and return it."""
         curl_bin_path = self.curl_binary()
         # fix windows default curl support
-        if is_windows() and "Windows\\system32" in curl_bin_path:
+        if is_windows() and "windows\\system32" in curl_bin_path.lower():
             return [curl_bin_path, "--location"]
         return [curl_bin_path, "--compressed", "--location"]
 

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -51,7 +51,11 @@ class URLGetter(Processor):
 
     def prepare_curl_cmd(self):
         """Assemble basic curl command and return it."""
-        return [self.curl_binary(), "--compressed", "--location"]
+        curl_bin_path = self.curl_binary()
+        # fix windows default curl support
+        if "Windows\\system32" in curl_bin_path:
+            return [curl_bin_path, "--location"]
+        return [curl_bin_path, "--compressed", "--location"]
 
     def add_curl_headers(self, curl_cmd, headers):
         """Add headers to curl_cmd."""


### PR DESCRIPTION
URLGetter.py
- Fixed: cURL shipping on Windows 10 does not support `--compressed`
  - if curl binary path contains `Windows\\system32` then omit `--compressed`
  - adding a different curl to PATH would also fix this issue on windows, but this fix will not interfere with that case
  - Would be nice if I could somehow test the curl binary to see if it supports `--compressed` rather than assuming it doesn't in a very path specific way. This is a bigger issue if Windows ships a curl binary that does support `--compressed` in the future.
  - this fix makes getting up and running with AutoPkg on Windows easier, but might have negative implications for any recipe that requires `--compressed`, though I don't know if any actually would.

URLDownloaderPython.py
- black formatter changes due to removing pylint messages
- Fixed: was missing a file close handler which only caused issues on Windows
- changed the way headers are fetched to allow for future custom `User-Agent` headers which are required due to some software companies blocking cURL specifically.