### PR TITLE
MunkiInstallsItemsCreator - Raise if empty installs array created

### DIFF
--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -89,6 +89,11 @@ class MunkiInstallsItemsCreator(Processor):
         # Get pkginfo from output plist.
         pkginfo = plistlib.loads(out)
         installs_array = pkginfo.get("installs", [])
+        
+        # Raise if installs_array is empty
+        if not installs_array:
+            raise ProcessorError(f"cannot generate installs_array from: faux_root {faux_root}, "
+                                 f"installs_item_paths: {self.env['installs_item_paths']}")
 
         if faux_root:
             for item in installs_array:


### PR DESCRIPTION
## Overview
Currently, MunkiInstallsItemsCreator will create an empty installs array if it cannot find any items within faux_root that match the installs_item_paths.

This can be confusing when writing recipes, and I know this has caught me out a few times.

This PR raises if the installs array is empty.

# Examples

recipe amended, removed %NAME% from faux_root

Pre PR

```
Processing /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(https://audiomovers\\.com/storage/plugins/.*?/listento-standalone-.*?-installer-osx-signed\\.pkg)\\"',
           'result_output_var_name': 'url',
           'url': 'https://audiomovers.com/wp/downloads/'}}
URLTextSearcher: Found matching text (url): https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader
{'Input': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Yuriy '
                                        'Shevyrov (US78Y74NNA)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "listento-standalone-20210419-installer-osx-signed.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-04-19 17:44:25 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Yuriy Shevyrov (US78Y74NNA)
CodeSignatureVerifier:        Expires: 2025-04-11 13:59:14 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E1 30 F3 51 48 C0 1B 35 8F A1 C7 02 A9 D4 62 DE EB 4E 88 26 A7 26
CodeSignatureVerifier:            CB 16 47 C5 C7 98 03 12 DA DF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                            'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/AudiomoversListento/',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack/Listento.pkg/payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack/Listento.pkg/payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento/
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/',
           'installs_item_paths': ['/Applications/Listento.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
{'Output': {'additional_pkginfo': {'installs': []}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': []},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True}}}
MunkiPkginfoMerger: Merged {'installs': []} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'DAWless high quality audio streaming',
                        'display_name': 'Audiomovers Listento',
                        'installs': [],
                        'name': 'AudiomoversListento',
                        'unattended_install': True,
                        'unattended_uninstall': True}}}
PlistReader
{'Input': {'info_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/AudiomoversListento/Applications/Listento.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento/Applications/Listento.app/Contents/Info.plist
PlistReader: Assigning value of '1.10.20210419' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '1.10.20210419'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '1.10.20210419'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'installs': [],
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True}}}
MunkiPkginfoMerger: Merged {'version': '1.10.20210419'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'DAWless high quality audio streaming',
                        'display_name': 'Audiomovers Listento',
                        'installs': [],
                        'name': 'AudiomoversListento',
                        'unattended_install': True,
                        'unattended_uninstall': True,
                        'version': '1.10.20210419'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                       'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'installs': [],
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'version': '1.10.20210419'},
           'repo_subdirectory': 'apps/AudiomoversListento',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/AudiomoversListento/AudiomoversListento-1.10.20210419__3.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__3.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'AudiomoversListento',
                                                       'pkg_repo_path': 'apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__3.pkg',
                                                       'pkginfo_path': 'apps/AudiomoversListento/AudiomoversListento-1.10.20210419__3.plist',
                                                       'version': '1.10.20210419'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2022, 4, 22, 11, 8, 21),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '12.3'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'DAWless high quality audio '
                                          'streaming',
                           'display_name': 'Audiomovers Listento',
                           'installed_size': 35800,
                           'installer_item_hash': '17293224b1d0c2c717bc593003fad5063a3a96d515e397e94b8f997ba0f516ff',
                           'installer_item_location': 'apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__3.pkg',
                           'installer_item_size': 19251,
                           'installs': [],
                           'minimum_os_version': '10.5.0',
                           'name': 'AudiomoversListento',
                           'receipts': [{'installed_size': 35800,
                                         'packageid': 'com.audiomovers.listento.standalone',
                                         'version': '1.10.20210419'}],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '1.10.20210419'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__3.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/AudiomoversListento/AudiomoversListento-1.10.20210419__3.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/AudiomoversListento',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/unpack']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/receipts/Audiomovers Listento.munki-receipt-20220422-120821.plist

The following new items were imported into Munki:
    Name                 Version        Catalogs  Pkginfo Path                                                         Pkg Repo Path                                                                                    Icon Repo Path
    ----                 -------        --------  ------------                                                         -------------                                                                                    --------------
    AudiomoversListento  1.10.20210419  testing   apps/AudiomoversListento/AudiomoversListento-1.10.20210419__3.plist  apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__3.pkg
```

