### PR TITLE
remove version pin of certifi to allow newer Root CAs

### DIFF
--- a/gh_actions_requirements.txt
+++ b/gh_actions_requirements.txt
@@ -5,7 +5,7 @@
 appdirs==1.4.4
 attrs==21.4.0
 black==22.3.0
-certifi==2021.10.8
+certifi
 cffi==1.15.0
 cfgv==3.3.1
 click==8.1.0


### PR DESCRIPTION
Remove pin of certifi, see here: https://github.com/autopkg/autopkg/issues/832