### PR TITLE
Update python_universal_tester.sh

### DIFF
--- a/python_universal_tester.sh
+++ b/python_universal_tester.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# This applies to macOS only.
+# This is to determine which python packages have binaries that do not work on both x86_64 and ARM64 CPUs.
 
 [[ $1 == *"3."* ]] && echo "Using Python $1" || (echo "Invalid Python version" && exit 1)
 


### PR DESCRIPTION
Add comments. In this context `universal` is specific to MacOS, which I do realize, but I often use `universal` to mean "cross-platform", which is confusing in this context.

Originally I put Apple Silicon / AMD64 (Intel), but figured the generic terms were better?