### PR TITLE
When "ditto" fails to extract an archive in PkgPayloadUnpacker, use "aa" if present

### DIFF
--- a/Code/autopkglib/PkgPayloadUnpacker.py
+++ b/Code/autopkglib/PkgPayloadUnpacker.py
@@ -102,11 +102,11 @@ class PkgPayloadUnpacker(Processor):
                     raise ProcessorError(
                         f"aa execution failed with error code {err.errno}: {err.strerror}"
                     )
-            if proc.returncode != 0:
-                raise ProcessorError(
-                    f"extraction of {self.env['pkg_payload_path']} with aa failed: "
-                    f"{err_out}"
-                )
+                if proc.returncode != 0:
+                    raise ProcessorError(
+                        f"extraction of {self.env['pkg_payload_path']} with aa failed: "
+                        f"{err_out}"
+                    )
             else:
                 raise ProcessorError(
                     f"ditto execution failed with error code {err.errno}: {err.strerror}"

--- a/Code/autopkglib/PkgPayloadUnpacker.py
+++ b/Code/autopkglib/PkgPayloadUnpacker.py
@@ -99,7 +99,6 @@ class PkgPayloadUnpacker(Processor):
                     "-i",
                     self.env["pkg_payload_path"],
                     "-d",
-                    # "/Volumes/NoSuch",
                     self.env["destination_path"],
                 ]
                 proc = subprocess.Popen(


### PR DESCRIPTION
Modern Apple Archives fail to be extracted using `ditto`. Case in point is TeamViewer.pkg in justinrimmel-recipes.

In Slack's `#autopkg` channel we have established that the `aa` command can do the job instead. In fact, it seems to also be able to extract the Payload archives that are not modern Apple Archives but CPIO archive payloads.

However, `aa` only appears to have been introduced on Big Sur, so can't replace `ditto` just yet.

This PR makes PkgPayloadUnpacker try `aa` only if `ditto` fails and `aa` is found at `/usr/bin/aa`. If `aa` is not present, the `ditto` failure is raised as a ProcessorError. 