### PR TITLE
[autopkgserver] autopkgserver should report all errors to a file, rather than console output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### [2.7.3](https://github.com/autopkg/autopkg/compare/v2.7.2...HEAD) (Unreleased)
+### [2.7.3](https://github.com/autopkg/autopkg/compare/v2.7.2...v2.7.3) (May 15, 2024)
 
 * Fix for URLDownloader `prefetch_filename` on macOS 14.5. (https://github.com/autopkg/autopkg/pull/939)
 * Fixes for unit test workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### [2.7.4](https://github.com/autopkg/autopkg/compare/v2.7.3...HEAD) (Unreleased)
+
 ### [2.7.3](https://github.com/autopkg/autopkg/compare/v2.7.2...v2.7.3) (May 15, 2024)
 
 * Fix for URLDownloader `prefetch_filename` on macOS 14.5. (https://github.com/autopkg/autopkg/pull/939)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
-### [2.7.4](https://github.com/autopkg/autopkg/compare/v2.7.3...v2.7.3) (May 15, 2024)
-
-### [2.7.3](https://github.com/autopkg/autopkg/compare/v2.7.2...v2.7.3) (May 15, 2024)
+### [2.7.3](https://github.com/autopkg/autopkg/compare/v2.7.2...HEAD) (Unreleased)
 
 * Fix for URLDownloader `prefetch_filename` on macOS 14.5. (https://github.com/autopkg/autopkg/pull/939)
 * Fixes for unit test workflow

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -604,7 +604,7 @@ def print_tool_info(options):
 
 def get_repo_info(path_or_url):
     """Given a path or URL, find a locally installed repo and return
-    infomation in a dictionary about it"""
+    information in a dictionary about it"""
     repo_info = {}
     recipe_repos = get_pref("RECIPE_REPOS") or {}
 

--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -18,7 +18,7 @@
 import os.path
 import re
 import subprocess
-from distutils.version import StrictVersion
+from packaging.version import Version
 from glob import glob
 
 from autopkglib import ProcessorError
@@ -118,7 +118,7 @@ class CodeSignatureVerifier(DmgMounter):
 
         # Use --deep option in OS X 10.9.5 or later
         darwin_version = os.uname()[2]
-        if StrictVersion(darwin_version) >= StrictVersion("13.4.0"):
+        if Version(darwin_version) >= Version("13.4.0"):
             if deep_verification:
                 self.output("Deep verification enabled...")
                 process.append("--deep")
@@ -126,7 +126,7 @@ class CodeSignatureVerifier(DmgMounter):
                 self.output("Deep verification disabled...")
 
         # Use --strict option in OS X 10.11 or later and only if requested by the recipe
-        if StrictVersion(darwin_version) >= StrictVersion("15.0"):
+        if Version(darwin_version) >= Version("15.0"):
             if strict_verification is None:
                 self.output(
                     "Strict verification not defined. Using codesign defaults..."
@@ -338,7 +338,7 @@ class CodeSignatureVerifier(DmgMounter):
             if file_extension in [".pkg", ".mpkg", ".xip"]:
                 # Check the kernel version to make sure we're running on
                 # 10.7 or later (10.6.8 == Darwin Kernel Version 10.8.0)
-                if StrictVersion(darwin_version) >= StrictVersion("11.0"):
+                if Version(darwin_version) >= Version("11.0"):
                     self.process_installer_package(matched_input_path)
                 else:
                     self.output(

--- a/Code/autopkglib/CodeSignatureVerifier.py
+++ b/Code/autopkglib/CodeSignatureVerifier.py
@@ -18,11 +18,11 @@
 import os.path
 import re
 import subprocess
-from packaging.version import Version
 from glob import glob
 
 from autopkglib import ProcessorError
 from autopkglib.DmgMounter import DmgMounter
+from packaging.version import Version
 
 __all__ = ["CodeSignatureVerifier"]
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 import traceback
 from copy import deepcopy
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 from typing import IO, Any, Dict, List, Optional, Union
 
 import appdirs
@@ -415,9 +415,9 @@ def get_autopkg_version():
 
 
 def version_equal_or_greater(this, that):
-    """Compares two LooseVersion objects. Returns True if this is
+    """Compares two Version (as LooseVersion) objects. Returns True if this is
     equal to or greater than that"""
-    return LooseVersion(this) >= LooseVersion(that)
+    return parse(this) >= parse(that)
 
 
 def update_data(a_dict, key, value):
@@ -893,8 +893,8 @@ def _cmp(x, y):
     return (x > y) - (x < y)
 
 
-class APLooseVersion(LooseVersion):
-    """Subclass of distutils.version.LooseVersion to fix issues under Python 3"""
+class APLooseVersion(Version):
+    """Subclass of packaging.version.Version to fix issues under Python 3"""
 
     def _pad(self, version_list, max_length):
         """Pad a version list by adding extra 0 components to the end if needed."""
@@ -906,7 +906,7 @@ class APLooseVersion(LooseVersion):
 
     def _compare(self, other):
         """Complete comparison mechanism since LooseVersion's is broken in Python 3."""
-        if not isinstance(other, (LooseVersion, APLooseVersion)):
+        if not isinstance(other, (Version, APLooseVersion)):
             other = APLooseVersion(other)
         max_length = max(len(self.version), len(other.version))
         self_cmp_version = self._pad(self.version, max_length)

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -26,12 +26,12 @@ import subprocess
 import sys
 import traceback
 from copy import deepcopy
-from packaging.version import Version, parse
 from typing import IO, Any, Dict, List, Optional, Union
 
 import appdirs
 import pkg_resources
 import yaml
+from packaging.version import Version, parse
 
 # Type for methods that accept either a filesystem path or a file-like object.
 FileOrPath = Union[IO, str, bytes, int]

--- a/Code/autopkglib/version.plist
+++ b/Code/autopkglib/version.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>Version</key>
-	<string>2.7.3</string>
+	<string>2.7.4</string>
 </dict>
 </plist>

--- a/Scripts/make_new_release.py
+++ b/Scripts/make_new_release.py
@@ -29,12 +29,12 @@ import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
-from packaging.version import parse
 from pprint import pprint
 from shutil import rmtree
 from time import strftime
 
 import certifi
+from packaging.version import parse
 
 
 class GitHubAPIError(BaseException):

--- a/Scripts/make_new_release.py
+++ b/Scripts/make_new_release.py
@@ -29,7 +29,7 @@ import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
-from distutils.version import LooseVersion
+from packaging.version import parse
 from pprint import pprint
 from shutil import rmtree
 from time import strftime
@@ -199,7 +199,7 @@ def main():
     except BaseException:
         sys.exit("Couldn't determine current autopkg version!")
     print(f"** Current AutoPkg version: {current_version}")
-    if LooseVersion(next_version) <= LooseVersion(current_version):
+    if parse(next_version) <= parse(current_version):
         sys.exit(
             f"Next version (gave {next_version}) must be greater than current version "
             f"{current_version}!"

--- a/gh_actions_requirements.txt
+++ b/gh_actions_requirements.txt
@@ -18,6 +18,7 @@ isort==5.10.1
 mccabe==0.6.1
 mypy-extensions==0.4.3
 nodeenv==1.6.0
+packaging==24.2
 pathspec==0.9.0
 platformdirs==2.5.1
 pre-commit==2.17.0

--- a/new_requirements.txt
+++ b/new_requirements.txt
@@ -18,6 +18,7 @@ isort==5.12.0
 mccabe==0.6.1
 mypy-extensions==0.4.3
 nodeenv==1.6.0
+packaging==24.2
 pathspec==0.9.0
 platformdirs==2.5.1
 pre-commit==2.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ importlib-metadata==0.13
 isort==5.0.4
 mccabe==0.6.1
 nodeenv==1.3.3
+packaging==24.2
 pre-commit==2.5
 pycodestyle==2.6.0
 pycparser==2.19
@@ -28,7 +29,6 @@ tokenize-rt==3.2.0
 toml==0.10.0
 virtualenv==20.0.8
 zipp==0.5.1
-packaging==24.2
 #
 # *nix Requirements
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ tokenize-rt==3.2.0
 toml==0.10.0
 virtualenv==20.0.8
 zipp==0.5.1
+packaging==24.2
 #
 # *nix Requirements
 #


### PR DESCRIPTION
Attempts to fix #830 where the error messages should be dumped to a file. 

Since autopkgserver is not run interactively, this can reveal issues with autopkgserver in the running environment.
This acts as a preliminary fix, and is open for suggestions on how to allow the logging framework to log these early runtime errors.

Summary of Changes:
1. Logger is created upon autopkgserver startup (before anything occurs).
2. Early errors (errors that occur before the AutoPkgServer object is even created) are logged to the logger as level "Critical"
3. The logger handle is passed through to the autopkgserver class, where it functions as before.
