### PR TITLE
Prevent MunkiImporter duplicating imports when multiple architectures

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -180,7 +180,10 @@ class MunkiImporter(Processor):
             matchingindexes = pkgdb["hashes"].get(pkginfo["installer_item_hash"])
             if matchingindexes:
                 # we have an item with the exact same checksum hash in the repo
-                return pkgdb["items"][matchingindexes[0]]
+                return [
+                    pkgdb["items"][matchingindex]
+                    for matchingindex in list(matchingindexes)
+                ]
 
         # try to match against installed applications
         applist = [
@@ -212,7 +215,10 @@ class MunkiImporter(Processor):
 
             # did we find any matches?
             if matching_indexes:
-                return pkgdb["items"][list(matching_indexes)[0]]
+                return [
+                    pkgdb["items"][matching_index]
+                    for matching_index in list(matching_indexes)
+                ]
 
         # fall back to matching against receipts
         matching_indexes = []
@@ -236,7 +242,10 @@ class MunkiImporter(Processor):
 
         # did we find any matches?
         if matching_indexes:
-            return pkgdb["items"][list(matching_indexes)[0]]
+            return [
+                pkgdb["items"][matching_index]
+                for matching_index in list(matching_indexes)
+            ]
 
         # try to match against install md5checksums
         filelist = [
@@ -360,15 +369,30 @@ class MunkiImporter(Processor):
 
         # check to see if this item is already in the repo
         if self.env.get("force_munkiimport"):
-            matchingitem = None
+            matchingitems = None
         else:
-            matchingitem = self._find_matching_pkginfo(library, pkginfo)
+            matchingitems = self._find_matching_pkginfo(library, pkginfo)
 
-        if matchingitem and (matchingitem.get("supported_architectures") ==
-                             pkginfo.get("supported_architectures")):
+        archs = []
+        if matchingitems:
+            archs = [
+                matchingitem.get("supported_architectures")
+                for matchingitem in matchingitems
+            ]
+
+        if matchingitems and (pkginfo.get("supported_architectures") in archs):
+            if archs and None not in archs:
+                installer_item_location = [
+                    matchingitem.get("installer_item_location")
+                    for matchingitem in list(matchingitems)
+                    if pkginfo.get("supported_architectures")
+                    == matchingitem.get("supported_architectures")
+                ][0]
+            else:
+                installer_item_location = matchingitems[0]["installer_item_location"]
             self.env["pkginfo_repo_path"] = ""
             self.env["pkg_repo_path"] = os.path.join(
-                self.env["MUNKI_REPO"], "pkgs", matchingitem["installer_item_location"]
+                self.env["MUNKI_REPO"], "pkgs", installer_item_location
             )
             self.env["munki_info"] = {}
             if "munki_repo_changed" not in self.env:
@@ -376,14 +400,16 @@ class MunkiImporter(Processor):
 
             self.output(
                 f"Item {os.path.basename(self.env['pkg_path'])} already exists in the "
-                f"munki repo as pkgs/{matchingitem['installer_item_location']}."
+                f"munki repo as pkgs/{installer_item_location}."
             )
             return
 
         # import pkg
         install_path = library.copy_pkg_to_repo(pkginfo, self.env["pkg_path"])
-        install_prefix = os.path.join(library.munki_repo, 'pkgs')
-        pkginfo["installer_item_location"] = os.path.relpath(install_path, install_prefix)
+        install_prefix = os.path.join(library.munki_repo, "pkgs")
+        pkginfo["installer_item_location"] = os.path.relpath(
+            install_path, install_prefix
+        )
         self.env["pkg_repo_path"] = install_path
 
         if self.env.get("uninstaller_pkg_path"):
@@ -416,7 +442,7 @@ class MunkiImporter(Processor):
 
         if icon_path:
             self.env["icon_repo_path"] = icon_path
-            icon_prefix = os.path.join(library.munki_repo, 'icons')
+            icon_prefix = os.path.join(library.munki_repo, "icons")
             rel_icon_path = os.path.relpath(icon_path, icon_prefix)
         else:
             self.env["icon_repo_path"] = rel_icon_path = ""
@@ -425,8 +451,8 @@ class MunkiImporter(Processor):
         pkginfo_path = library.copy_pkginfo_to_repo(
             pkginfo, self.env.get("MUNKI_PKGINFO_FILE_EXTENSION", "plist")
         )
-        pkginfo_prefix = os.path.join(library.munki_repo, 'pkgsinfo')
-        pkg_prefix = os.path.join(library.munki_repo, 'pkgs')
+        pkginfo_prefix = os.path.join(library.munki_repo, "pkgsinfo")
+        pkg_prefix = os.path.join(library.munki_repo, "pkgs")
 
         self.env["pkginfo_repo_path"] = pkginfo_path
 
@@ -453,7 +479,9 @@ class MunkiImporter(Processor):
                 "name": pkginfo["name"],
                 "version": pkginfo["version"],
                 "catalogs": ",".join(pkginfo["catalogs"]),
-                "pkginfo_path": os.path.relpath(self.env["pkginfo_repo_path"], pkginfo_prefix),
+                "pkginfo_path": os.path.relpath(
+                    self.env["pkginfo_repo_path"], pkginfo_prefix
+                ),
                 "pkg_repo_path": os.path.relpath(self.env["pkg_repo_path"], pkg_prefix),
                 "icon_repo_path": rel_icon_path,  # can be path or ""
             },


### PR DESCRIPTION
There is a special case when the changes introduced by Erik regarding architecture checking allow MunkiImporter to duplicate a munki import when both arm64 and x86_64 are already imported in the repo.

`_find_matching_pkginfo` return only one item matching a criteria based on hash, app list, receipts... There is a special case when autopkg runs without a Cache and processing a recipe with PkgCreator where `installer_item_hash` will be always different and next criteria can be the same for arm64 and x86_64 recipes. So returning only one item from the catalog could fail when matching this: https://github.com/autopkg/autopkg/blob/1b0031c108f055e1f72e6588776936e4ab797222/Code/autopkglib/MunkiImporter.py#L367-L368
<details>
<summary>Output</summary>
<p>

```shell
 joaquin  ~/gitlab/autopkg-build2   master  makecatalogs ~/Library/AutoPkg/RecipeRepos/munki-repo | grep CreativeCloudInstaller                                                                                                                                             18:16:19 
Hashing CreativeCloudInstaller.png...
Adding pkgsinfo/apps/adobe/CreativeCloudInstaller-5.6.0.788.plist to import...
Adding pkgsinfo/apps/adobe/CreativeCloudInstaller-5.6.0.788__1.plist to import...
 joaquin  ~/gitlab/autopkg-build2   master  rm -rf /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstaller*                                                                                                                                   18:19:07 
 joaquin  ~/gitlab/autopkg-build2   master  /usr/local/bin/autopkg run --override-dir="overrides" -vvv AdobeCreativeCloudInstallerAppleSilicon.munki.recipe                                                                                                                 18:20:33 
Processing AdobeCreativeCloudInstallerAppleSilicon.munki.recipe...
{'ARCHITECTURE': 'macarm64',
 'AUTOPKG_VERSION': '2.3.2',
 'CACHE_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/Cache',
 'MUNKI_REPO': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo',
 'MUNKI_REPO_SUBDIR': 'apps/adobe',
 'NAME': 'Creative Cloud Installer',
 'NAMEWITHOUTSPACES': 'CreativeCloudInstaller',
 'PARENT_RECIPES': ['/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe/AdobeCreativeCloudInstallerAppleSilicon.munki.recipe',
                    '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.pkg.recipe',
                    '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon',
 'RECIPE_DIR': '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides',
 'RECIPE_OVERRIDE_DIRS': ['overrides'],
 'RECIPE_PATH': '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides/AdobeCreativeCloudInstallerAppleSilicon.munki.recipe',
 'RECIPE_REPOS': {'/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.adobe-ccp-recipes': {'URL': 'https://github.com/autopkg/adobe-ccp-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes': {'URL': 'https://github.com/autopkg/apizz-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes': {'URL': 'https://github.com/autopkg/arubdesu-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.cgerke-recipes': {'URL': 'https://github.com/autopkg/cgerke-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.chilcote-recipes': {'URL': 'https://github.com/autopkg/chilcote-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.crystalllized-recipes': {'URL': 'https://github.com/autopkg/crystalllized-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dankeller-recipes': {'URL': 'https://github.com/autopkg/dankeller-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes': {'URL': 'https://github.com/autopkg/dataJAR-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.erikng-recipes': {'URL': 'https://github.com/autopkg/erikng-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.flywire-recipes': {'URL': 'https://github.com/autopkg/flywire-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes': {'URL': 'https://github.com/autopkg/foigus-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes': {'URL': 'https://github.com/autopkg/grahamgilbert-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes': {'URL': 'https://github.com/autopkg/hjuutilainen-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes': {'URL': 'https://github.com/autopkg/homebysix-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes': {'URL': 'https://github.com/autopkg/jleggat-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes': {'URL': 'https://github.com/autopkg/joshua-d-miller-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes': {'URL': 'https://github.com/autopkg/keeleysam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes': {'URL': 'https://github.com/autopkg/killahquam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes': {'URL': 'https://github.com/autopkg/moofit-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes': {'URL': 'https://github.com/autopkg/mosen-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.neilmartin83-recipes': {'URL': 'https://github.com/autopkg/neilmartin83-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes': {'URL': 'https://github.com/autopkg/nmcspadden-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.novaksam-recipes': {'URL': 'https://github.com/autopkg/novaksam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes': {'URL': 'https://github.com/autopkg/nstrauss-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes': {'URL': 'https://github.com/autopkg/orchard-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes': {'URL': 'https://github.com/autopkg/scriptingosx-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes': {'URL': 'https://github.com/autopkg/sheagcraig-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.valdore86-recipes': {'URL': 'https://github.com/autopkg/valdore86-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes': {'URL': 'https://github.com/autopkg/ygini-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.lctrkid.Recipes-for-AutoPkg': {'URL': 'https://github.com/lctrkid/Recipes-for-AutoPkg'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/tech.flywire.gitlab.flywire.it.flywire-autopkg-recipes': {'URL': 'https://gitlab.flywire.tech/flywire/it/flywire-autopkg-recipes.git'}},
 'RECIPE_REPO_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.cgerke-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dankeller-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.novaksam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.valdore86-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/tech.flywire.gitlab.flywire.it.flywire-autopkg-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.chilcote-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.adobe-ccp-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.neilmartin83-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.lctrkid.Recipes-for-AutoPkg',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.crystalllized-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.flywire-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.erikng-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud'],
 'SEARCH_PATTERN': '(?P<url>http.*?://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/macarm64/ACCC.*?.dmg)',
 'SEARCH_URL': 'https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html',
 'SOFTWARETITLE': 'Creative Cloud Installer',
 'VENDOR': 'Adobe',
 'pkginfo': {'blocking_applications': [],
             'catalogs': ['import'],
             'category': 'Adobe',
             'description': 'The Creative Cloud app runs in the menu bar and '
                            'allows you to install, update or remove Creative '
                            'Cloud applications for which you are licensed.',
             'developer': 'Adobe',
             'display_name': 'Creative Cloud Installer',
             'icon_name': 'CreativeCloudInstaller.png',
             'name': 'CreativeCloudInstaller',
             'postinstall_script': '#!/bin/bash\n'
                                   '\n'
                                   'config_path="/Library/Application '
                                   'Support/Adobe/OOBE/Configs"\n'
                                   'config="/Library/Application '
                                   'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                   'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                   '\n'
                                   '[[ -f "$config" ]] && echo '
                                   '"$serviceconfig" > "$config" || mkdir -p '
                                   '"$config_path"; echo "$serviceconfig" > '
                                   '"$config"\n'
                                   '\n'
                                   'exit 0\n'
                                   '\t\t\t',
             'supported_architectures': ['arm64'],
             'unattended_install': True,
             'uninstall_method': 'uninstall_script',
             'uninstall_script': '#!/bin/bash\n'
                                 '"/Applications/Utilities/Adobe Creative '
                                 'Cloud/Utils/Creative Cloud '
                                 'Uninstaller.app/Contents/MacOS/Creative '
                                 'Cloud Uninstaller" -u\n'},
 'verbose': 3}
URLTextSearcher
{'Input': {'re_pattern': '(?P<url>http.*?://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/macarm64/ACCC.*?.dmg)',
           'url': 'https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg
URLTextSearcher: Found matching text (match): https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg
{'Output': {'match': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg',
            'url': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg'}}
URLDownloader
{'Input': {'url': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 07 Oct 2021 09:26:27 GMT
URLDownloader: Storing new ETag header: "0727296d57981f95cb315241c07e1866:1633940519.730346"
URLDownloader: Downloaded /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg
{'Output': {'download_changed': True,
            'etag': '"0727296d57981f95cb315241c07e1866:1633940519.730346"',
            'last_modified': 'Thu, 07 Oct 2021 09:26:27 GMT',
            'pathname': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg/Install.app',
           'requirement': 'identifier "com.adobe.cc.Install" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'JQ525L2MZD'}}
CodeSignatureVerifier: Mounted disk image /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.6F3iiX/Install.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.6F3iiX/Install.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.6F3iiX/Install.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml',
           'overwrite': True,
           'source_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg/packages/ApplicationInfo.xml'}}
Copier: Parsed dmg results: dmg_path: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg, dmg: .dmg/, dmg_source_path: packages/ApplicationInfo.xml
Copier: Mounted disk image /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg
Copier: Copied /private/tmp/dmg.YIsvkX/packages/ApplicationInfo.xml to /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
{'Output': {}}
XMLReader
{'Input': {'elements': [{'text': 'version', 'xpath': 'version'}],
           'xml_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml'}}
XMLReader: Reading: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
XMLReader: Assigning value of '5.6.0.788' to output variable 'version'
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {},
           'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot'}}
PkgRootCreator: Created /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {},
           'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts'}}
PkgRootCreator: Created /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml',
           'overwrite': True,
           'source_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg/packages/ApplicationInfo.xml'}}
Copier: Parsed dmg results: dmg_path: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg, dmg: .dmg/, dmg_source_path: packages/ApplicationInfo.xml
Copier: Mounted disk image /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg
Copier: Copied /private/tmp/dmg.3GmVzE/packages/ApplicationInfo.xml to /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
{'Output': {}}
XMLReader
{'Input': {'elements': [{'text': 'version', 'xpath': 'version'}],
           'xml_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml'}}
XMLReader: Reading: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
XMLReader: Assigning value of '5.6.0.788' to output variable 'version'
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/AdobeCreativeCloudInstaller-5.6.0.788.dmg',
           'overwrite': True,
           'source_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg'}}
Copier: Parsed dmg results: dmg_path: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg, dmg: , dmg_source_path: 
Copier: Copied /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg to /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/AdobeCreativeCloudInstaller-5.6.0.788.dmg
{'Output': {}}
FileCreator
{'Input': {'file_content': '#!/bin/bash\n'
                           '\t\t\t\t\n'
                           '# Determine working directory\n'
                           'installDir=$(dirname $0)\n'
                           'dmg=("${installDir}"/*\\.dmg)\n'
                           '\n'
                           '# Mount the disk image to /Volumes\n'
                           'mountResult=$(/usr/bin/hdiutil attach "${dmg}" '
                           '-nobrowse -noverify -noautoopen)\n'
                           'mountPoint=$(/bin/echo "${mountResult}" | '
                           "/usr/bin/grep Volumes | /usr/bin/awk '{print "
                           "substr($0, index($0,$3))}')\n"
                           '\n'
                           '# Install the software\n'
                           '"${mountPoint}/Install.app/Contents/MacOS/Install" '
                           '--mode=silent\n'
                           '\n'
                           '# Get the exit code so we can fail properly\n'
                           'exitcode=$?\n'
                           '\n'
                           '# Unmount the disk image from /Volumes\n'
                           '/usr/bin/hdiutil detach "${mountPoint}"\n'
                           '\n'
                           '# Exit according to whether the install succeeded '
                           'or not\n'
                           'exit "${exitcode}"\n',
           'file_mode': '0755',
           'file_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/postinstall'}}
FileCreator: Created file at /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/postinstall
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'id': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                           'pkgname': 'AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788',
                           'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot',
                           'pkgtype': 'flat',
                           'scripts': 'Scripts',
                           'version': '5.6.0.788'}}}
PkgCreator: Checking all items in request:
PkgCreator: pkgroot: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot
PkgCreator: pkgname: AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788
PkgCreator: pkgtype: flat
PkgCreator: id: com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg
PkgCreator: version: 5.6.0.788
PkgCreator: scripts: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts
PkgCreator: pkgdir: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon
PkgCreator: infofile: 
PkgCreator: resources: 
PkgCreator: options: 
PkgCreator: chown: []
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: OUTPUT FOR REPLY:
PkgCreator: OK:/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg

PkgCreator: Doing nothing...
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                                                    'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg',
                                                    'version': '5.6.0.788'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg'}}
PathDeleter
{'Input': {'path_list': ['/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot',
                         '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts',
                         '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml']}}
PathDeleter: Deleted /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot
PathDeleter: Deleted /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts
PathDeleter: Deleted /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
{'Output': {}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleName': 'Creative '
                                                                'Cloud',
                                                'CFBundleShortVersionString': '5.6.0.788',
                                                'path': '/Applications/Utilities/Adobe '
                                                        'Creative '
                                                        'Cloud/ACC/Creative '
                                                        'Cloud.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': [],
                       'catalogs': ['import'],
                       'category': 'Adobe',
                       'description': 'The Creative Cloud app runs in the menu '
                                      'bar and allows you to install, update '
                                      'or remove Creative Cloud applications '
                                      'for which you are licensed.',
                       'developer': 'Adobe',
                       'display_name': 'Creative Cloud Installer',
                       'icon_name': 'CreativeCloudInstaller.png',
                       'name': 'CreativeCloudInstaller',
                       'postinstall_script': '#!/bin/bash\n'
                                             '\n'
                                             'config_path="/Library/Application '
                                             'Support/Adobe/OOBE/Configs"\n'
                                             'config="/Library/Application '
                                             'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                             'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                             '\n'
                                             '[[ -f "$config" ]] && echo '
                                             '"$serviceconfig" > "$config" || '
                                             'mkdir -p "$config_path"; echo '
                                             '"$serviceconfig" > "$config"\n'
                                             '\n'
                                             'exit 0\n'
                                             '\t\t\t',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True,
                       'uninstall_method': 'uninstall_script',
                       'uninstall_script': '#!/bin/bash\n'
                                           '"/Applications/Utilities/Adobe '
                                           'Creative Cloud/Utils/Creative '
                                           'Cloud '
                                           'Uninstaller.app/Contents/MacOS/Creative '
                                           'Cloud Uninstaller" -u\n'}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleName': 'Creative Cloud', 'CFBundleShortVersionString': '5.6.0.788', 'path': '/Applications/Utilities/Adobe Creative Cloud/ACC/Creative Cloud.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': [],
                        'catalogs': ['import'],
                        'category': 'Adobe',
                        'description': 'The Creative Cloud app runs in the '
                                       'menu bar and allows you to install, '
                                       'update or remove Creative Cloud '
                                       'applications for which you are '
                                       'licensed.',
                        'developer': 'Adobe',
                        'display_name': 'Creative Cloud Installer',
                        'icon_name': 'CreativeCloudInstaller.png',
                        'installs': [{'CFBundleName': 'Creative Cloud',
                                      'CFBundleShortVersionString': '5.6.0.788',
                                      'path': '/Applications/Utilities/Adobe '
                                              'Creative Cloud/ACC/Creative '
                                              'Cloud.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'CreativeCloudInstaller',
                        'postinstall_script': '#!/bin/bash\n'
                                              '\n'
                                              'config_path="/Library/Application '
                                              'Support/Adobe/OOBE/Configs"\n'
                                              'config="/Library/Application '
                                              'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                              'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                              '\n'
                                              '[[ -f "$config" ]] && echo '
                                              '"$serviceconfig" > "$config" || '
                                              'mkdir -p "$config_path"; echo '
                                              '"$serviceconfig" > "$config"\n'
                                              '\n'
                                              'exit 0\n'
                                              '\t\t\t',
                        'supported_architectures': ['arm64'],
                        'unattended_install': True,
                        'uninstall_method': 'uninstall_script',
                        'uninstall_script': '#!/bin/bash\n'
                                            '"/Applications/Utilities/Adobe '
                                            'Creative Cloud/Utils/Creative '
                                            'Cloud '
                                            'Uninstaller.app/Contents/MacOS/Creative '
                                            'Cloud Uninstaller" -u\n'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo',
           'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg',
           'pkginfo': {'blocking_applications': [],
                       'catalogs': ['import'],
                       'category': 'Adobe',
                       'description': 'The Creative Cloud app runs in the menu '
                                      'bar and allows you to install, update '
                                      'or remove Creative Cloud applications '
                                      'for which you are licensed.',
                       'developer': 'Adobe',
                       'display_name': 'Creative Cloud Installer',
                       'icon_name': 'CreativeCloudInstaller.png',
                       'installs': [{'CFBundleName': 'Creative Cloud',
                                     'CFBundleShortVersionString': '5.6.0.788',
                                     'path': '/Applications/Utilities/Adobe '
                                             'Creative Cloud/ACC/Creative '
                                             'Cloud.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'CreativeCloudInstaller',
                       'postinstall_script': '#!/bin/bash\n'
                                             '\n'
                                             'config_path="/Library/Application '
                                             'Support/Adobe/OOBE/Configs"\n'
                                             'config="/Library/Application '
                                             'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                             'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                             '\n'
                                             '[[ -f "$config" ]] && echo '
                                             '"$serviceconfig" > "$config" || '
                                             'mkdir -p "$config_path"; echo '
                                             '"$serviceconfig" > "$config"\n'
                                             '\n'
                                             'exit 0\n'
                                             '\t\t\t',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True,
                       'uninstall_method': 'uninstall_script',
                       'uninstall_script': '#!/bin/bash\n'
                                           '"/Applications/Utilities/Adobe '
                                           'Creative Cloud/Utils/Creative '
                                           'Cloud '
                                           'Uninstaller.app/Contents/MacOS/Creative '
                                           'Cloud Uninstaller" -u\n'},
           'repo_subdirectory': 'apps/adobe'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo
MunkiImporter: Copied pkginfo to: /Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo/pkgsinfo/apps/adobe/CreativeCloudInstaller-5.6.0.788__2.plist
MunkiImporter:            pkg to: /Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo/pkgs/apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788__1.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'import',
                                                       'icon_repo_path': '',
                                                       'name': 'CreativeCloudInstaller',
                                                       'pkg_repo_path': 'apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788__1.pkg',
                                                       'pkginfo_path': 'apps/adobe/CreativeCloudInstaller-5.6.0.788__2.plist',
                                                       'version': '5.6.0.788'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'joaquincabrerizo',
                                         'creation_date': datetime.datetime(2021, 12, 21, 17, 21, 38),
                                         'munki_version': '5.6.2.4398',
                                         'os_version': '12.0.1'},
                           'autoremove': False,
                           'blocking_applications': [],
                           'catalogs': ['import'],
                           'category': 'Adobe',
                           'description': 'The Creative Cloud app runs in the '
                                          'menu bar and allows you to install, '
                                          'update or remove Creative Cloud '
                                          'applications for which you are '
                                          'licensed.',
                           'developer': 'Adobe',
                           'display_name': 'Creative Cloud Installer',
                           'icon_name': 'CreativeCloudInstaller.png',
                           'installer_item_hash': '65a07667889913439968b1eed61fc75da11a3047bfe9c9094b165f722e5dda8c',
                           'installer_item_location': 'apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788__1.pkg',
                           'installer_item_size': 243459,
                           'installs': [{'CFBundleName': 'Creative Cloud',
                                         'CFBundleShortVersionString': '5.6.0.788',
                                         'path': '/Applications/Utilities/Adobe '
                                                 'Creative Cloud/ACC/Creative '
                                                 'Cloud.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'CreativeCloudInstaller',
                           'postinstall_script': '#!/bin/bash\n'
                                                 '\n'
                                                 'config_path="/Library/Application '
                                                 'Support/Adobe/OOBE/Configs"\n'
                                                 'config="/Library/Application '
                                                 'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                                 'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                                 '\n'
                                                 '[[ -f "$config" ]] && echo '
                                                 '"$serviceconfig" > "$config" '
                                                 '|| mkdir -p "$config_path"; '
                                                 'echo "$serviceconfig" > '
                                                 '"$config"\n'
                                                 '\n'
                                                 'exit 0\n'
                                                 '\t\t\t',
                           'receipts': [{'installed_size': 0,
                                         'packageid': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                                         'version': '5.6.0.788'}],
                           'supported_architectures': ['arm64'],
                           'unattended_install': True,
                           'uninstall_method': 'uninstall_script',
                           'uninstall_script': '#!/bin/bash\n'
                                               '"/Applications/Utilities/Adobe '
                                               'Creative Cloud/Utils/Creative '
                                               'Cloud '
                                               'Uninstaller.app/Contents/MacOS/Creative '
                                               'Cloud Uninstaller" -u\n',
                           'uninstallable': True,
                           'version': '5.6.0.788'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo/pkgs/apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788__1.pkg',
            'pkginfo_repo_path': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo/pkgsinfo/apps/adobe/CreativeCloudInstaller-5.6.0.788__2.plist'}}
{'ARCHITECTURE': 'macarm64',
 'AUTOPKG_VERSION': '2.3.2',
 'CACHE_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/Cache',
 'CHECK_FILESIZE_ONLY': False,
 'MUNKILIB_DIR': '/usr/local/munki',
 'MUNKI_REPO': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo',
 'MUNKI_REPO_PLUGIN': 'FileRepo',
 'MUNKI_REPO_SUBDIR': 'apps/adobe',
 'NAME': 'Creative Cloud Installer',
 'NAMEWITHOUTSPACES': 'CreativeCloudInstaller',
 'PARENT_RECIPES': ['/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe/AdobeCreativeCloudInstallerAppleSilicon.munki.recipe',
                    '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.pkg.recipe',
                    '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon',
 'RECIPE_DIR': '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides',
 'RECIPE_OVERRIDE_DIRS': ['overrides'],
 'RECIPE_PATH': '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides/AdobeCreativeCloudInstallerAppleSilicon.munki.recipe',
 'RECIPE_REPOS': {'/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.adobe-ccp-recipes': {'URL': 'https://github.com/autopkg/adobe-ccp-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes': {'URL': 'https://github.com/autopkg/apizz-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes': {'URL': 'https://github.com/autopkg/arubdesu-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.cgerke-recipes': {'URL': 'https://github.com/autopkg/cgerke-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.chilcote-recipes': {'URL': 'https://github.com/autopkg/chilcote-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.crystalllized-recipes': {'URL': 'https://github.com/autopkg/crystalllized-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dankeller-recipes': {'URL': 'https://github.com/autopkg/dankeller-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes': {'URL': 'https://github.com/autopkg/dataJAR-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.erikng-recipes': {'URL': 'https://github.com/autopkg/erikng-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.flywire-recipes': {'URL': 'https://github.com/autopkg/flywire-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes': {'URL': 'https://github.com/autopkg/foigus-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes': {'URL': 'https://github.com/autopkg/grahamgilbert-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes': {'URL': 'https://github.com/autopkg/hjuutilainen-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes': {'URL': 'https://github.com/autopkg/homebysix-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes': {'URL': 'https://github.com/autopkg/jleggat-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes': {'URL': 'https://github.com/autopkg/joshua-d-miller-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes': {'URL': 'https://github.com/autopkg/keeleysam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes': {'URL': 'https://github.com/autopkg/killahquam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes': {'URL': 'https://github.com/autopkg/moofit-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes': {'URL': 'https://github.com/autopkg/mosen-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.neilmartin83-recipes': {'URL': 'https://github.com/autopkg/neilmartin83-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes': {'URL': 'https://github.com/autopkg/nmcspadden-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.novaksam-recipes': {'URL': 'https://github.com/autopkg/novaksam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes': {'URL': 'https://github.com/autopkg/nstrauss-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes': {'URL': 'https://github.com/autopkg/orchard-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes': {'URL': 'https://github.com/autopkg/scriptingosx-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes': {'URL': 'https://github.com/autopkg/sheagcraig-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.valdore86-recipes': {'URL': 'https://github.com/autopkg/valdore86-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes': {'URL': 'https://github.com/autopkg/ygini-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.lctrkid.Recipes-for-AutoPkg': {'URL': 'https://github.com/lctrkid/Recipes-for-AutoPkg'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/tech.flywire.gitlab.flywire.it.flywire-autopkg-recipes': {'URL': 'https://gitlab.flywire.tech/flywire/it/flywire-autopkg-recipes.git'}},
 'RECIPE_REPO_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.cgerke-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dankeller-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.novaksam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.valdore86-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/tech.flywire.gitlab.flywire.it.flywire-autopkg-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.chilcote-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.adobe-ccp-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.neilmartin83-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.lctrkid.Recipes-for-AutoPkg',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.crystalllized-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.flywire-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.erikng-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud'],
 'SEARCH_PATTERN': '(?P<url>http.*?://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/macarm64/ACCC.*?.dmg)',
 'SEARCH_URL': 'https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html',
 'SOFTWARETITLE': 'Creative Cloud Installer',
 'VENDOR': 'Adobe',
 'additional_pkginfo': {'installs': [{'CFBundleName': 'Creative Cloud',
                                      'CFBundleShortVersionString': '5.6.0.788',
                                      'path': '/Applications/Utilities/Adobe '
                                              'Creative Cloud/ACC/Creative '
                                              'Cloud.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}]},
 'destination_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/AdobeCreativeCloudInstaller-5.6.0.788.dmg',
 'download_changed': True,
 'elements': [{'text': 'version', 'xpath': 'version'}],
 'etag': '"0727296d57981f95cb315241c07e1866:1633940519.730346"',
 'file_content': '#!/bin/bash\n'
                 '\t\t\t\t\n'
                 '# Determine working directory\n'
                 'installDir=$(dirname $0)\n'
                 'dmg=("${installDir}"/*\\.dmg)\n'
                 '\n'
                 '# Mount the disk image to /Volumes\n'
                 'mountResult=$(/usr/bin/hdiutil attach "${dmg}" -nobrowse '
                 '-noverify -noautoopen)\n'
                 'mountPoint=$(/bin/echo "${mountResult}" | /usr/bin/grep '
                 "Volumes | /usr/bin/awk '{print substr($0, index($0,$3))}')\n"
                 '\n'
                 '# Install the software\n'
                 '"${mountPoint}/Install.app/Contents/MacOS/Install" '
                 '--mode=silent\n'
                 '\n'
                 '# Get the exit code so we can fail properly\n'
                 'exitcode=$?\n'
                 '\n'
                 '# Unmount the disk image from /Volumes\n'
                 '/usr/bin/hdiutil detach "${mountPoint}"\n'
                 '\n'
                 '# Exit according to whether the install succeeded or not\n'
                 'exit "${exitcode}"\n',
 'file_mode': '0755',
 'file_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/postinstall',
 'force_munki_repo_lib': False,
 'icon_repo_path': '',
 'input_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg/Install.app',
 'last_modified': 'Thu, 07 Oct 2021 09:26:27 GMT',
 'match': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg',
 'munki_importer_summary_result': {'data': {'catalogs': 'import',
                                            'icon_repo_path': '',
                                            'name': 'CreativeCloudInstaller',
                                            'pkg_repo_path': 'apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788__1.pkg',
                                            'pkginfo_path': 'apps/adobe/CreativeCloudInstaller-5.6.0.788__2.plist',
                                            'version': '5.6.0.788'},
                                   'report_fields': ['name',
                                                     'version',
                                                     'catalogs',
                                                     'pkginfo_path',
                                                     'pkg_repo_path',
                                                     'icon_repo_path'],
                                   'summary_text': 'The following new items '
                                                   'were imported into Munki:'},
 'munki_info': {'_metadata': {'created_by': 'joaquincabrerizo',
                              'creation_date': datetime.datetime(2021, 12, 21, 17, 21, 38),
                              'munki_version': '5.6.2.4398',
                              'os_version': '12.0.1'},
                'autoremove': False,
                'blocking_applications': [],
                'catalogs': ['import'],
                'category': 'Adobe',
                'description': 'The Creative Cloud app runs in the menu bar '
                               'and allows you to install, update or remove '
                               'Creative Cloud applications for which you are '
                               'licensed.',
                'developer': 'Adobe',
                'display_name': 'Creative Cloud Installer',
                'icon_name': 'CreativeCloudInstaller.png',
                'installer_item_hash': '65a07667889913439968b1eed61fc75da11a3047bfe9c9094b165f722e5dda8c',
                'installer_item_location': 'apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788__1.pkg',
                'installer_item_size': 243459,
                'installs': [{'CFBundleName': 'Creative Cloud',
                              'CFBundleShortVersionString': '5.6.0.788',
                              'path': '/Applications/Utilities/Adobe Creative '
                                      'Cloud/ACC/Creative Cloud.app',
                              'type': 'application',
                              'version_comparison_key': 'CFBundleShortVersionString'}],
                'minimum_os_version': '10.5.0',
                'name': 'CreativeCloudInstaller',
                'postinstall_script': '#!/bin/bash\n'
                                      '\n'
                                      'config_path="/Library/Application '
                                      'Support/Adobe/OOBE/Configs"\n'
                                      'config="/Library/Application '
                                      'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                      'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                      '\n'
                                      '[[ -f "$config" ]] && echo '
                                      '"$serviceconfig" > "$config" || mkdir '
                                      '-p "$config_path"; echo '
                                      '"$serviceconfig" > "$config"\n'
                                      '\n'
                                      'exit 0\n'
                                      '\t\t\t',
                'receipts': [{'installed_size': 0,
                              'packageid': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                              'version': '5.6.0.788'}],
                'supported_architectures': ['arm64'],
                'unattended_install': True,
                'uninstall_method': 'uninstall_script',
                'uninstall_script': '#!/bin/bash\n'
                                    '"/Applications/Utilities/Adobe Creative '
                                    'Cloud/Utils/Creative Cloud '
                                    'Uninstaller.app/Contents/MacOS/Creative '
                                    'Cloud Uninstaller" -u\n',
                'uninstallable': True,
                'version': '5.6.0.788'},
 'munki_repo_changed': True,
 'new_package_request': True,
 'overwrite': True,
 'path_list': ['/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot',
               '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts',
               '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml'],
 'pathname': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg',
 'pkg_creator_summary_result': {'data': {'identifier': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                                         'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg',
                                         'version': '5.6.0.788'},
                                'report_fields': ['identifier',
                                                  'version',
                                                  'pkg_path'],
                                'summary_text': 'The following packages were '
                                                'built:'},
 'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo/pkgs/apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788__1.pkg',
 'pkg_repo_path': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo/pkgs/apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788__1.pkg',
 'pkg_request': {'chown': [],
                 'id': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                 'infofile': '',
                 'options': '',
                 'pkgdir': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon',
                 'pkgname': 'AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788',
                 'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot',
                 'pkgtype': 'flat',
                 'resources': '',
                 'scripts': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts',
                 'version': '5.6.0.788'},
 'pkgdirs': {},
 'pkginfo': {'blocking_applications': [],
             'catalogs': ['import'],
             'category': 'Adobe',
             'description': 'The Creative Cloud app runs in the menu bar and '
                            'allows you to install, update or remove Creative '
                            'Cloud applications for which you are licensed.',
             'developer': 'Adobe',
             'display_name': 'Creative Cloud Installer',
             'icon_name': 'CreativeCloudInstaller.png',
             'installs': [{'CFBundleName': 'Creative Cloud',
                           'CFBundleShortVersionString': '5.6.0.788',
                           'path': '/Applications/Utilities/Adobe Creative '
                                   'Cloud/ACC/Creative Cloud.app',
                           'type': 'application',
                           'version_comparison_key': 'CFBundleShortVersionString'}],
             'name': 'CreativeCloudInstaller',
             'postinstall_script': '#!/bin/bash\n'
                                   '\n'
                                   'config_path="/Library/Application '
                                   'Support/Adobe/OOBE/Configs"\n'
                                   'config="/Library/Application '
                                   'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                   'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                   '\n'
                                   '[[ -f "$config" ]] && echo '
                                   '"$serviceconfig" > "$config" || mkdir -p '
                                   '"$config_path"; echo "$serviceconfig" > '
                                   '"$config"\n'
                                   '\n'
                                   'exit 0\n'
                                   '\t\t\t',
             'supported_architectures': ['arm64'],
             'unattended_install': True,
             'uninstall_method': 'uninstall_script',
             'uninstall_script': '#!/bin/bash\n'
                                 '"/Applications/Utilities/Adobe Creative '
                                 'Cloud/Utils/Creative Cloud '
                                 'Uninstaller.app/Contents/MacOS/Creative '
                                 'Cloud Uninstaller" -u\n'},
 'pkginfo_repo_path': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo/pkgsinfo/apps/adobe/CreativeCloudInstaller-5.6.0.788__2.plist',
 'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts',
 'prefetch_filename': False,
 're_pattern': '(?P<url>http.*?://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/macarm64/ACCC.*?.dmg)',
 'repo_subdirectory': 'apps/adobe',
 'requirement': 'identifier "com.adobe.cc.Install" and anchor apple generic '
                'and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists '
                '*/ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* '
                'exists */ and certificate leaf[subject.OU] = JQ525L2MZD',
 'result_output_var_name': 'match',
 'source_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg',
 'url': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 3,
 'version': '5.6.0.788',
 'xml_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml',
 'xml_reader_output_variables': {}}
Receipt written to /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/receipts/AdobeCreativeCloudInstallerAppleSilicon.munki-receipt-20211221-182139.plist

The following new items were downloaded:
    Download Path                                                                                                                   
    -------------                                                                                                                   
    /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg  

The following packages were built:
    Identifier                                             Version    Pkg Path                                                                                                                                                  
    ----------                                             -------    --------                                                                                                                                                  
    com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg  5.6.0.788  /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg  

The following new items were imported into Munki:
    Name                    Version    Catalogs  Pkginfo Path                                          Pkg Repo Path                                                         Icon Repo Path  
    ----                    -------    --------  ------------                                          -------------                                                         --------------  
    CreativeCloudInstaller  5.6.0.788  import    apps/adobe/CreativeCloudInstaller-5.6.0.788__2.plist  apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788__1.pkg                  
 joaquin  ~/gitlab/autopkg-build2   master  rm -rf /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstaller*                                                                                                                                 18:24:13 
 joaquin  ~/gitlab/autopkg-build2   master  ~/github/autopkg/Code/autopkg run --override-dir="overrides" -vvv AdobeCreativeCloudInstallerAppleSilicon.munki.recipe                                                                                                          18:24:27 
Processing AdobeCreativeCloudInstallerAppleSilicon.munki.recipe...
{'ARCHITECTURE': 'macarm64',
 'AUTOPKG_VERSION': '2.3.2',
 'CACHE_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/Cache',
 'MUNKI_REPO': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo',
 'MUNKI_REPO_SUBDIR': 'apps/adobe',
 'NAME': 'Creative Cloud Installer',
 'NAMEWITHOUTSPACES': 'CreativeCloudInstaller',
 'PARENT_RECIPES': ['/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe/AdobeCreativeCloudInstallerAppleSilicon.munki.recipe',
                    '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.pkg.recipe',
                    '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon',
 'RECIPE_DIR': '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides',
 'RECIPE_OVERRIDE_DIRS': ['overrides'],
 'RECIPE_PATH': '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides/AdobeCreativeCloudInstallerAppleSilicon.munki.recipe',
 'RECIPE_REPOS': {'/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.adobe-ccp-recipes': {'URL': 'https://github.com/autopkg/adobe-ccp-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes': {'URL': 'https://github.com/autopkg/apizz-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes': {'URL': 'https://github.com/autopkg/arubdesu-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.cgerke-recipes': {'URL': 'https://github.com/autopkg/cgerke-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.chilcote-recipes': {'URL': 'https://github.com/autopkg/chilcote-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.crystalllized-recipes': {'URL': 'https://github.com/autopkg/crystalllized-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dankeller-recipes': {'URL': 'https://github.com/autopkg/dankeller-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes': {'URL': 'https://github.com/autopkg/dataJAR-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.erikng-recipes': {'URL': 'https://github.com/autopkg/erikng-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.flywire-recipes': {'URL': 'https://github.com/autopkg/flywire-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes': {'URL': 'https://github.com/autopkg/foigus-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes': {'URL': 'https://github.com/autopkg/grahamgilbert-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes': {'URL': 'https://github.com/autopkg/hjuutilainen-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes': {'URL': 'https://github.com/autopkg/homebysix-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes': {'URL': 'https://github.com/autopkg/jleggat-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes': {'URL': 'https://github.com/autopkg/joshua-d-miller-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes': {'URL': 'https://github.com/autopkg/keeleysam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes': {'URL': 'https://github.com/autopkg/killahquam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes': {'URL': 'https://github.com/autopkg/moofit-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes': {'URL': 'https://github.com/autopkg/mosen-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.neilmartin83-recipes': {'URL': 'https://github.com/autopkg/neilmartin83-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes': {'URL': 'https://github.com/autopkg/nmcspadden-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.novaksam-recipes': {'URL': 'https://github.com/autopkg/novaksam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes': {'URL': 'https://github.com/autopkg/nstrauss-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes': {'URL': 'https://github.com/autopkg/orchard-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes': {'URL': 'https://github.com/autopkg/scriptingosx-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes': {'URL': 'https://github.com/autopkg/sheagcraig-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.valdore86-recipes': {'URL': 'https://github.com/autopkg/valdore86-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes': {'URL': 'https://github.com/autopkg/ygini-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.lctrkid.Recipes-for-AutoPkg': {'URL': 'https://github.com/lctrkid/Recipes-for-AutoPkg'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/tech.flywire.gitlab.flywire.it.flywire-autopkg-recipes': {'URL': 'https://gitlab.flywire.tech/flywire/it/flywire-autopkg-recipes.git'}},
 'RECIPE_REPO_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.cgerke-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dankeller-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.novaksam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.valdore86-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/tech.flywire.gitlab.flywire.it.flywire-autopkg-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.chilcote-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.adobe-ccp-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.neilmartin83-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.lctrkid.Recipes-for-AutoPkg',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.crystalllized-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.flywire-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.erikng-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud'],
 'SEARCH_PATTERN': '(?P<url>http.*?://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/macarm64/ACCC.*?.dmg)',
 'SEARCH_URL': 'https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html',
 'SOFTWARETITLE': 'Creative Cloud Installer',
 'VENDOR': 'Adobe',
 'pkginfo': {'blocking_applications': [],
             'catalogs': ['import'],
             'category': 'Adobe',
             'description': 'The Creative Cloud app runs in the menu bar and '
                            'allows you to install, update or remove Creative '
                            'Cloud applications for which you are licensed.',
             'developer': 'Adobe',
             'display_name': 'Creative Cloud Installer',
             'icon_name': 'CreativeCloudInstaller.png',
             'name': 'CreativeCloudInstaller',
             'postinstall_script': '#!/bin/bash\n'
                                   '\n'
                                   'config_path="/Library/Application '
                                   'Support/Adobe/OOBE/Configs"\n'
                                   'config="/Library/Application '
                                   'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                   'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                   '\n'
                                   '[[ -f "$config" ]] && echo '
                                   '"$serviceconfig" > "$config" || mkdir -p '
                                   '"$config_path"; echo "$serviceconfig" > '
                                   '"$config"\n'
                                   '\n'
                                   'exit 0\n'
                                   '\t\t\t',
             'supported_architectures': ['arm64'],
             'unattended_install': True,
             'uninstall_method': 'uninstall_script',
             'uninstall_script': '#!/bin/bash\n'
                                 '"/Applications/Utilities/Adobe Creative '
                                 'Cloud/Utils/Creative Cloud '
                                 'Uninstaller.app/Contents/MacOS/Creative '
                                 'Cloud Uninstaller" -u\n'},
 'verbose': 3}
URLTextSearcher
{'Input': {'re_pattern': '(?P<url>http.*?://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/macarm64/ACCC.*?.dmg)',
           'url': 'https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg
URLTextSearcher: Found matching text (match): https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg
{'Output': {'match': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg',
            'url': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg'}}
URLDownloader
{'Input': {'url': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 07 Oct 2021 09:26:27 GMT
URLDownloader: Storing new ETag header: "0727296d57981f95cb315241c07e1866:1633940519.730346"
URLDownloader: Downloaded /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg
{'Output': {'download_changed': True,
            'etag': '"0727296d57981f95cb315241c07e1866:1633940519.730346"',
            'last_modified': 'Thu, 07 Oct 2021 09:26:27 GMT',
            'pathname': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg/Install.app',
           'requirement': 'identifier "com.adobe.cc.Install" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'JQ525L2MZD'}}
CodeSignatureVerifier: Mounted disk image /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.voyt7E/Install.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.voyt7E/Install.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.voyt7E/Install.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml',
           'overwrite': True,
           'source_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg/packages/ApplicationInfo.xml'}}
Copier: Parsed dmg results: dmg_path: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg, dmg: .dmg/, dmg_source_path: packages/ApplicationInfo.xml
Copier: Mounted disk image /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg
Copier: Copied /private/tmp/dmg.FFUAxg/packages/ApplicationInfo.xml to /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
{'Output': {}}
XMLReader
{'Input': {'elements': [{'text': 'version', 'xpath': 'version'}],
           'xml_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml'}}
XMLReader: Reading: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
XMLReader: Assigning value of '5.6.0.788' to output variable 'version'
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {},
           'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot'}}
PkgRootCreator: Created /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {},
           'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts'}}
PkgRootCreator: Created /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml',
           'overwrite': True,
           'source_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg/packages/ApplicationInfo.xml'}}
Copier: Parsed dmg results: dmg_path: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg, dmg: .dmg/, dmg_source_path: packages/ApplicationInfo.xml
Copier: Mounted disk image /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg
Copier: Copied /private/tmp/dmg.2yqPOs/packages/ApplicationInfo.xml to /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
{'Output': {}}
XMLReader
{'Input': {'elements': [{'text': 'version', 'xpath': 'version'}],
           'xml_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml'}}
XMLReader: Reading: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
XMLReader: Assigning value of '5.6.0.788' to output variable 'version'
{'Output': {}}
Copier
{'Input': {'destination_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/AdobeCreativeCloudInstaller-5.6.0.788.dmg',
           'overwrite': True,
           'source_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg'}}
Copier: Parsed dmg results: dmg_path: /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg, dmg: , dmg_source_path: 
Copier: Copied /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg to /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/AdobeCreativeCloudInstaller-5.6.0.788.dmg
{'Output': {}}
FileCreator
{'Input': {'file_content': '#!/bin/bash\n'
                           '\t\t\t\t\n'
                           '# Determine working directory\n'
                           'installDir=$(dirname $0)\n'
                           'dmg=("${installDir}"/*\\.dmg)\n'
                           '\n'
                           '# Mount the disk image to /Volumes\n'
                           'mountResult=$(/usr/bin/hdiutil attach "${dmg}" '
                           '-nobrowse -noverify -noautoopen)\n'
                           'mountPoint=$(/bin/echo "${mountResult}" | '
                           "/usr/bin/grep Volumes | /usr/bin/awk '{print "
                           "substr($0, index($0,$3))}')\n"
                           '\n'
                           '# Install the software\n'
                           '"${mountPoint}/Install.app/Contents/MacOS/Install" '
                           '--mode=silent\n'
                           '\n'
                           '# Get the exit code so we can fail properly\n'
                           'exitcode=$?\n'
                           '\n'
                           '# Unmount the disk image from /Volumes\n'
                           '/usr/bin/hdiutil detach "${mountPoint}"\n'
                           '\n'
                           '# Exit according to whether the install succeeded '
                           'or not\n'
                           'exit "${exitcode}"\n',
           'file_mode': '0755',
           'file_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/postinstall'}}
FileCreator: Created file at /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/postinstall
{'Output': {}}
PkgCreator
{'Input': {'pkg_request': {'id': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                           'pkgname': 'AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788',
                           'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot',
                           'pkgtype': 'flat',
                           'scripts': 'Scripts',
                           'version': '5.6.0.788'}}}
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'new_package_request': True,
            'pkg_creator_summary_result': {'data': {'identifier': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                                                    'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg',
                                                    'version': '5.6.0.788'},
                                           'report_fields': ['identifier',
                                                             'version',
                                                             'pkg_path'],
                                           'summary_text': 'The following '
                                                           'packages were '
                                                           'built:'},
            'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg'}}
PathDeleter
{'Input': {'path_list': ['/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot',
                         '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts',
                         '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml']}}
PathDeleter: Deleted /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot
PathDeleter: Deleted /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts
PathDeleter: Deleted /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml
{'Output': {}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleName': 'Creative '
                                                                'Cloud',
                                                'CFBundleShortVersionString': '5.6.0.788',
                                                'path': '/Applications/Utilities/Adobe '
                                                        'Creative '
                                                        'Cloud/ACC/Creative '
                                                        'Cloud.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'blocking_applications': [],
                       'catalogs': ['import'],
                       'category': 'Adobe',
                       'description': 'The Creative Cloud app runs in the menu '
                                      'bar and allows you to install, update '
                                      'or remove Creative Cloud applications '
                                      'for which you are licensed.',
                       'developer': 'Adobe',
                       'display_name': 'Creative Cloud Installer',
                       'icon_name': 'CreativeCloudInstaller.png',
                       'name': 'CreativeCloudInstaller',
                       'postinstall_script': '#!/bin/bash\n'
                                             '\n'
                                             'config_path="/Library/Application '
                                             'Support/Adobe/OOBE/Configs"\n'
                                             'config="/Library/Application '
                                             'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                             'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                             '\n'
                                             '[[ -f "$config" ]] && echo '
                                             '"$serviceconfig" > "$config" || '
                                             'mkdir -p "$config_path"; echo '
                                             '"$serviceconfig" > "$config"\n'
                                             '\n'
                                             'exit 0\n'
                                             '\t\t\t',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True,
                       'uninstall_method': 'uninstall_script',
                       'uninstall_script': '#!/bin/bash\n'
                                           '"/Applications/Utilities/Adobe '
                                           'Creative Cloud/Utils/Creative '
                                           'Cloud '
                                           'Uninstaller.app/Contents/MacOS/Creative '
                                           'Cloud Uninstaller" -u\n'}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleName': 'Creative Cloud', 'CFBundleShortVersionString': '5.6.0.788', 'path': '/Applications/Utilities/Adobe Creative Cloud/ACC/Creative Cloud.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'blocking_applications': [],
                        'catalogs': ['import'],
                        'category': 'Adobe',
                        'description': 'The Creative Cloud app runs in the '
                                       'menu bar and allows you to install, '
                                       'update or remove Creative Cloud '
                                       'applications for which you are '
                                       'licensed.',
                        'developer': 'Adobe',
                        'display_name': 'Creative Cloud Installer',
                        'icon_name': 'CreativeCloudInstaller.png',
                        'installs': [{'CFBundleName': 'Creative Cloud',
                                      'CFBundleShortVersionString': '5.6.0.788',
                                      'path': '/Applications/Utilities/Adobe '
                                              'Creative Cloud/ACC/Creative '
                                              'Cloud.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'CreativeCloudInstaller',
                        'postinstall_script': '#!/bin/bash\n'
                                              '\n'
                                              'config_path="/Library/Application '
                                              'Support/Adobe/OOBE/Configs"\n'
                                              'config="/Library/Application '
                                              'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                              'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                              '\n'
                                              '[[ -f "$config" ]] && echo '
                                              '"$serviceconfig" > "$config" || '
                                              'mkdir -p "$config_path"; echo '
                                              '"$serviceconfig" > "$config"\n'
                                              '\n'
                                              'exit 0\n'
                                              '\t\t\t',
                        'supported_architectures': ['arm64'],
                        'unattended_install': True,
                        'uninstall_method': 'uninstall_script',
                        'uninstall_script': '#!/bin/bash\n'
                                            '"/Applications/Utilities/Adobe '
                                            'Creative Cloud/Utils/Creative '
                                            'Cloud '
                                            'Uninstaller.app/Contents/MacOS/Creative '
                                            'Cloud Uninstaller" -u\n'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo',
           'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg',
           'pkginfo': {'blocking_applications': [],
                       'catalogs': ['import'],
                       'category': 'Adobe',
                       'description': 'The Creative Cloud app runs in the menu '
                                      'bar and allows you to install, update '
                                      'or remove Creative Cloud applications '
                                      'for which you are licensed.',
                       'developer': 'Adobe',
                       'display_name': 'Creative Cloud Installer',
                       'icon_name': 'CreativeCloudInstaller.png',
                       'installs': [{'CFBundleName': 'Creative Cloud',
                                     'CFBundleShortVersionString': '5.6.0.788',
                                     'path': '/Applications/Utilities/Adobe '
                                             'Creative Cloud/ACC/Creative '
                                             'Cloud.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'CreativeCloudInstaller',
                       'postinstall_script': '#!/bin/bash\n'
                                             '\n'
                                             'config_path="/Library/Application '
                                             'Support/Adobe/OOBE/Configs"\n'
                                             'config="/Library/Application '
                                             'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                             'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                             '\n'
                                             '[[ -f "$config" ]] && echo '
                                             '"$serviceconfig" > "$config" || '
                                             'mkdir -p "$config_path"; echo '
                                             '"$serviceconfig" > "$config"\n'
                                             '\n'
                                             'exit 0\n'
                                             '\t\t\t',
                       'supported_architectures': ['arm64'],
                       'unattended_install': True,
                       'uninstall_method': 'uninstall_script',
                       'uninstall_script': '#!/bin/bash\n'
                                           '"/Applications/Utilities/Adobe '
                                           'Creative Cloud/Utils/Creative '
                                           'Cloud '
                                           'Uninstaller.app/Contents/MacOS/Creative '
                                           'Cloud Uninstaller" -u\n'},
           'repo_subdirectory': 'apps/adobe'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo
MunkiImporter: Item AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg already exists in the munki repo as pkgs/apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg.
{'Output': {'pkg_repo_path': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo/pkgs/apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg'}}
{'ARCHITECTURE': 'macarm64',
 'AUTOPKG_VERSION': '2.3.2',
 'CACHE_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/Cache',
 'CHECK_FILESIZE_ONLY': False,
 'MUNKILIB_DIR': '/usr/local/munki',
 'MUNKI_REPO': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo',
 'MUNKI_REPO_PLUGIN': 'FileRepo',
 'MUNKI_REPO_SUBDIR': 'apps/adobe',
 'NAME': 'Creative Cloud Installer',
 'NAMEWITHOUTSPACES': 'CreativeCloudInstaller',
 'PARENT_RECIPES': ['/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe/AdobeCreativeCloudInstallerAppleSilicon.munki.recipe',
                    '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.pkg.recipe',
                    '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud/AdobeCreativeCloudInstallerAppleSilicon.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon',
 'RECIPE_DIR': '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides',
 'RECIPE_OVERRIDE_DIRS': ['overrides'],
 'RECIPE_PATH': '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides/AdobeCreativeCloudInstallerAppleSilicon.munki.recipe',
 'RECIPE_REPOS': {'/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.adobe-ccp-recipes': {'URL': 'https://github.com/autopkg/adobe-ccp-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes': {'URL': 'https://github.com/autopkg/apizz-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes': {'URL': 'https://github.com/autopkg/arubdesu-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.cgerke-recipes': {'URL': 'https://github.com/autopkg/cgerke-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.chilcote-recipes': {'URL': 'https://github.com/autopkg/chilcote-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.crystalllized-recipes': {'URL': 'https://github.com/autopkg/crystalllized-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dankeller-recipes': {'URL': 'https://github.com/autopkg/dankeller-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes': {'URL': 'https://github.com/autopkg/dataJAR-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.erikng-recipes': {'URL': 'https://github.com/autopkg/erikng-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.flywire-recipes': {'URL': 'https://github.com/autopkg/flywire-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes': {'URL': 'https://github.com/autopkg/foigus-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes': {'URL': 'https://github.com/autopkg/grahamgilbert-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes': {'URL': 'https://github.com/autopkg/hjuutilainen-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes': {'URL': 'https://github.com/autopkg/homebysix-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes': {'URL': 'https://github.com/autopkg/jleggat-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes': {'URL': 'https://github.com/autopkg/joshua-d-miller-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes': {'URL': 'https://github.com/autopkg/justinrummel-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes': {'URL': 'https://github.com/autopkg/keeleysam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes': {'URL': 'https://github.com/autopkg/killahquam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes': {'URL': 'https://github.com/autopkg/moofit-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes': {'URL': 'https://github.com/autopkg/mosen-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.neilmartin83-recipes': {'URL': 'https://github.com/autopkg/neilmartin83-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes': {'URL': 'https://github.com/autopkg/nmcspadden-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.novaksam-recipes': {'URL': 'https://github.com/autopkg/novaksam-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes': {'URL': 'https://github.com/autopkg/nstrauss-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes': {'URL': 'https://github.com/autopkg/orchard-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes': {'URL': 'https://github.com/autopkg/rtrouton-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes': {'URL': 'https://github.com/autopkg/scriptingosx-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes': {'URL': 'https://github.com/autopkg/sheagcraig-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.valdore86-recipes': {'URL': 'https://github.com/autopkg/valdore86-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes': {'URL': 'https://github.com/autopkg/ygini-recipes'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg': {'URL': 'https://github.com/facebook/Recipes-for-AutoPkg.git'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.lctrkid.Recipes-for-AutoPkg': {'URL': 'https://github.com/lctrkid/Recipes-for-AutoPkg'},
                  '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/tech.flywire.gitlab.flywire.it.flywire-autopkg-recipes': {'URL': 'https://gitlab.flywire.tech/flywire/it/flywire-autopkg-recipes.git'}},
 'RECIPE_REPO_DIR': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos',
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.sheagcraig-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.cgerke-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.arubdesu-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dankeller-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.novaksam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.apizz-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.valdore86-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.moofit-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/tech.flywire.gitlab.flywire.it.flywire-autopkg-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.chilcote-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.facebook.Recipes-for-AutoPkg',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.justinrummel-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.adobe-ccp-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.neilmartin83-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.lctrkid.Recipes-for-AutoPkg',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.crystalllized-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.flywire-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.erikng-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.nstrauss-recipes',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/joaquincabrerizo/gitlab/autopkg-build2/overrides',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.orchard-recipes/Adobe',
                        '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/com.github.autopkg.rtrouton-recipes/AdobeCreativeCloud'],
 'SEARCH_PATTERN': '(?P<url>http.*?://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/macarm64/ACCC.*?.dmg)',
 'SEARCH_URL': 'https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html',
 'SOFTWARETITLE': 'Creative Cloud Installer',
 'VENDOR': 'Adobe',
 'additional_pkginfo': {'installs': [{'CFBundleName': 'Creative Cloud',
                                      'CFBundleShortVersionString': '5.6.0.788',
                                      'path': '/Applications/Utilities/Adobe '
                                              'Creative Cloud/ACC/Creative '
                                              'Cloud.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}]},
 'destination_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/AdobeCreativeCloudInstaller-5.6.0.788.dmg',
 'download_changed': True,
 'elements': [{'text': 'version', 'xpath': 'version'}],
 'etag': '"0727296d57981f95cb315241c07e1866:1633940519.730346"',
 'file_content': '#!/bin/bash\n'
                 '\t\t\t\t\n'
                 '# Determine working directory\n'
                 'installDir=$(dirname $0)\n'
                 'dmg=("${installDir}"/*\\.dmg)\n'
                 '\n'
                 '# Mount the disk image to /Volumes\n'
                 'mountResult=$(/usr/bin/hdiutil attach "${dmg}" -nobrowse '
                 '-noverify -noautoopen)\n'
                 'mountPoint=$(/bin/echo "${mountResult}" | /usr/bin/grep '
                 "Volumes | /usr/bin/awk '{print substr($0, index($0,$3))}')\n"
                 '\n'
                 '# Install the software\n'
                 '"${mountPoint}/Install.app/Contents/MacOS/Install" '
                 '--mode=silent\n'
                 '\n'
                 '# Get the exit code so we can fail properly\n'
                 'exitcode=$?\n'
                 '\n'
                 '# Unmount the disk image from /Volumes\n'
                 '/usr/bin/hdiutil detach "${mountPoint}"\n'
                 '\n'
                 '# Exit according to whether the install succeeded or not\n'
                 'exit "${exitcode}"\n',
 'file_mode': '0755',
 'file_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts/postinstall',
 'force_munki_repo_lib': False,
 'input_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg/Install.app',
 'last_modified': 'Thu, 07 Oct 2021 09:26:27 GMT',
 'match': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg',
 'munki_info': {},
 'munki_repo_changed': False,
 'new_package_request': True,
 'overwrite': True,
 'path_list': ['/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot',
               '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts',
               '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml'],
 'pathname': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg',
 'pkg_creator_summary_result': {'data': {'identifier': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                                         'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg',
                                         'version': '5.6.0.788'},
                                'report_fields': ['identifier',
                                                  'version',
                                                  'pkg_path'],
                                'summary_text': 'The following packages were '
                                                'built:'},
 'pkg_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg',
 'pkg_repo_path': '/Users/joaquincabrerizo/Library/AutoPkg/RecipeRepos/munki-repo/pkgs/apps/adobe/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg',
 'pkg_request': {'chown': [],
                 'id': 'com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg',
                 'infofile': '',
                 'options': '',
                 'pkgdir': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon',
                 'pkgname': 'AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788',
                 'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/pkgroot',
                 'pkgtype': 'flat',
                 'resources': '',
                 'scripts': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts',
                 'version': '5.6.0.788'},
 'pkgdirs': {},
 'pkginfo': {'blocking_applications': [],
             'catalogs': ['import'],
             'category': 'Adobe',
             'description': 'The Creative Cloud app runs in the menu bar and '
                            'allows you to install, update or remove Creative '
                            'Cloud applications for which you are licensed.',
             'developer': 'Adobe',
             'display_name': 'Creative Cloud Installer',
             'icon_name': 'CreativeCloudInstaller.png',
             'installs': [{'CFBundleName': 'Creative Cloud',
                           'CFBundleShortVersionString': '5.6.0.788',
                           'path': '/Applications/Utilities/Adobe Creative '
                                   'Cloud/ACC/Creative Cloud.app',
                           'type': 'application',
                           'version_comparison_key': 'CFBundleShortVersionString'}],
             'name': 'CreativeCloudInstaller',
             'postinstall_script': '#!/bin/bash\n'
                                   '\n'
                                   'config_path="/Library/Application '
                                   'Support/Adobe/OOBE/Configs"\n'
                                   'config="/Library/Application '
                                   'Support/Adobe/OOBE/Configs/ServiceConfig.xml"\n'
                                   'serviceconfig="<config><panel><name>AppsPanel</name><visible>true</visible></panel><panel><name>FilesPanel</name><masked>false</masked></panel><panel><name>MarketPanel</name><masked>false</masked></panel><feature><name>SelfServeInstalls</name><enabled>true</enabled></feature><feature><name>BrowserBasedAuthentication</name><enabled>false</enabled></feature></config>"\n'
                                   '\n'
                                   '[[ -f "$config" ]] && echo '
                                   '"$serviceconfig" > "$config" || mkdir -p '
                                   '"$config_path"; echo "$serviceconfig" > '
                                   '"$config"\n'
                                   '\n'
                                   'exit 0\n'
                                   '\t\t\t',
             'supported_architectures': ['arm64'],
             'unattended_install': True,
             'uninstall_method': 'uninstall_script',
             'uninstall_script': '#!/bin/bash\n'
                                 '"/Applications/Utilities/Adobe Creative '
                                 'Cloud/Utils/Creative Cloud '
                                 'Uninstaller.app/Contents/MacOS/Creative '
                                 'Cloud Uninstaller" -u\n'},
 'pkginfo_repo_path': '',
 'pkgroot': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/Scripts',
 'prefetch_filename': False,
 're_pattern': '(?P<url>http.*?://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/.*?/macarm64/ACCC.*?.dmg)',
 'repo_subdirectory': 'apps/adobe',
 'requirement': 'identifier "com.adobe.cc.Install" and anchor apple generic '
                'and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists '
                '*/ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* '
                'exists */ and certificate leaf[subject.OU] = JQ525L2MZD',
 'result_output_var_name': 'match',
 'source_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg',
 'url': 'https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/5_6_0/macarm64/ACCCx5_6_0_788.dmg',
 'url_downloader_summary_result': {'data': {'download_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg'},
                                   'summary_text': 'The following new items '
                                                   'were downloaded:'},
 'verbose': 3,
 'version': '5.6.0.788',
 'xml_path': '/Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/ApplicationInfo.xml',
 'xml_reader_output_variables': {}}
Receipt written to /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/receipts/AdobeCreativeCloudInstallerAppleSilicon.munki-receipt-20211221-182527.plist

The following new items were downloaded:
    Download Path                                                                                                                   
    -------------                                                                                                                   
    /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/downloads/ACCCx5_6_0_788.dmg  

The following packages were built:
    Identifier                                             Version    Pkg Path                                                                                                                                                  
    ----------                                             -------    --------                                                                                                                                                  
    com.adobe.AdobeCreativeCloudInstallerAppleSilicon.pkg  5.6.0.788  /Users/joaquincabrerizo/Library/AutoPkg/Cache/local.munki.AdobeCreativeCloudInstallerAppleSilicon/AdobeCreativeCloudInstaller-AppleSilicon-5.6.0.788.pkg
```
</p>
</details>