### PR TITLE
Add `asset_url` output variable to GitHubReleasesInfoProvider

### DIFF
--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -98,6 +98,14 @@ class GitHubReleasesInfoProvider(Processor):
                 "URL for the first asset found for the project's latest release."
             )
         },
+        "asset_url": {
+            "description": (
+                "The asset URL for the project's latest release. This is an "
+                "API-only URL distinct from the browser_download_url, and is "
+                "required for programmatically downloading assets from private "
+                "repositories."
+            )
+        },
         "version": {
             "description": (
                 "Version info parsed, naively derived from the release's tag."
@@ -188,6 +196,9 @@ class GitHubReleasesInfoProvider(Processor):
 
         # Record the url
         self.env["url"] = self.selected_asset["browser_download_url"]
+
+        # Record the asset url
+        self.env["asset_url"] = self.selected_asset["url"]
 
         # Get a version string from the tag name
         tag = self.selected_release["tag_name"]

--- a/Code/tests/test_githubreleasesinfoprovider.py
+++ b/Code/tests/test_githubreleasesinfoprovider.py
@@ -67,6 +67,14 @@ class TestGitHubReleasesInfoProvider(unittest.TestCase):
         self.processor.main()
         self.assertIsNotNone(test_env["url"])
 
+    def test_returns_asset_url(self):
+        """The processor should return an asset URL."""
+        test_env = {"github_repo": "autopkg/autopkg"}
+        test_env.update(self.base_env)
+        self.processor.env = test_env
+        self.processor.main()
+        self.assertIsNotNone(test_env["asset_url"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds `asset_url` as an additional output variable to the GitHubReleasesInfoProvider processor.

As is, the processor is able to access the releases of a private repository when provided a `GITHUB_TOKEN`, and returns the `browser_download_url` as key `url`. While `curl` and the URLDownloader processor can successfully download an asset of a public repository using the `browser_download_url`, this is not possible for assets in private repositories gated behind authentication. Even if providing `Authorization: token <token>` and `Accept: application/octet-stream` headers to `curl` the download fails with a 404 error for private assets.

Per the [REST API docs](https://docs.github.com/en/rest/reference/releases#get-a-release), you must use the release asset's API-only URL – with the key `url` instead of `browser_download_url`.

Adding this key would allow people with private organization repos to access their releases.

This addition does not change or conflict with the current behavior of returning the `browser_download_url` as the key `url`. Returning this variable as `asset_url` should prevent any issues with existing recipes. No existing functionality is removed from or changed within the processor.

I've additionally included a minimal unit test.