### PR TITLE
Resolve GitHubReleasesInfoProvider character decode error for Audacity

### DIFF
--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -272,7 +272,7 @@ To save the token, paste it to the following prompt."""
             self.http_result_code = int(header["http_result_code"])
 
         try:
-            with open(temp_content) as f:
+            with open(temp_content, errors="ignore") as f:
                 resp_data = json.load(f)
         except json.JSONDecodeError:
             resp_data = None


### PR DESCRIPTION
To resolve character decoding errors: https://stackoverflow.com/a/50709581/861745

This will remove and ignore the characters causing the issue from the results. Using `, encoding="utf-8"` also works, but not certain if that should be hard coded default or not?

This resolves the following issue:

```
The following recipes failed:
    com.github.jgstew.download.Audacity-Win
        Error in com.github.jgstew.download.Audacity-Win: Processor: GitHubReleasesInfoProvider: Error: 'charmap' codec can't decode byte 0x9d in position 85160: character maps to <undefined>
```