### PR TITLE
MunkiInstallsItemsCreator.py - Add option to derive minimum os version

### DIFF
--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -17,9 +17,8 @@
 
 import plistlib
 import subprocess
-from distutils.version import LooseVersion
 
-from autopkglib import Processor, ProcessorError, log
+from autopkglib import APLooseVersion, Processor, ProcessorError, log
 
 try:
     from Foundation import NSDictionary
@@ -116,14 +115,14 @@ class MunkiInstallsItemsCreator(Processor):
                             # Compare any subsequent values of item['minosversion']
                             # against self.env["minimum_os_version"] setting
                             # self.env["minimum_os_version"] to the highest minimum
-                            if (LooseVersion(item['minosversion']) >=
-                                LooseVersion(self.env["minimum_os_version"])):
+                            if (APLooseVersion(item['minosversion']) >=
+                                APLooseVersion(self.env["minimum_os_version"])):
                                 self.output("Setting minimum os version to: "
                                             f"{item['minosversion']}, as greater than prior "
                                             f"value of: {self.env['minimum_os_version']}")
                                 self.env["minimum_os_version"] = item['minosversion']
-                            if (LooseVersion(item['minosversion']) <=
-                                LooseVersion(self.env["minimum_os_version"])):
+                            if (APLooseVersion(item['minosversion']) <=
+                                APLooseVersion(self.env["minimum_os_version"])):
                                 self.output(f"Minimum os version: {item['minosversion']}, "
                                             "is lower than prior value of: "
                                             f"{self.env['minimum_os_version']}... skipping...")


### PR DESCRIPTION
## Overview

This PR adds an option to MunkiInstallsItemsCreator to derive the minimum os version from the installs array.

Currently, MunkiInstallsItemsCreator can generate installs arrays like the below:

```
MunkiInstallsItemsCreator: Created installs item for /Applications/Listento.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                                 'CFBundleName': 'Listento',
                                                 'CFBundleShortVersionString': '1.10.20210419',
                                                 'CFBundleVersion': '1.10.20210419',
                                                 'minosversion': '10.11',
                                                 'path': '/Applications/Listento.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
```

In this example, there is a value for `minosversion`, but this doesn't make it into the title properly as needs to be passed to the `minimum_os_version` key within `additional_pkginfo` and not the `installs` array.

For example, the below (when merged via `MunkiPkginfoMerger`) would set the titles `minimum_os_version` to 10.11:

```
MunkiInstallsItemsCreator: Created installs item for /Applications/Listento.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                                 'CFBundleName': 'Listento',
                                                 'CFBundleShortVersionString': '1.10.20210419',
                                                 'CFBundleVersion': '1.10.20210419',
                                                 'minosversion': '10.11',
                                                 'path': '/Applications/Listento.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}],
                                   'minimum_os_version': '10.11'}}}
```

So, this PR attempts to address this. And has been expanded following a conversation on the #autopkg slack channel.

To enable this new functionality, a new input_variable has been created for `MunkiInstallsItemsCreator` named: `derive_minimum_os_version`

If this is passed any value, it's enabled. (similar to the GitHubReleasesInfoProvider's, include_prereleases input_variable).

Once set, and the recipe is ran:

• If a `minosversion` is set within the installs array, will set `minimum_os_version` to this value.
• If multiple values for `minosversion` are found, then `minimum_os_version` is set to the highest minimum.
• If no `minosversion` value found, then `minimum_os_version` is not set. (this could be amended to always default to a value, such as 10.5.0)

## Examples

### Single .app in installs array with minos defined within info.plist

Pre PR:

