### PR TITLE
Reset archive_format after each Unarchiver process invocation

### DIFF
--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -217,6 +217,10 @@ class Unarchiver(Processor):
         self._extract(fmt, archive_path, destination_path)
         self.output(f"Unarchived {archive_path} to {destination_path}")
 
+        # Clear archive_format in case there are subsequent Unarchiver processes
+        if self.env.get("archive_format"):
+            del self.env["archive_format"]
+
 
 if __name__ == "__main__":
     PROCESSOR = Unarchiver()


### PR DESCRIPTION
Resolves https://github.com/autopkg/autopkg/issues/776.

Run output showing the issue described above on the current `dev` branch of AutoPkg:

```
% autopkg run -vv Perforce/HelixALM.pkg.recipe
WARNING: Did not load any default preferences.
Processing Perforce/HelixALM.pkg.recipe...
WARNING: Perforce/HelixALM.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
PerforceURLProvider
{'Input': {'product': 'HelixALM'}}
PerforceURLProvider: Searching https://cdist2.perforce.com/alm/helixalm/ for r[\d\.]+/
PerforceURLProvider: Searching https://cdist2.perforce.com/alm/helixalm/r2021.2.1/ for ttmacclientinstall\.zip
PerforceURLProvider: Found url: https://cdist2.perforce.com/alm/helixalm/r2021.2.1/ttmacclientinstall.zip
{'Output': {'url': 'https://cdist2.perforce.com/alm/helixalm/r2021.2.1/ttmacclientinstall.zip'}}
URLDownloader
{'Input': {'url': 'https://cdist2.perforce.com/alm/helixalm/r2021.2.1/ttmacclientinstall.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/downloads/ttmacclientinstall.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/downloads/ttmacclientinstall.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/downloads/ttmacclientinstall.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename ttmacclientinstall.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/downloads/ttmacclientinstall.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1/ttclientinstall.app/Contents/Resources/ttclientinstall.app/Contents/Resources/Java/Disk1/InstData/Resource1.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2'}}
Unarchiver: Guessed archive format 'zip' from filename Resource1.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1/ttclientinstall.app/Contents/Resources/ttclientinstall.app/Contents/Resources/Java/Disk1/InstData/Resource1.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/Helix '
                           'ALM Client.app.tar.gz',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3'}}
Unarchiver: Guessed archive format 'tar_gzip' from filename Helix ALM Client.app.tar.gz
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/Helix ALM Client.app.tar.gz to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix '
                         'ALM Client.app',
           'requirement': 'identifier "com.seapine.testtrackclient" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'PYYFSY54S7'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': 'Helix ALM ([\\d\\.]+)',
           'result_output_var_name': 'version',
           'url': 'file://~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.txt'}}
URLTextSearcher: Found matching text (version): 2021.2.1
{'Output': {'version': '2021.2.1'}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775',
                       'Applications/HelixALM': '0775',
                       'Library': '0775',
                       'Library/Application Support': '0775',
                       'Library/Application Support/Seapine': '0775',
                       'Library/Application Support/Seapine/TestTrackIntegration.framework': '0775',
                       'private': '0775',
                       'private/etc': '0775',
                       'usr': '0775',
                       'usr/local': '0775',
                       'usr/local/seapine': '0775',
                       'usr/local/seapine/tt': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications
PkgRootCreator: Creating Applications/HelixALM
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM
PkgRootCreator: Creating Library
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library
PkgRootCreator: Creating Library/Application Support
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application Support
PkgRootCreator: Creating Library/Application Support/Seapine
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application Support/Seapine
PkgRootCreator: Creating Library/Application Support/Seapine/TestTrackIntegration.framework
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application Support/Seapine/TestTrackIntegration.framework
PkgRootCreator: Creating private
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/private
PkgRootCreator: Creating private/etc
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/private/etc
PkgRootCreator: Creating usr
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/usr
PkgRootCreator: Creating usr/local
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/usr/local
PkgRootCreator: Creating usr/local/seapine
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/usr/local/seapine
PkgRootCreator: Creating usr/local/seapine/tt
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/usr/local/seapine/tt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix '
                               'ALM Client.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix '
                          'ALM Client.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix ALM Client.app
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1/ttclientinstall.app/Contents/Resources/ttclientinstall.app/Contents/Resources/Java/jre.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM'}}
Unarchiver: Guessed archive format 'zip' from filename jre.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1/ttclientinstall.app/Contents/Resources/ttclientinstall.app/Contents/Resources/Java/jre.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/whatsnew.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/whatsnew.txt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/whatsnew.htm',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.htm'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.htm, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.htm to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/whatsnew.htm
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Qt '
                               'License.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Qt '
                          'License.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Qt License.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Qt License.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Qt License.txt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix '
                               'ALM Documentation.url',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Documentation/Helix '
                          'ALM Documentation.url'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Documentation/Helix ALM Documentation.url, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Documentation/Helix ALM Documentation.url to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix ALM Documentation.url
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix '
                               'ALM License.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Helix '
                          'ALM License.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Helix ALM License.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Helix ALM License.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix ALM License.txt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Aspose.Words.lic',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Words.lic'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Words.lic, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Words.lic to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Aspose.Words.lic
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Aspose.Total.Java.lic',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Total.Java.lic'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Total.Java.lic, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Total.Java.lic to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Aspose.Total.Java.lic
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Installer '
                               'ReadMe.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Installer '
                          'ReadMe.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Installer ReadMe.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Installer ReadMe.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Installer ReadMe.txt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Assignments.wav',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Assignments.wav'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Assignments.wav, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Assignments.wav to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Assignments.wav
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/TestTrackData.dtd',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TestTrackData.dtd'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TestTrackData.dtd, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TestTrackData.dtd to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/TestTrackData.dtd
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/WordImportExport.jar',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/WordImportExport.jar'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/WordImportExport.jar, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/WordImportExport.jar to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/WordImportExport.jar
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/TinyMCE '
                               'License.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TinyMCE '
                          'License.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TinyMCE License.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TinyMCE License.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/TinyMCE License.txt
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_format': 'zip',
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/webcomponents_fad60d0bb8f1_zg_ia_sf.jar',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/webcomponents'}}
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/webcomponents_fad60d0bb8f1_zg_ia_sf.jar to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/webcomponents
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application '
                               'Support/Seapine/TestTrackIntegration.framework/libttintegration.dylib',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/libttintegration.dylib'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/libttintegration.dylib, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/libttintegration.dylib to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application Support/Seapine/TestTrackIntegration.framework/libttintegration.dylib
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_format': 'zip',
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/ttqtframeworks.tar.gz',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application '
                               'Support/Seapine/tt/Frameworks'}}
Unarchiving ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/ttqtframeworks.tar.gz with ditto failed: ditto: Couldn't read PKZip signature

Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/receipts/HelixALM.pkg-receipt-20211125-214654.plist

The following recipes failed:
    Perforce/HelixALM.pkg.recipe
        Error in com.github.homebysix.pkg.HelixALM: Processor: Unarchiver: Error: Unarchiving ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/ttqtframeworks.tar.gz with ditto failed: ditto: Couldn't read PKZip signature

Nothing downloaded, packaged or imported.
```

