### PR TITLE
Update xattr.py to not throw hard errors on some Linux systems.

### DIFF
--- a/Code/autopkglib/xattr.py
+++ b/Code/autopkglib/xattr.py
@@ -86,8 +86,7 @@ def getxattr(path: str, attr: str, symlink: bool = False) -> Optional[str]:
     try:
         return _xattr.getxattr(path, attr, symlink)
     except OSError as e:
-        print("WARNING: xattr.getxattr threw OSError.")
-        print(e)
+        print(f"WARNING: xattr.getxattr threw OSError. {e}")
         return None
 
 

--- a/Code/autopkglib/xattr.py
+++ b/Code/autopkglib/xattr.py
@@ -95,8 +95,7 @@ def listxattr(path: str, symlink: bool = False) -> List[str]:
     try:
         return _xattr.listxattr(path, symlink)
     except OSError as e:
-        print("WARNING: xattr.listxattr threw OSError.")
-        print(e)
+        print(f"WARNING: xattr.listxattr threw OSError. {e}")
         return []
 
 
@@ -104,8 +103,7 @@ def removexattr(path: str, attr: str, symlink: bool = False) -> None:
     try:
         return _xattr.removexattr(path, attr, symlink)
     except OSError as e:
-        print("WARNING: xattr.removexattr threw OSError.")
-        print(e)
+        print(f"WARNING: xattr.removexattr threw OSError. {e}")
         return None
 
 
@@ -115,6 +113,5 @@ def setxattr(
     try:
         return _xattr.setxattr(path, attr, value, options, symlink)
     except OSError as e:
-        print("WARNING: xattr.setxattr threw OSError.")
-        print(e)
+        print(f"WARNING: xattr.setxattr threw OSError. {e}")
         return None

--- a/Code/autopkglib/xattr.py
+++ b/Code/autopkglib/xattr.py
@@ -83,18 +83,38 @@ assert (
 
 
 def getxattr(path: str, attr: str, symlink: bool = False) -> Optional[str]:
-    return _xattr.getxattr(path, attr, symlink)
+    try:
+        return _xattr.getxattr(path, attr, symlink)
+    except OSError as e:
+        print("WARNING: xattr.getxattr threw OSError")
+        print(e)
+        return None
 
 
 def listxattr(path: str, symlink: bool = False) -> List[str]:
-    return _xattr.listxattr(path, symlink)
+    try:
+        return _xattr.listxattr(path, symlink)
+    except OSError as e:
+        print("WARNING: xattr.listxattr threw OSError")
+        print(e)
+        return []
 
 
 def removexattr(path: str, attr: str, symlink: bool = False) -> None:
-    return _xattr.removexattr(path, attr, symlink)
+    try:
+        return _xattr.removexattr(path, attr, symlink)
+    except OSError as e:
+        print("WARNING: xattr.removexattr threw OSError")
+        print(e)
+        return None
 
 
 def setxattr(
     path: str, attr: str, value: str, options: int = 0, symlink: bool = False
 ) -> None:
-    return _xattr.setxattr(path, attr, value, options, symlink)
+    try:
+        return _xattr.setxattr(path, attr, value, options, symlink)
+    except OSError as e:
+        print("WARNING: xattr.setxattr threw OSError")
+        print(e)
+        return None

--- a/Code/autopkglib/xattr.py
+++ b/Code/autopkglib/xattr.py
@@ -86,7 +86,7 @@ def getxattr(path: str, attr: str, symlink: bool = False) -> Optional[str]:
     try:
         return _xattr.getxattr(path, attr, symlink)
     except OSError as e:
-        print("WARNING: xattr.getxattr threw OSError")
+        print("WARNING: xattr.getxattr threw OSError.")
         print(e)
         return None
 
@@ -95,7 +95,7 @@ def listxattr(path: str, symlink: bool = False) -> List[str]:
     try:
         return _xattr.listxattr(path, symlink)
     except OSError as e:
-        print("WARNING: xattr.listxattr threw OSError")
+        print("WARNING: xattr.listxattr threw OSError.")
         print(e)
         return []
 
@@ -104,7 +104,7 @@ def removexattr(path: str, attr: str, symlink: bool = False) -> None:
     try:
         return _xattr.removexattr(path, attr, symlink)
     except OSError as e:
-        print("WARNING: xattr.removexattr threw OSError")
+        print("WARNING: xattr.removexattr threw OSError.")
         print(e)
         return None
 
@@ -115,6 +115,6 @@ def setxattr(
     try:
         return _xattr.setxattr(path, attr, value, options, symlink)
     except OSError as e:
-        print("WARNING: xattr.setxattr threw OSError")
+        print("WARNING: xattr.setxattr threw OSError.")
         print(e)
         return None


### PR DESCRIPTION
xattr does not work in some Linux file systems, or in Linux running under WSL, or in some docker containers in general. This will make the failures of xattr no longer hard errors in these cases.

Use of xattr for storing etag data is not ideal in the first place and is already solved in URLDownloaderPython by using a json metadata file instead, but this will help with compatibility in general for older methods. This will have the drawback of not detecting that the already downloaded file is the same correctly due to lack of metadata for any recipe currently relying on xattr. That said, redownloading the file seems better than throwing hard errors.

I believe the behavior should be similar to how these older methods work on Windows today since on Windows xattr is no-op within autopkg.