Post PR - incorrect path

```
Processing /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(https://audiomovers\\.com/storage/plugins/.*?/listento-standalone-.*?-installer-osx-signed\\.pkg)\\"',
           'result_output_var_name': 'url',
           'url': 'https://audiomovers.com/wp/downloads/'}}
URLTextSearcher: Found matching text (url): https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader
{'Input': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Yuriy '
                                        'Shevyrov (US78Y74NNA)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "listento-standalone-20210419-installer-osx-signed.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-04-19 17:44:25 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Yuriy Shevyrov (US78Y74NNA)
CodeSignatureVerifier:        Expires: 2025-04-11 13:59:14 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E1 30 F3 51 48 C0 1B 35 8F A1 C7 02 A9 D4 62 DE EB 4E 88 26 A7 26
CodeSignatureVerifier:            CB 16 47 C5 C7 98 03 12 DA DF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                            'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/AudiomoversListento/',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack/Listento.pkg/payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack/Listento.pkg/payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento/
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/',
           'installs_item_paths': ['/Applications/Listento.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
cannot generate installs_array from: faux_root /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento, installs_item_paths: ['/Applications/Listento.app']
Failed.
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/receipts/Audiomovers Listento.munki-receipt-20220422-121548.plist

The following recipes failed:
    /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe
        Error in com.github.dataJAR-recipes.munki.Audiomovers Listento: Processor: MunkiInstallsItemsCreator: Error: cannot generate installs_array from: faux_root /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento, installs_item_paths: ['/Applications/Listento.app']

Nothing downloaded, packaged or imported.

```

Post PR - correct path