```
Processing /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(https://audiomovers\\.com/storage/plugins/.*?/listento-standalone-.*?-installer-osx-signed\\.pkg)\\"',
           'result_output_var_name': 'url',
           'url': 'https://audiomovers.com/wp/downloads/'}}
URLTextSearcher: Found matching text (url): https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader
{'Input': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Yuriy '
                                        'Shevyrov (US78Y74NNA)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "listento-standalone-20210419-installer-osx-signed.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-04-19 17:44:25 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Yuriy Shevyrov (US78Y74NNA)
CodeSignatureVerifier:        Expires: 2025-04-11 13:59:14 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E1 30 F3 51 48 C0 1B 35 8F A1 C7 02 A9 D4 62 DE EB 4E 88 26 A7 26
CodeSignatureVerifier:            CB 16 47 C5 C7 98 03 12 DA DF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                            'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/AudiomoversListento/',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack/Listento.pkg/payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack/Listento.pkg/payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento/
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/AudiomoversListento',
           'installs_item_paths': ['/Applications/Listento.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Listento.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                                 'CFBundleName': 'Listento',
                                                 'CFBundleShortVersionString': '1.10.20210419',
                                                 'CFBundleVersion': '1.10.20210419',
                                                 'minosversion': '10.11',
                                                 'path': '/Applications/Listento.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                                'CFBundleName': 'Listento',
                                                'CFBundleShortVersionString': '1.10.20210419',
                                                'CFBundleVersion': '1.10.20210419',
                                                'minosversion': '10.11',
                                                'path': '/Applications/Listento.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone', 'CFBundleName': 'Listento', 'CFBundleShortVersionString': '1.10.20210419', 'CFBundleVersion': '1.10.20210419', 'minosversion': '10.11', 'path': '/Applications/Listento.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'DAWless high quality audio streaming',
                        'display_name': 'Audiomovers Listento',
                        'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                      'CFBundleName': 'Listento',
                                      'CFBundleShortVersionString': '1.10.20210419',
                                      'CFBundleVersion': '1.10.20210419',
                                      'minosversion': '10.11',
                                      'path': '/Applications/Listento.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'AudiomoversListento',
                        'unattended_install': True,
                        'unattended_uninstall': True}}}
PlistReader
{'Input': {'info_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/AudiomoversListento/Applications/Listento.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento/Applications/Listento.app/Contents/Info.plist
PlistReader: Assigning value of '1.10.20210419' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '1.10.20210419'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '1.10.20210419'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                     'CFBundleName': 'Listento',
                                     'CFBundleShortVersionString': '1.10.20210419',
                                     'CFBundleVersion': '1.10.20210419',
                                     'minosversion': '10.11',
                                     'path': '/Applications/Listento.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True}}}
MunkiPkginfoMerger: Merged {'version': '1.10.20210419'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'DAWless high quality audio streaming',
                        'display_name': 'Audiomovers Listento',
                        'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                      'CFBundleName': 'Listento',
                                      'CFBundleShortVersionString': '1.10.20210419',
                                      'CFBundleVersion': '1.10.20210419',
                                      'minosversion': '10.11',
                                      'path': '/Applications/Listento.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'AudiomoversListento',
                        'unattended_install': True,
                        'unattended_uninstall': True,
                        'version': '1.10.20210419'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                       'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                     'CFBundleName': 'Listento',
                                     'CFBundleShortVersionString': '1.10.20210419',
                                     'CFBundleVersion': '1.10.20210419',
                                     'minosversion': '10.11',
                                     'path': '/Applications/Listento.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'version': '1.10.20210419'},
           'repo_subdirectory': 'apps/AudiomoversListento',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/AudiomoversListento/AudiomoversListento-1.10.20210419__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__1.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'AudiomoversListento',
                                                       'pkg_repo_path': 'apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__1.pkg',
                                                       'pkginfo_path': 'apps/AudiomoversListento/AudiomoversListento-1.10.20210419__1.plist',
                                                       'version': '1.10.20210419'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2022, 4, 22, 8, 43, 50),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '12.3'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'DAWless high quality audio '
                                          'streaming',
                           'display_name': 'Audiomovers Listento',
                           'installed_size': 35800,
                           'installer_item_hash': '17293224b1d0c2c717bc593003fad5063a3a96d515e397e94b8f997ba0f516ff',
                           'installer_item_location': 'apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__1.pkg',
                           'installer_item_size': 19251,
                           'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                         'CFBundleName': 'Listento',
                                         'CFBundleShortVersionString': '1.10.20210419',
                                         'CFBundleVersion': '1.10.20210419',
                                         'minosversion': '10.11',
                                         'path': '/Applications/Listento.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'AudiomoversListento',
                           'receipts': [{'installed_size': 35800,
                                         'packageid': 'com.audiomovers.listento.standalone',
                                         'version': '1.10.20210419'}],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '1.10.20210419'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__1.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/AudiomoversListento/AudiomoversListento-1.10.20210419__1.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/AudiomoversListento',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/unpack']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/receipts/Audiomovers Listento.munki-receipt-20220422-094351.plist

The following new items were imported into Munki:
    Name                 Version        Catalogs  Pkginfo Path                                                         Pkg Repo Path                                                                                    Icon Repo Path
    ----                 -------        --------  ------------                                                         -------------                                                                                    --------------
    AudiomoversListento  1.10.20210419  testing   apps/AudiomoversListento/AudiomoversListento-1.10.20210419__1.plist  apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__1.pkg

```

