### PR TITLE
Always return list when finding matching pkgs

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -170,7 +170,7 @@ class MunkiImporter(Processor):
 
     def _find_matching_pkginfo(self, repo_library, pkginfo):
         """Looks through all catalog for items matching the one
-        described by pkginfo. Returns a matching item if found."""
+        described by pkginfo. Returns a list of matching items if found."""
         if not pkginfo.get("installer_item_hash"):
             return None
 
@@ -265,7 +265,7 @@ class MunkiImporter(Processor):
                             # TODO: maybe match pkg name, too?
                             # if matching_pkg['name'] == pkginfo['name']:
 
-                            return matching_pkg
+                            return [matching_pkg]
 
         # Try to match against a simple list of files and paths
         # where our pkginfo version also matches
@@ -287,7 +287,7 @@ class MunkiImporter(Processor):
                             # make sure we do this only for items that also
                             # match our pkginfo version
                             if matching_pkg["version"] == pkginfo["version"]:
-                                return matching_pkg
+                                return [matching_pkg]
 
         # if we get here, we found no matches
         return None


### PR DESCRIPTION
Running `VirtualBoxExtPack.munki` has been failing since the latest autopkg release:


```
autopkg  run VirtualBoxExtPack.munki.recipe 
Processing VirtualBoxExtPack.munki.recipe...
'str' object has no attribute 'get'
Failed.

The following recipes failed:
    VirtualBoxExtPack.munki.recipe
        Error in local.munki.VirtualBoxExtPack: Processor: MunkiImporter: Error: 'str' object has no attribute 'get'

Nothing downloaded, packaged or imported.
```

This is likely because MunkiImport [tries to find matching packages](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L171) and expects it to either return `None` or [a list](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L380).

Some ([1](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L268), [2](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiImporter.py#L290)) edge cases are still returning a single package though, breaking the iterator.