### PR TITLE
Fix GitHubInfoReleasesProvider on Windows in case of non-ascii characters

### DIFF
--- a/.github/workflows/TestGitHubReleasesInfoProvider.yaml
+++ b/.github/workflows/TestGitHubReleasesInfoProvider.yaml
@@ -23,6 +23,13 @@ jobs:
         shell: cmd
         run: powershell -command "Set-ExecutionPolicy -Force -ExecutionPolicy RemoteSigned -Scope CurrentUser"
 
+      - name: Set github token autopkg
+        # required for githubreleaseinfoprovider in github actions
+        # without this, API limits will be hit
+        run: |
+          cd ~
+          echo ${{ secrets.GITHUB_TOKEN }} > ".autopkg_gh_token"
+
       - name: checkout this repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/TestGitHubReleasesInfoProvider.yaml
+++ b/.github/workflows/TestGitHubReleasesInfoProvider.yaml
@@ -47,13 +47,12 @@ jobs:
         run: |
           if not exist "%USERPROFILE%/AppData/Local/Autopkg" mkdir "%USERPROFILE%/AppData/Local/Autopkg"
           if not exist "%USERPROFILE%/AppData/Local/Autopkg/config.json" echo {} > "%USERPROFILE%/AppData/Local/Autopkg/config.json"
+
       - name: create default autopkg config file Linux
         if: runner.os == 'Linux'
         run: |
           cd ~ && mkdir -p .config/Autopkg
           cd ~ && echo {} > .config/Autopkg/config.json
-      - name: run recipe autopkg
-        run: python Code/autopkg run -vv Test-Recipes/AutopkgCore.test.recipe.yaml
 
       - name: create file
         shell: bash

--- a/.github/workflows/TestGitHubReleasesInfoProvider.yaml
+++ b/.github/workflows/TestGitHubReleasesInfoProvider.yaml
@@ -42,10 +42,10 @@ jobs:
           python-version: 3.8
           cache: "pip"
           cache-dependency-path: |
-            requirements.txt
+            gh_actions_requirements.txt
 
       - name: Install requirements
-        run: pip install --requirement requirements.txt
+        run: pip install --requirement gh_actions_requirements.txt
 
       - name: create empty config windows
         # https://stackoverflow.com/questions/57946173/github-actions-run-step-on-specific-os

--- a/.github/workflows/TestGitHubReleasesInfoProvider.yaml
+++ b/.github/workflows/TestGitHubReleasesInfoProvider.yaml
@@ -1,0 +1,79 @@
+---
+name: Test GitHubReleasesInfoProvider Processors
+
+on:
+  pull_request:
+    paths:
+      - "Test-Recipes/AutopkgCore.test.recipe.yaml"
+      - ".github/workflows/TestGitHubReleasesInfoProvider.yaml"
+      - "Code/autopkglib/GitHubReleasesInfoProvider.py"
+      - "Code/autopkglib/github/**"
+
+jobs:
+  TestGitHubReleasesInfoProvider:
+    strategy:
+      matrix:
+        # https://ncorti.com/blog/howto-github-actions-build-matrix
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # only needed on self hosted windows runners:
+      - name: set powershell execution policy CurrentUser
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: powershell -command "Set-ExecutionPolicy -Force -ExecutionPolicy RemoteSigned -Scope CurrentUser"
+
+      - name: checkout this repo
+        uses: actions/checkout@v3
+
+      - name: checkout autopkg
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+
+      - name: Install requirements
+        run: pip install --requirement requirements.txt
+
+      - name: create empty config windows
+        # https://stackoverflow.com/questions/57946173/github-actions-run-step-on-specific-os
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          if not exist "%USERPROFILE%/AppData/Local/Autopkg" mkdir "%USERPROFILE%/AppData/Local/Autopkg"
+          if not exist "%USERPROFILE%/AppData/Local/Autopkg/config.json" echo {} > "%USERPROFILE%/AppData/Local/Autopkg/config.json"
+      - name: create default autopkg config file Linux
+        if: runner.os == 'Linux'
+        run: |
+          cd ~ && mkdir -p .config/Autopkg
+          cd ~ && echo {} > .config/Autopkg/config.json
+      - name: run recipe autopkg
+        run: python Code/autopkg run -vv Test-Recipes/AutopkgCore.test.recipe.yaml
+
+      - name: create file
+        shell: bash
+        run: |
+          cat <<'EOFEOF' > GitHubReleasesInfoProvider.test.recipe.yaml
+          ---
+          Description: Test GitHubReleasesInfoProvider Processor
+          Identifier: com.github.autopkg.test.GitHubReleasesInfoProvider
+          Input:
+            NAME: GitHubReleasesInfoProviderTest
+          MinimumVersion: "2.3"
+          Process:
+              - Processor: GitHubReleasesInfoProvider
+                Arguments:
+                  github_repo: audacity/audacity
+                  asset_regex: .*64bit\.exe$
+                  include_prereleases: False
+          EOFEOF
+      - name: get file contents
+        shell: bash
+        run: cat GitHubReleasesInfoProvider.test.recipe.yaml
+      - name: run integration recipe created in action
+        run: python Code/autopkg run -vvvv GitHubReleasesInfoProvider.test.recipe.yaml