Post PR:

```
Processing /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(https://audiomovers\\.com/storage/plugins/.*?/listento-standalone-.*?-installer-osx-signed\\.pkg)\\"',
           'result_output_var_name': 'url',
           'url': 'https://audiomovers.com/wp/downloads/'}}
URLTextSearcher: Found matching text (url): https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader
{'Input': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Yuriy '
                                        'Shevyrov (US78Y74NNA)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "listento-standalone-20210419-installer-osx-signed.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-04-19 17:44:25 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Yuriy Shevyrov (US78Y74NNA)
CodeSignatureVerifier:        Expires: 2025-04-11 13:59:14 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E1 30 F3 51 48 C0 1B 35 8F A1 C7 02 A9 D4 62 DE EB 4E 88 26 A7 26
CodeSignatureVerifier:            CB 16 47 C5 C7 98 03 12 DA DF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                            'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/AudiomoversListento/',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack/Listento.pkg/payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack/Listento.pkg/payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento/
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'derive_minimum_os_version': 'test',
           'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/AudiomoversListento',
           'installs_item_paths': ['/Applications/Listento.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Listento.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.11
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                                 'CFBundleName': 'Listento',
                                                 'CFBundleShortVersionString': '1.10.20210419',
                                                 'CFBundleVersion': '1.10.20210419',
                                                 'minosversion': '10.11',
                                                 'path': '/Applications/Listento.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}],
                                   'minimum_os_version': '10.11'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                                'CFBundleName': 'Listento',
                                                'CFBundleShortVersionString': '1.10.20210419',
                                                'CFBundleVersion': '1.10.20210419',
                                                'minosversion': '10.11',
                                                'path': '/Applications/Listento.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}],
                                  'minimum_os_version': '10.11'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone', 'CFBundleName': 'Listento', 'CFBundleShortVersionString': '1.10.20210419', 'CFBundleVersion': '1.10.20210419', 'minosversion': '10.11', 'path': '/Applications/Listento.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.11'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'DAWless high quality audio streaming',
                        'display_name': 'Audiomovers Listento',
                        'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                      'CFBundleName': 'Listento',
                                      'CFBundleShortVersionString': '1.10.20210419',
                                      'CFBundleVersion': '1.10.20210419',
                                      'minosversion': '10.11',
                                      'path': '/Applications/Listento.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.11',
                        'name': 'AudiomoversListento',
                        'unattended_install': True,
                        'unattended_uninstall': True}}}
PlistReader
{'Input': {'info_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/AudiomoversListento/Applications/Listento.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento/Applications/Listento.app/Contents/Info.plist
PlistReader: Assigning value of '1.10.20210419' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '1.10.20210419'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '1.10.20210419'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                     'CFBundleName': 'Listento',
                                     'CFBundleShortVersionString': '1.10.20210419',
                                     'CFBundleVersion': '1.10.20210419',
                                     'minosversion': '10.11',
                                     'path': '/Applications/Listento.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.11',
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True}}}
MunkiPkginfoMerger: Merged {'version': '1.10.20210419'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'DAWless high quality audio streaming',
                        'display_name': 'Audiomovers Listento',
                        'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                      'CFBundleName': 'Listento',
                                      'CFBundleShortVersionString': '1.10.20210419',
                                      'CFBundleVersion': '1.10.20210419',
                                      'minosversion': '10.11',
                                      'path': '/Applications/Listento.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'minimum_os_version': '10.11',
                        'name': 'AudiomoversListento',
                        'unattended_install': True,
                        'unattended_uninstall': True,
                        'version': '1.10.20210419'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                       'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                     'CFBundleName': 'Listento',
                                     'CFBundleShortVersionString': '1.10.20210419',
                                     'CFBundleVersion': '1.10.20210419',
                                     'minosversion': '10.11',
                                     'path': '/Applications/Listento.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'minimum_os_version': '10.11',
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'version': '1.10.20210419'},
           'repo_subdirectory': 'apps/AudiomoversListento',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/AudiomoversListento/AudiomoversListento-1.10.20210419.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'AudiomoversListento',
                                                       'pkg_repo_path': 'apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419.pkg',
                                                       'pkginfo_path': 'apps/AudiomoversListento/AudiomoversListento-1.10.20210419.plist',
                                                       'version': '1.10.20210419'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2022, 4, 22, 8, 38, 22),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '12.3'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'DAWless high quality audio '
                                          'streaming',
                           'display_name': 'Audiomovers Listento',
                           'installed_size': 35800,
                           'installer_item_hash': '17293224b1d0c2c717bc593003fad5063a3a96d515e397e94b8f997ba0f516ff',
                           'installer_item_location': 'apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419.pkg',
                           'installer_item_size': 19251,
                           'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                         'CFBundleName': 'Listento',
                                         'CFBundleShortVersionString': '1.10.20210419',
                                         'CFBundleVersion': '1.10.20210419',
                                         'minosversion': '10.11',
                                         'path': '/Applications/Listento.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.11',
                           'name': 'AudiomoversListento',
                           'receipts': [{'installed_size': 35800,
                                         'packageid': 'com.audiomovers.listento.standalone',
                                         'version': '1.10.20210419'}],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '1.10.20210419'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/AudiomoversListento/AudiomoversListento-1.10.20210419.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/AudiomoversListento',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/unpack']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/receipts/Audiomovers Listento.munki-receipt-20220422-093822.plist

The following new items were imported into Munki:
    Name                 Version        Catalogs  Pkginfo Path                                                      Pkg Repo Path                                                                                 Icon Repo Path
    ----                 -------        --------  ------------                                                      -------------                                                                                 --------------
    AudiomoversListento  1.10.20210419  testing   apps/AudiomoversListento/AudiomoversListento-1.10.20210419.plist  apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419.pkg

```

