### PR TITLE
Fix for xattr usage on Linux

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -17,6 +17,7 @@
 """See docstring for URLDownloader class"""
 
 import os.path
+import platform
 import tempfile
 
 from autopkglib import BUNDLE_ID, ProcessorError, xattr
@@ -157,8 +158,12 @@ class URLDownloader(URLGetter):
             del self.env["url_downloader_summary_result"]
 
         # XATTR names for Etag and Last-Modified headers
-        self.xattr_etag = f"{BUNDLE_ID}.etag"
-        self.xattr_last_modified = f"{BUNDLE_ID}.last-modified"
+        if platform.platform().startswith("Linux"):
+            self.xattr_etag = f"user.{BUNDLE_ID}.etag"
+            self.xattr_last_modified = f"user.{BUNDLE_ID}.last-modified"
+        else:
+            self.xattr_etag = f"{BUNDLE_ID}.etag"
+            self.xattr_last_modified = f"{BUNDLE_ID}.last-modified"
 
         self.env["last_modified"] = ""
         self.env["etag"] = ""


### PR DESCRIPTION
Linux requires xattr names to start with "user." This fix allows autopkg on Linux to store extended attributes on downloaded files on some Linux-supported filesystems. ext4, for example, is known to work. Conversely, attempting to store extended attributes on files on NFS mounts is known to still fail.