--- a/.github/workflows/TestGitHubReleasesInfoProvider.yaml
+++ b/.github/workflows/TestGitHubReleasesInfoProvider.yaml
@@ -4,10 +4,10 @@ name: Test GitHubReleasesInfoProvider Processors
 on:
   pull_request:
     paths:
-      - "Test-Recipes/AutopkgCore.test.recipe.yaml"
       - ".github/workflows/TestGitHubReleasesInfoProvider.yaml"
       - "Code/autopkglib/GitHubReleasesInfoProvider.py"
       - "Code/autopkglib/github/**"
+      - "requirements.txt"
 
 jobs:
   TestGitHubReleasesInfoProvider:

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -274,12 +274,11 @@ To save the token, paste it to the following prompt."""
         try:
             with open(temp_content) as f:
                 resp_data = json.load(f)
+        except UnicodeDecodeError:
+            with open(temp_content, "rb") as f:
+                resp_data = json.load(f)
         except json.JSONDecodeError:
-            try:
-                with open(temp_content, "rb") as f:
-                    resp_data = json.load(f)
-            except json.JSONDecodeError:
-                resp_data = None
+            resp_data = None
 
         return (resp_data, self.http_result_code)
 

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -271,6 +271,7 @@ To save the token, paste it to the following prompt."""
         if header["http_result_code"] != "000":
             self.http_result_code = int(header["http_result_code"])
 
+        resp_data = None
         try:
             with open(temp_content) as f:
                 resp_data = json.load(f)
@@ -278,7 +279,7 @@ To save the token, paste it to the following prompt."""
             with open(temp_content, "rb") as f:
                 resp_data = json.load(f)
         except json.JSONDecodeError:
-            resp_data = None
+            pass
 
         return (resp_data, self.http_result_code)
 

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -275,7 +275,11 @@ To save the token, paste it to the following prompt."""
             with open(temp_content) as f:
                 resp_data = json.load(f)
         except json.JSONDecodeError:
-            resp_data = None
+            try:
+                with open(temp_content, "rb") as f:
+                    resp_data = json.load(f)
+            except json.JSONDecodeError:
+                resp_data = None
 
         return (resp_data, self.http_result_code)
 

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -278,8 +278,8 @@ To save the token, paste it to the following prompt."""
         except UnicodeDecodeError:
             with open(temp_content, "rb") as f:
                 resp_data = json.load(f)
-        except json.JSONDecodeError:
-            pass
+        except json.JSONDecodeError as e:
+            self.output(f"JSONDecodeError: {e}")
 
         return (resp_data, self.http_result_code)
 


### PR DESCRIPTION
This should resolve https://github.com/autopkg/autopkg/pull/764 (see discussion there)

This will allow GitHubInfoReleasesProvider to work on Windows for releases which contain unusual characters. It will require Python3.6+ on Windows, but will not induce that requirement for non-Windows. Reference: https://docs.python.org/3/library/json.html#json.load

I think this is a better approach since the encoding could be any of "UTF-8, UTF-16 or UTF-32" and this approach should work, rather than specifically forcing "UTF-8" to be the one used for decoding. From the footnote: "Changed in version 3.6: fp can now be a binary file. The input encoding should be UTF-8, UTF-16 or UTF-32."

This approach also has the advantage of not affecting the current typical behavior at all.