### Multiple .app in installs array with minos defined within only one .apps info.plist


Pre (missing details to PR length):

```            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2022, 4, 22, 8, 50, 6),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '12.3'},
                           'autoremove': False,
                           'blocking_applications': ['DrRacket',
                                                     'PLT Games',
                                                     'Racket Documentation',
                                                     'Slideshow'],
                           'catalogs': ['testing'],
                           'description': 'Racket is a general-purpose '
                                          'programming language as well as the '
                                          'world’s first ecosystem for '
                                          'developing and deploying new '
                                          'languages. Make your dream '
                                          'language, or use one of the dozens '
                                          'already available.',
                           'developer': 'PLT Inc',
                           'display_name': 'Racket 7',
                           'installed_size': 522158,
                           'installer_item_hash': '4c7ccd4ff7284ae2d95d1450bf7e91fdaa4528040ba92c805ed1883198936680',
                           'installer_item_location': 'apps/Racket7/Racket7-7.9.pkg',
                           'installer_item_size': 141013,
                           'installs': [{'CFBundleIdentifier': 'org.racket-lang.DrRacket',
                                         'CFBundleShortVersionString': '7.9',
                                         'CFBundleVersion': '7.9',
                                         'path': '/Applications/Racket '
                                                 'v7.9/DrRacket.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'},
                                        {'CFBundleIdentifier': 'org.racket-lang.PLT '
                                                               'Games',
                                         'CFBundleShortVersionString': '7.9',
                                         'CFBundleVersion': '7.9',
                                         'path': '/Applications/Racket '
                                                 'v7.9/PLT Games.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'},
                                        {'CFBundleIdentifier': 'org.racket-lang.Racket '
                                                               'Documentation',
                                         'CFBundleShortVersionString': '7.9',
                                         'CFBundleVersion': '7.9',
                                         'path': '/Applications/Racket '
                                                 'v7.9/Racket '
                                                 'Documentation.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'},
                                        {'CFBundleIdentifier': 'org.racket-lang.Slideshow',
                                         'CFBundleShortVersionString': '7.9',
                                         'CFBundleVersion': '7.9',
                                         'path': '/Applications/Racket '
                                                 'v7.9/Slideshow.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'Racket7',
                           'receipts': [{'installed_size': 522158,
                                         'packageid': 'org.racket-lang.Racket7',
                                         'version': '7.9'}],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '7.9'},
```

