### PR TITLE
SparkleUpdateInfoProvider: Version and shortVersionString can be in either item or enclosure

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -221,11 +221,22 @@ class SparkleUpdateInfoProvider(URLGetter):
             if enclosure is not None:
                 item = {}
                 item["url"] = self.build_url(enclosure)
-                item["version"] = self.determine_version(enclosure, item["url"])
 
-                human_version = enclosure.get(f"{{{self.xmlns}}}shortVersionString")
+                # version and shortVersionString can be either in item or in enclosure
+                # https://sparkle-project.org/documentation/publishing/
+                version = item_elem.find(f"{{{self.xmlns}}}version")
+                if version is not None:
+                    item["version"] = version.text
+                else:
+                    item["version"] = self.determine_version(enclosure, item["url"])
+                human_version = item_elem.find(f"{{{self.xmlns}}}shortVersionString")
                 if human_version is not None:
-                    item["human_version"] = human_version
+                    item["human_version"] = human_version.text
+                else:
+                    human_version = enclosure.get(f"{{{self.xmlns}}}shortVersionString")
+                    if human_version is not None:
+                        item["human_version"] = human_version
+
                 min_version = item_elem.find(f"{{{self.xmlns}}}minimumSystemVersion")
                 if min_version is not None:
                     item["minimum_os_version"] = min_version.text


### PR DESCRIPTION
According to [Sparkle documentation](https://sparkle-project.org/documentation/publishing/), the

> Note on `sparkle:version`: Our previous documentation used to recommend specifying `sparkle:version` (and `sparkle:shortVersionString`) as part of the `enclosure` item. While this works fine, for overall consistency we now recommend specifying them as top level items instead as shown here. This is supported across all versions of Sparkle.

This note was [added](https://github.com/sparkle-project/sparkle-project.github.io/pull/73) in July 2021.

This PR adjusts SparkleUpdateInfoProvider to account for this change, by checking both the item and the enclosure for `version` and `shortVersionString` information. Resolves #839.

## Testing

Problem feed before change:

```
% ./Code/autopkg run -vv 'peetinc-recipes/Rectangle/Rectangle.download.recipe'
Processing peetinc-recipes/Rectangle/Rectangle.download.recipe...
WARNING: peetinc-recipes/Rectangle/Rectangle.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://rectangleapp.com/downloads/updates.xml'}}
Can't extract version info from item in feed!
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.download.Rectangle/receipts/Rectangle.download-receipt-20221119-100316.plist

The following recipes failed:
    peetinc-recipes/Rectangle/Rectangle.download.recipe
        Error in com.github.peetinc.download.Rectangle: Processor: SparkleUpdateInfoProvider: Error: Can't extract version info from item in feed!

Nothing downloaded, packaged or imported.
```

Problem feed after change:

```
% ./Code/autopkg run -vv 'peetinc-recipes/Rectangle/Rectangle.download.recipe'
Processing peetinc-recipes/Rectangle/Rectangle.download.recipe...
WARNING: peetinc-recipes/Rectangle/Rectangle.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://rectangleapp.com/downloads/updates.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 69
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 0.63
SparkleUpdateInfoProvider: Found URL https://github.com/rxhanson/Rectangle/releases/download/v0.63/Rectangle0.63.dmg
{'Output': {'url': 'https://github.com/rxhanson/Rectangle/releases/download/v0.63/Rectangle0.63.dmg',
            'version': '0.63'}}
URLDownloader
{'Input': {'filename': 'Rectangle-0.63.dmg',
           'url': 'https://github.com/rxhanson/Rectangle/releases/download/v0.63/Rectangle0.63.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 17 Nov 2022 02:04:03 GMT
URLDownloader: Storing new ETag header: "0x8DAC840000301BC"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.peetinc.download.Rectangle/downloads/Rectangle-0.63.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DAC840000301BC"',
            'last_modified': 'Thu, 17 Nov 2022 02:04:03 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Rectangle/downloads/Rectangle-0.63.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Rectangle/downloads/Rectangle-0.63.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Rectangle/downloads/Rectangle-0.63.dmg/Rectangle.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.knollsoft.Rectangle" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = XSYZ3E4B7D)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.download.Rectangle/downloads/Rectangle-0.63.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.9CmDMz/Rectangle.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.9CmDMz/Rectangle.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.9CmDMz/Rectangle.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.download.Rectangle/receipts/Rectangle.download-receipt-20221119-100408.plist

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    ~/Library/AutoPkg/Cache/com.github.peetinc.download.Rectangle/downloads/Rectangle-0.63.dmg
```

Previously working feed before change:

```
% ./Code/autopkg run -vv 'peetinc-recipes/Jumpcut/Jumpcut.download.recipe'    
Processing peetinc-recipes/Jumpcut/Jumpcut.download.recipe...
WARNING: peetinc-recipes/Jumpcut/Jumpcut.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://snark.github.io/jumpcut/jumpcut.appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 20220525
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 0.82
SparkleUpdateInfoProvider: Found URL https://github.com/snark/jumpcut/releases/download/v0.82/Jumpcut-0.82.tar.bz2
{'Output': {'url': 'https://github.com/snark/jumpcut/releases/download/v0.82/Jumpcut-0.82.tar.bz2',
            'version': '0.82'}}
URLDownloader
{'Input': {'filename': 'Jumpcut-0.82.tar.bz2',
           'url': 'https://github.com/snark/jumpcut/releases/download/v0.82/Jumpcut-0.82.tar.bz2'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 25 May 2022 11:44:35 GMT
URLDownloader: Storing new ETag header: "0x8DA3E43F11E848D"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2
{'Output': {'download_changed': True,
            'etag': '"0x8DA3E43F11E848D"',
            'last_modified': 'Wed, 25 May 2022 11:44:35 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename Jumpcut-0.82.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut/Jumpcut.app',
           'requirement': 'anchor apple generic and identifier '
                          '"net.sf.Jumpcut" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "4987SK7L6Z")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut/Jumpcut.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut/Jumpcut.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut/Jumpcut.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/receipts/Jumpcut.download-receipt-20221119-100727.plist

The following new items were downloaded:
    Download Path                                                                                            
    -------------                                                                                            
    ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2
```

Previously working feed after change:

```
% ./Code/autopkg run -vv 'peetinc-recipes/Jumpcut/Jumpcut.download.recipe'
Processing peetinc-recipes/Jumpcut/Jumpcut.download.recipe...
WARNING: peetinc-recipes/Jumpcut/Jumpcut.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://snark.github.io/jumpcut/jumpcut.appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 20220525
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 0.82
SparkleUpdateInfoProvider: Found URL https://github.com/snark/jumpcut/releases/download/v0.82/Jumpcut-0.82.tar.bz2
{'Output': {'url': 'https://github.com/snark/jumpcut/releases/download/v0.82/Jumpcut-0.82.tar.bz2',
            'version': '0.82'}}
URLDownloader
{'Input': {'filename': 'Jumpcut-0.82.tar.bz2',
           'url': 'https://github.com/snark/jumpcut/releases/download/v0.82/Jumpcut-0.82.tar.bz2'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename Jumpcut-0.82.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/downloads/Jumpcut-0.82.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut/Jumpcut.app',
           'requirement': 'anchor apple generic and identifier '
                          '"net.sf.Jumpcut" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "4987SK7L6Z")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut/Jumpcut.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut/Jumpcut.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/Jumpcut/Jumpcut.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.download.Jumpcut/receipts/Jumpcut.download-receipt-20221119-100825.plist

Nothing downloaded, packaged or imported.
```