### PR TITLE
Update GitHubReleasesInfoProvider.py to get asset_created_at time

### DIFF
--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -111,6 +111,11 @@ class GitHubReleasesInfoProvider(Processor):
                 "Version info parsed, naively derived from the release's tag."
             )
         },
+        "asset_created_at": {
+            "description": (
+                "The release time of the asset."
+            )
+        },
     }
 
     __doc__ = description
@@ -199,6 +204,9 @@ class GitHubReleasesInfoProvider(Processor):
 
         # Record the asset url
         self.env["asset_url"] = self.selected_asset["url"]
+        
+        # Record the asset created_at time
+        self.env["asset_created_at"] = self.selected_asset["created_at"]
 
         # Get a version string from the tag name
         tag = self.selected_release["tag_name"]


### PR DESCRIPTION
add the ability to get the asset created_at time. See example JSON here: https://api.github.com/repos/autopkg/autopkg/releases/latest

The GitHub action to test this processor specifically is in this PR: https://github.com/autopkg/autopkg/pull/783