Post (missing details to PR length):

```
munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2022, 4, 22, 8, 53, 22),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '12.3'},
                           'autoremove': False,
                           'blocking_applications': ['DrRacket',
                                                     'PLT Games',
                                                     'Racket Documentation',
                                                     'Slideshow'],
                           'catalogs': ['testing'],
                           'description': 'Racket is a general-purpose '
                                          'programming language as well as the '
                                          'world’s first ecosystem for '
                                          'developing and deploying new '
                                          'languages. Make your dream '
                                          'language, or use one of the dozens '
                                          'already available.',
                           'developer': 'PLT Inc',
                           'display_name': 'Racket 7',
                           'installed_size': 522158,
                           'installer_item_hash': '4c7ccd4ff7284ae2d95d1450bf7e91fdaa4528040ba92c805ed1883198936680',
                           'installer_item_location': 'apps/Racket7/Racket7-7.9__1.pkg',
                           'installer_item_size': 141013,
                           'installs': [{'CFBundleIdentifier': 'org.racket-lang.DrRacket',
                                         'CFBundleShortVersionString': '7.9',
                                         'CFBundleVersion': '7.9',
                                         'path': '/Applications/Racket '
                                                 'v7.9/DrRacket.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'},
                                        {'CFBundleIdentifier': 'org.racket-lang.PLT '
                                                               'Games',
                                         'CFBundleShortVersionString': '7.9',
                                         'CFBundleVersion': '7.9',
                                         'path': '/Applications/Racket '
                                                 'v7.9/PLT Games.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'},
                                        {'CFBundleIdentifier': 'org.racket-lang.Racket '
                                                               'Documentation',
                                         'CFBundleShortVersionString': '7.9',
                                         'CFBundleVersion': '7.9',
                                         'path': '/Applications/Racket '
                                                 'v7.9/Racket '
                                                 'Documentation.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'},
                                        {'CFBundleIdentifier': 'org.racket-lang.Slideshow',
                                         'CFBundleShortVersionString': '7.9',
                                         'CFBundleVersion': '7.9',
                                         'path': '/Applications/Racket '
                                                 'v7.9/Slideshow.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'Racket7',
                           'receipts': [{'installed_size': 522158,
                                         'packageid': 'org.racket-lang.Racket7',
                                         'version': '7.9'}],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '7.9'},
```

