### PR TITLE
new core processor: FolderCreator

### DIFF
--- a/Code/autopkglib/FolderCreator.py
+++ b/Code/autopkglib/FolderCreator.py
@@ -29,13 +29,13 @@ class FolderCreator(PkgRootCreator):
     input_variables = {
         "root": {
             "required": True,
-            "description": "Path to where the package root will be created.",
+            "description": "Path to where the root folder will be created.",
         },
         "subdirs": {
             "required": False,
             "description": (
                 "A dictionary of directories to be created "
-                "inside the pkgroot, with their modes in octal form."
+                "inside the root, with their modes in octal form."
             ),
         },
     }

--- a/Code/autopkglib/FolderCreator.py
+++ b/Code/autopkglib/FolderCreator.py
@@ -1,0 +1,55 @@
+#!/usr/local/autopkg/python
+#
+# Copyright 2010 Per Olofsson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""See docstring for FolderCreator class"""
+
+import os.path
+import shutil
+
+from autopkglib.PkgRootCreator import PkgRootCreator
+
+__all__ = ["FolderCreator"]
+
+class FolderCreator(PkgRootCreator):
+    """Create a directory and relative subdirectories and set their permissions."""
+
+    description = __doc__
+    input_variables = {
+        "root": {
+            "required": True,
+            "description": "Path to where the package root will be created.",
+        },
+        "subdirs": {
+            "required": False,
+            "description": (
+                "A dictionary of directories to be created "
+                "inside the pkgroot, with their modes in octal form."
+            ),
+        },
+    }
+    output_variables = {}
+
+    def main(self):
+        root = self.env['root']
+        if 'subdirs' not in self.env:
+            subdirs = {}
+        else:
+            subdirs = self.env['subdirs']
+        # calls create on PkgRootCreator class
+        self.Create(root, subdirs)
+
+if __name__ == "__main__":
+    PROCESSOR = FolderCreator()
+    PROCESSOR.execute_shell()

--- a/Code/autopkglib/PkgRootCreator.py
+++ b/Code/autopkglib/PkgRootCreator.py
@@ -47,28 +47,28 @@ class PkgRootCreator(Processor):
     }
     output_variables = {}
 
-    def main(self):
+    def Create(self, pkgroot, pkgdirs):
         # Delete pkgroot if it exists.
         try:
-            if os.path.islink(self.env["pkgroot"]) or os.path.isfile(
-                self.env["pkgroot"]
+            if os.path.islink(pkgroot) or os.path.isfile(
+                pkgroot
             ):
-                os.unlink(self.env["pkgroot"])
-            elif os.path.isdir(self.env["pkgroot"]):
-                shutil.rmtree(self.env["pkgroot"])
+                os.unlink(pkgroot)
+            elif os.path.isdir(pkgroot):
+                shutil.rmtree(pkgroot)
         except OSError as err:
-            raise ProcessorError(f"Can't remove {self.env['pkgroot']}: {err.strerror}")
+            raise ProcessorError(f"Can't remove {pkgroot}: {err.strerror}")
 
         # Create pkgroot. autopkghelper sets it to root:admin 01775.
         try:
-            os.makedirs(self.env["pkgroot"])
-            self.output(f"Created {self.env['pkgroot']}")
+            os.makedirs(pkgroot)
+            self.output(f"Created {pkgroot}")
         except OSError as err:
-            raise ProcessorError(f"Can't create {self.env['pkgroot']}: {err.strerror}")
+            raise ProcessorError(f"Can't create {pkgroot}: {err.strerror}")
 
         # Create directories.
-        absroot = os.path.abspath(self.env["pkgroot"])
-        for directory, mode in sorted(self.env["pkgdirs"].items()):
+        absroot = os.path.abspath(pkgroot)
+        for directory, mode in sorted(pkgdirs.items()):
             self.output(f"Creating {directory}", verbose_level=2)
             # Make sure we don't get an absolute path.
             if directory.startswith("/"):
@@ -90,6 +90,8 @@ class PkgRootCreator(Processor):
                     f"Can't create {dirpath} with mode {mode}: {err.strerror}"
                 )
 
+    def main(self):
+        self.Create(self.env['pkgroot'], self.env['pkgdirs'])
 
 if __name__ == "__main__":
     PROCESSOR = PkgRootCreator()


### PR DESCRIPTION
I was personally surprised to find that there is no `FolderCreator` processor, though there is `FileCreator`. Many recipes seem to use `PkgRootCreator` in face of `FolderCreator` not existing, like in this [Zoom recipe](https://github.com/autopkg/MLBZ521-recipes/blob/b8d38cb0332a759469e0a4b45eb388b729c4a724/Zoom/Zoom-ForIT.pkg.recipe#L113). 

Hence this PR :) It's secretly a stub for `PkgRootCreator` but I think it will be more intuitive for new recipe authors who need to create some folders. 