### PR TITLE
Preserve YAML scalar types when writing YAML to disk

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -58,6 +58,7 @@ from autopkglib import (
     set_pref,
     version_equal_or_greater,
 )
+from autopkglib.autopkgyaml import autopkg_str_representer
 from autopkglib.github import GitHubSession, print_gh_search_results
 
 if sys.platform != "darwin":
@@ -74,6 +75,12 @@ _ = f"""{sys.version_info.major} It looks like you're running the autopkg tool w
 
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70
+
+# Override global yaml state with our str representer
+# See https://github.com/autopkg/autopkg/issues/768
+yaml.add_representer(str, autopkg_str_representer)
+# to use with safe_dump:
+yaml.representer.SafeRepresenter.add_representer(str, autopkg_str_representer)
 
 
 def print_version(argv):

--- a/Code/autopkglib/autopkgyaml/__init__.py
+++ b/Code/autopkglib/autopkgyaml/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/local/autopkg/python
+#
+# Copyright 2021 Brandon Friess
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper to deal with YAML serialization"""
+
+
+def autopkg_str_representer(dumper, data):
+    """Makes every multiline string a block literal"""
+    if len(data.splitlines()) > 1:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)


### PR DESCRIPTION
Attempt to solve https://github.com/autopkg/autopkg/issues/768

This is a quick pass at trying to solve the issue where multiline comment blocks (ie. scalars) in source recipes aren't preserved when autopkg goes to write them to disk via `make-override` or `update-trust-info`.

My approach is to add an autopkg specific representer on the global YAML state that acts on `str` types. It essentially makes every multiline string be a block literal.

Thus far, it has been working for my needs.

Looking for feedback on the approach; I'm open to other ideas!

Ex:
```
Python 3.7.5 (default, May 22 2020, 16:27:59)
[Clang 11.0.0 (clang-1100.0.33.12)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.path.insert(0, "/Users/bfreezy/workspace/autopkg/Code")
>>> import yaml
>>> from pprint import pprint
>>> from autopkglib.autopkgyaml import autopkg_str_representer
>>> yaml.add_representer(str, autopkg_str_representer)
>>> yaml.representer.SafeRepresenter.add_representer(str, autopkg_str_representer)
>>> with open('/Users/bfreezy/example/autopkg/Tuple/Tuple.munki.recipe.yaml', 'rb') as f:
...   recipe_dict = yaml.load(f, Loader=yaml.FullLoader)
...
>>> pprint(yaml.dump(recipe_dict))
('Description: Downloads the latest version of Tuple and imports it into '
 'Munki.\n'
 'Identifier: com.bfreezy.autopkg.tuple.munki\n'
 'Input:\n'
 "  DAYS_IN_TESTING: '2'\n"
 "  DAYS_TO_ROLLOUT_TO_PROD: '7'\n"
 '  MUNKI_REPO_SUBDIR: apps/%NAME%\n'
 '  NAME: tuple\n'
 '  pkginfo:\n'
 '    catalogs:\n'
 '    - testing\n'
 '    - production\n'
 '    category: Developer Tools\n'
 '    description: Tuple is a Mac-only remote pair programming tool for '
 'discerning developers.\n'
 '    developer: Tuple LLC\n'
 '    display_name: Tuple\n'
 "    name: '%NAME%'\n"
 '    postinstall_script: |\n'
 '      #!/bin/bash\n'
 '      # Add directory traversal for the entire application and ensure\n'
 '      # all executables are executable by group and other\n'
 '      /bin/chmod -R go+rX /Applications/Tuple.app\n'
 '    unattended_install: true\n'
 "MinimumVersion: '2.3'\n"
 'ParentRecipe: com.bfreezy.autopkg.tuple.download\n'
 'Process:\n'
 '- Arguments:\n'
 "    dmg_path: '%RECIPE_CACHE_DIR%/%NAME%.dmg'\n"
 "    dmg_root: '%RECIPE_CACHE_DIR%/%NAME%'\n"
 '  Processor: DmgCreator\n'
 '- Arguments:\n'
 "    days_in_testing: '%DAYS_IN_TESTING%'\n"
 "    days_to_rollout_to_prod: '%DAYS_TO_ROLLOUT_TO_PROD%'\n"
 '  Processor: com.bfreezy.autopkg.shared/ComputeRollout\n'
 '- Arguments:\n'
 '    additional_pkginfo:\n'
 "      installable_condition: '%installable_condition_string%'\n"
 '  Processor: MunkiPkginfoMerger\n'
 '- Arguments:\n'
 "    pkg_path: '%dmg_path%'\n"
 "    repo_subdirectory: '%MUNKI_REPO_SUBDIR%'\n"
 '  Processor: MunkiImporter\n')
```

The important bit is the scalar `|` being preserved on the postinstall_script key:
```
 '    postinstall_script: |\n'
 '      #!/bin/bash\n'
 '      # Add directory traversal for the entire application and ensure\n'
 '      # all executables are executable by group and other\n'
 '      /bin/chmod -R go+rX /Applications/Tuple.app\n'
 '    unattended_install: true\n'
```