```
Processing /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe...
WARNING: /Users/ben/Git/other/dataJAR-recipes/Audiomovers Listento/Audiomovers Listento.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(https://audiomovers\\.com/storage/plugins/.*?/listento-standalone-.*?-installer-osx-signed\\.pkg)\\"',
           'result_output_var_name': 'url',
           'url': 'https://audiomovers.com/wp/downloads/'}}
URLTextSearcher: Found matching text (url): https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader
{'Input': {'url': 'https://audiomovers.com/storage/plugins/20210419/listento-standalone-20210419-installer-osx-signed.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Yuriy '
                                        'Shevyrov (US78Y74NNA)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "listento-standalone-20210419-installer-osx-signed.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2021-04-19 17:44:25 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Yuriy Shevyrov (US78Y74NNA)
CodeSignatureVerifier:        Expires: 2025-04-11 13:59:14 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E1 30 F3 51 48 C0 1B 35 8F A1 C7 02 A9 D4 62 DE EB 4E 88 26 A7 26 
CodeSignatureVerifier:            CB 16 47 C5 C7 98 03 12 DA DF
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack',
           'flat_pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                            'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg',
           'purge_destination': True}}
FlatPkgUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/AudiomoversListento/',
           'pkg_payload_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                               'Listento/unpack/Listento.pkg/payload',
           'purge_destination': True}}
PkgPayloadUnpacker: Unpacked /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack/Listento.pkg/payload to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento/
{'Output': {}}
MunkiInstallsItemsCreator
{'Input': {'faux_root': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/AudiomoversListento',
           'installs_item_paths': ['/Applications/Listento.app'],
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiInstallsItemsCreator: Created installs item for /Applications/Listento.app
{'Output': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                                 'CFBundleName': 'Listento',
                                                 'CFBundleShortVersionString': '1.10.20210419',
                                                 'CFBundleVersion': '1.10.20210419',
                                                 'minosversion': '10.11',
                                                 'path': '/Applications/Listento.app',
                                                 'type': 'application',
                                                 'version_comparison_key': 'CFBundleShortVersionString'}]}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                                'CFBundleName': 'Listento',
                                                'CFBundleShortVersionString': '1.10.20210419',
                                                'CFBundleVersion': '1.10.20210419',
                                                'minosversion': '10.11',
                                                'path': '/Applications/Listento.app',
                                                'type': 'application',
                                                'version_comparison_key': 'CFBundleShortVersionString'}]},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True}}}
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone', 'CFBundleName': 'Listento', 'CFBundleShortVersionString': '1.10.20210419', 'CFBundleVersion': '1.10.20210419', 'minosversion': '10.11', 'path': '/Applications/Listento.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'DAWless high quality audio streaming',
                        'display_name': 'Audiomovers Listento',
                        'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                      'CFBundleName': 'Listento',
                                      'CFBundleShortVersionString': '1.10.20210419',
                                      'CFBundleVersion': '1.10.20210419',
                                      'minosversion': '10.11',
                                      'path': '/Applications/Listento.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'AudiomoversListento',
                        'unattended_install': True,
                        'unattended_uninstall': True}}}
PlistReader
{'Input': {'info_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                        'Listento/AudiomoversListento/Applications/Listento.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento/Applications/Listento.app/Contents/Info.plist
PlistReader: Assigning value of '1.10.20210419' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '1.10.20210419'}}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '1.10.20210419'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                     'CFBundleName': 'Listento',
                                     'CFBundleShortVersionString': '1.10.20210419',
                                     'CFBundleVersion': '1.10.20210419',
                                     'minosversion': '10.11',
                                     'path': '/Applications/Listento.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True}}}
MunkiPkginfoMerger: Merged {'version': '1.10.20210419'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'DAWless high quality audio streaming',
                        'display_name': 'Audiomovers Listento',
                        'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                      'CFBundleName': 'Listento',
                                      'CFBundleShortVersionString': '1.10.20210419',
                                      'CFBundleVersion': '1.10.20210419',
                                      'minosversion': '10.11',
                                      'path': '/Applications/Listento.app',
                                      'type': 'application',
                                      'version_comparison_key': 'CFBundleShortVersionString'}],
                        'name': 'AudiomoversListento',
                        'unattended_install': True,
                        'unattended_uninstall': True,
                        'version': '1.10.20210419'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                       'Listento/downloads/listento-standalone-20210419-installer-osx-signed.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'DAWless high quality audio streaming',
                       'display_name': 'Audiomovers Listento',
                       'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                     'CFBundleName': 'Listento',
                                     'CFBundleShortVersionString': '1.10.20210419',
                                     'CFBundleVersion': '1.10.20210419',
                                     'minosversion': '10.11',
                                     'path': '/Applications/Listento.app',
                                     'type': 'application',
                                     'version_comparison_key': 'CFBundleShortVersionString'}],
                       'name': 'AudiomoversListento',
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'version': '1.10.20210419'},
           'repo_subdirectory': 'apps/AudiomoversListento',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/AudiomoversListento/AudiomoversListento-1.10.20210419__5.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__5.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'AudiomoversListento',
                                                       'pkg_repo_path': 'apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__5.pkg',
                                                       'pkginfo_path': 'apps/AudiomoversListento/AudiomoversListento-1.10.20210419__5.plist',
                                                       'version': '1.10.20210419'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2022, 4, 22, 11, 25, 46),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '12.3'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'DAWless high quality audio '
                                          'streaming',
                           'display_name': 'Audiomovers Listento',
                           'installed_size': 35800,
                           'installer_item_hash': '17293224b1d0c2c717bc593003fad5063a3a96d515e397e94b8f997ba0f516ff',
                           'installer_item_location': 'apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__5.pkg',
                           'installer_item_size': 19251,
                           'installs': [{'CFBundleIdentifier': 'com.audiomovers.standalone',
                                         'CFBundleName': 'Listento',
                                         'CFBundleShortVersionString': '1.10.20210419',
                                         'CFBundleVersion': '1.10.20210419',
                                         'minosversion': '10.11',
                                         'path': '/Applications/Listento.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'minimum_os_version': '10.5.0',
                           'name': 'AudiomoversListento',
                           'receipts': [{'installed_size': 35800,
                                         'packageid': 'com.audiomovers.listento.standalone',
                                         'version': '1.10.20210419'}],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '1.10.20210419'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__5.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/AudiomoversListento/AudiomoversListento-1.10.20210419__5.plist'}}
PathDeleter
{'Input': {'path_list': ['/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/AudiomoversListento',
                         '/Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers '
                         'Listento/unpack']}}
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/AudiomoversListento
PathDeleter: Deleted /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/unpack
{'Output': {}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.dataJAR-recipes.munki.Audiomovers Listento/receipts/Audiomovers Listento.munki-receipt-20220422-122546.plist

The following new items were imported into Munki:
    Name                 Version        Catalogs  Pkginfo Path                                                         Pkg Repo Path                                                                                    Icon Repo Path  
    ----                 -------        --------  ------------                                                         -------------                                                                                    --------------  
    AudiomoversListento  1.10.20210419  testing   apps/AudiomoversListento/AudiomoversListento-1.10.20210419__5.plist  apps/AudiomoversListento/listento-standalone-20210419-installer-osx-signed-1.10.20210419__5.pkg                  
```