Run output after the change in this PR:

```
% autopkg run -vv Perforce/HelixALM.pkg.recipe
WARNING: Did not load any default preferences.
Processing Perforce/HelixALM.pkg.recipe...
WARNING: Perforce/HelixALM.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
PerforceURLProvider
{'Input': {'product': 'HelixALM'}}
PerforceURLProvider: Searching https://cdist2.perforce.com/alm/helixalm/ for r[\d\.]+/
PerforceURLProvider: Searching https://cdist2.perforce.com/alm/helixalm/r2021.2.1/ for ttmacclientinstall\.zip
PerforceURLProvider: Found url: https://cdist2.perforce.com/alm/helixalm/r2021.2.1/ttmacclientinstall.zip
{'Output': {'url': 'https://cdist2.perforce.com/alm/helixalm/r2021.2.1/ttmacclientinstall.zip'}}
URLDownloader
{'Input': {'url': 'https://cdist2.perforce.com/alm/helixalm/r2021.2.1/ttmacclientinstall.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/downloads/ttmacclientinstall.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/downloads/ttmacclientinstall.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/downloads/ttmacclientinstall.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename ttmacclientinstall.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/downloads/ttmacclientinstall.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1/ttclientinstall.app/Contents/Resources/ttclientinstall.app/Contents/Resources/Java/Disk1/InstData/Resource1.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2'}}
Unarchiver: Guessed archive format 'zip' from filename Resource1.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1/ttclientinstall.app/Contents/Resources/ttclientinstall.app/Contents/Resources/Java/Disk1/InstData/Resource1.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/Helix '
                           'ALM Client.app.tar.gz',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3'}}
Unarchiver: Guessed archive format 'tar_gzip' from filename Helix ALM Client.app.tar.gz
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/Helix ALM Client.app.tar.gz to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix '
                         'ALM Client.app',
           'requirement': 'identifier "com.seapine.testtrackclient" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'PYYFSY54S7'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': 'Helix ALM ([\\d\\.]+)',
           'result_output_var_name': 'version',
           'url': 'file://~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.txt'}}
URLTextSearcher: Found matching text (version): 2021.2.1
{'Output': {'version': '2021.2.1'}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775',
                       'Applications/HelixALM': '0775',
                       'Library': '0775',
                       'Library/Application Support': '0775',
                       'Library/Application Support/Seapine': '0775',
                       'Library/Application Support/Seapine/TestTrackIntegration.framework': '0775',
                       'private': '0775',
                       'private/etc': '0775',
                       'usr': '0775',
                       'usr/local': '0775',
                       'usr/local/seapine': '0775',
                       'usr/local/seapine/tt': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications
PkgRootCreator: Creating Applications/HelixALM
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM
PkgRootCreator: Creating Library
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library
PkgRootCreator: Creating Library/Application Support
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application Support
PkgRootCreator: Creating Library/Application Support/Seapine
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application Support/Seapine
PkgRootCreator: Creating Library/Application Support/Seapine/TestTrackIntegration.framework
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application Support/Seapine/TestTrackIntegration.framework
PkgRootCreator: Creating private
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/private
PkgRootCreator: Creating private/etc
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/private/etc
PkgRootCreator: Creating usr
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/usr
PkgRootCreator: Creating usr/local
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/usr/local
PkgRootCreator: Creating usr/local/seapine
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/usr/local/seapine
PkgRootCreator: Creating usr/local/seapine/tt
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/usr/local/seapine/tt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix '
                               'ALM Client.app',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix '
                          'ALM Client.app'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked3/Helix ALM Client.app to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix ALM Client.app
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1/ttclientinstall.app/Contents/Resources/ttclientinstall.app/Contents/Resources/Java/jre.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM'}}
Unarchiver: Guessed archive format 'zip' from filename jre.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked1/ttclientinstall.app/Contents/Resources/ttclientinstall.app/Contents/Resources/Java/jre.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/whatsnew.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/whatsnew.txt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/whatsnew.htm',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.htm'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.htm, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/whatsnew.htm to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/whatsnew.htm
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Qt '
                               'License.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Qt '
                          'License.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Qt License.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Qt License.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Qt License.txt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix '
                               'ALM Documentation.url',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Documentation/Helix '
                          'ALM Documentation.url'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Documentation/Helix ALM Documentation.url, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Documentation/Helix ALM Documentation.url to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix ALM Documentation.url
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix '
                               'ALM License.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Helix '
                          'ALM License.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Helix ALM License.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Helix ALM License.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Helix ALM License.txt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Aspose.Words.lic',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Words.lic'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Words.lic, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Words.lic to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Aspose.Words.lic
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Aspose.Total.Java.lic',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Total.Java.lic'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Total.Java.lic, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Aspose.Total.Java.lic to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Aspose.Total.Java.lic
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Installer '
                               'ReadMe.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Installer '
                          'ReadMe.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Installer ReadMe.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Installer ReadMe.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Installer ReadMe.txt
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Assignments.wav',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Assignments.wav'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Assignments.wav, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/Assignments.wav to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/Assignments.wav
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/TestTrackData.dtd',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TestTrackData.dtd'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TestTrackData.dtd, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TestTrackData.dtd to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/TestTrackData.dtd
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/WordImportExport.jar',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/WordImportExport.jar'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/WordImportExport.jar, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/WordImportExport.jar to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/WordImportExport.jar
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/TinyMCE '
                               'License.txt',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TinyMCE '
                          'License.txt'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TinyMCE License.txt, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/TinyMCE License.txt to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/TinyMCE License.txt
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_format': 'zip',
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/webcomponents_fad60d0bb8f1_zg_ia_sf.jar',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/webcomponents'}}
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/webcomponents_fad60d0bb8f1_zg_ia_sf.jar to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Applications/HelixALM/webcomponents
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application '
                               'Support/Seapine/TestTrackIntegration.framework/libttintegration.dylib',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/libttintegration.dylib'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/libttintegration.dylib, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/libttintegration.dylib to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application Support/Seapine/TestTrackIntegration.framework/libttintegration.dylib
{'Output': {}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/ttqtframeworks.tar.gz',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application '
                               'Support/Seapine/tt/Frameworks'}}
Unarchiver: Guessed archive format 'tar_gzip' from filename ttqtframeworks.tar.gz
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/MacOSX/ttqtframeworks.tar.gz to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/Library/Application Support/Seapine/tt/Frameworks
{'Output': {}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/private/etc/ttclient.conf',
           'source_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/ttclient.conf'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/ttclient.conf, dmg: , dmg_source_path: 
Copier: Copied ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/unpacked2/$IA_PROJECT_DIR$/ttclient.conf to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM/private/etc/ttclient.conf
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'chown': [{'group': 'admin',
                                      'path': 'Applications',
                                      'user': 'root'}],
                           'id': 'com.perforce.HelixALMClient',
                           'options': 'purge_ds_store',
                           'pkgdir': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM',
                           'pkgname': 'HelixALM-2021.2.1'}}}
PkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM-2021.2.1.pkg.
PkgCreator: Existing package matches version and identifier, not building.
{'Output': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/HelixALM-2021.2.1.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.pkg.HelixALM/receipts/HelixALM.pkg-receipt-20211125-214812.plist

Nothing downloaded, packaged or imported.
```

Notice the second output contains this line, which indicates the `archive_path` environmental variable was successfully reset after the previous Unarchiver process ran.

```
Unarchiver: Guessed archive format 'tar_gzip' from filename ttqtframeworks.tar.gz
```