### PR TITLE
Add plist serializer

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -587,7 +587,7 @@ def write_plist_exit_on_fail(plist_dict, path):
     if the write fails."""
     try:
         with open(path, "wb") as f:
-            plistlib.dump(plist_dict, f)
+            plistlib.dump(plist_serializer(plist_dict), f)
     except (TypeError, OverflowError):
         log_err(f"Failed to save plist to {path}.")
         sys.exit(-1)
@@ -1741,7 +1741,7 @@ def update_trust_info(argv):
                     yaml.dump(recipe, f, encoding="utf-8")
             else:
                 with open(recipe_path, "wb") as f:
-                    plistlib.dump(recipe, f)
+                    plistlib.dump(plist_serializer(recipe), f)
             log(f"Wrote updated {recipe_path}")
         else:
             log_err(
@@ -1971,7 +1971,7 @@ def make_override(argv):
             yaml.dump(override_dict, f, encoding="utf-8")
     else:
         with open(override_file, "wb") as f:
-            plistlib.dump(override_dict, f)
+            plistlib.dump(plist_serializer(override_dict), f)
     log(f"Override file saved to {override_file}")
     return 0
 
@@ -2178,7 +2178,7 @@ def run_recipes(argv):
     run_results = []
     try:
         with open(current_run_results_plist, "wb") as f:
-            plistlib.dump(run_results, f)
+            plistlib.dump(plist_serializer(run_results), f)
     except OSError as err:
         log_err(f"Can't write results to {current_run_results_plist}: {err.strerror}")
 
@@ -2291,7 +2291,7 @@ def run_recipes(argv):
         run_results.append(autopackager.results)
         try:
             with open(current_run_results_plist, "wb") as f:
-                plistlib.dump(run_results, f)
+                plistlib.dump(plist_serializer(run_results), f)
         except OSError as err:
             log_err(
                 f"Can't write results to {current_run_results_plist}: {err.strerror}"
@@ -2354,7 +2354,7 @@ def run_recipes(argv):
             receipt_path = os.path.join(receipt_dir, receipt_name)
             try:
                 with open(receipt_path, "wb") as f:
-                    plistlib.dump(autopackager.results, f)
+                    plistlib.dump(plist_serializer(autopackager.results), f)
                 if options.verbose:
                     log(f"Receipt written to {receipt_path}")
             except OSError as err:
@@ -2683,10 +2683,29 @@ def new_recipe(argv):
                 yaml.dump(recipe, f, encoding="utf-8")
         else:
             with open(filename, "wb") as f:
-                plistlib.dump(recipe, f)
+                plistlib.dump(plist_serializer(recipe), f)
         log(f"Saved new recipe to {filename}")
     except Exception as err:
         log_err(f"Failed to write recipe: {err}")
+
+
+def plist_serializer(obj):
+    """Serialize an object to ensure it can be dumped in plist format.
+
+    Args:
+        obj (dict, list): Object is assumed to be either a dict or list
+            that will be parsed.
+
+    Returns:
+        (any): The received object will be returned, modified if required.
+    """
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            obj[k] = "" if v is None else plist_serializer(v)
+    elif isinstance(obj, list):
+        for item in range(len(obj)):
+            plist_serializer(obj[item])
+    return obj
 
 
 def main(argv):


### PR DESCRIPTION
tl/dr:  This simple function should resolve an (edge case) issue where `plistlib.dump` raises an exception when the contents contain `None` type values.

Details:
YAML supports `null` values, as does Python `dict`s as `None`, however, Plists do not and [`plistlib.dump()`](https://docs.python.org/3/library/plistlib.html#plistlib.dump) raises a `TypeError` if a value is null.

I have recipes overrides where I simply override specific keys with an empty value, e.g.:
```
<key>OS_REQUIREMENTS</key>
<string></string>
```

This has worked without issue for years.  But recently, I've began creating new overrides and converting current overrides to YAML when/if I'm update them.  Following the same premise, the empty value could be accomplished by:
```
  OS_REQUIREMENTS: null
```
or
```
  OS_REQUIREMENTS: 
```
All the the libraries and existing logic within AutoPkg _actually_ supports both above options (so much so, that `autopkg update-trust-info <recipe_id>` leaves `null` values in place, as would likely be expected).....all the way up to when the contents of the `run_results` variable is passed into `plistlib.dump()` on an `autopkg run <recipe_id>` and then an error occurs:
```
{
    "Traceback (most recent call last):
  File \"/usr/local/bin/autopkg\", line 2758, in <module>
    sys.exit(main(sys.argv))
  File \"/usr/local/bin/autopkg\", line 2754, in main
    return subcommands[verb][\"function\"](argv)
  File \"/usr/local/bin/autopkg\", line 2276, in run_recipes
    plistlib.dump(run_results, f)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 970, in dump
    writer.write(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 402, in write
    self.write_value(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 437, in write_value
    self.write_array(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 482, in write_array
    self.write_value(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 437, in write_value
    self.write_array(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 482, in write_array
    self.write_value(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 425, in write_value
    self.write_dict(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 472, in write_dict
    self.write_value(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 425, in write_value
    self.write_dict(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 472, in write_dict
    self.write_value(value)
  File \"/Library/AutoPkg/Python3/Python.framework/Versions/Current/lib/python3.7/plistlib.py\", line 440, in write_value
    raise TypeError(\"unsupported type": {
        "%s\" % type(value))
TypeError": {
            "unsupported type": "<class 'NoneType'>"
        }
    }
}
```
The recipe run _actually seems_ to complete successfully, but this error is produced after the fact (at least, my wrapper around `autopkg` produces a success message and then an error message, strangely enough).

I've only see this using the `run` subcommand, but I went ahead and added the function to all uses of `plistlib.dump`.

So far, I've found [one other report](https://macadmins.slack.com/archives/C056155B4/p1632752937261400) of this, though cannot confirm it is due to this same issue.