### PR TITLE
Redesign SparkleUpdateInfoProvider channel support

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -233,7 +233,6 @@ class SparkleUpdateInfoProvider(URLGetter):
 
             item = {}
             item["url"] = self.build_url(enclosure)
-            item["version"] = self.determine_version(enclosure, item["url"])
 
             # version and shortVersionString can be either in item or in enclosure
             # https://sparkle-project.org/documentation/publishing/#update-your-appcast

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -262,10 +262,15 @@ class SparkleUpdateInfoProvider(URLGetter):
             # element text as we'll be passing this as an argument to a
             # curl process
             if description_elem is not None:
-                item["description_url"] = description_elem.text.strip()
+                item["description_url"] = description_elem.text
 
             if item_elem.find("description") is not None:
                 item["description_data"] = item_elem.find("description").text
+
+            # Strip values
+            for k, v in item.items():
+                if v is not None:
+                    item[k] = v.strip()
 
             versions.append(item)
 

--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -199,11 +199,21 @@ class SparkleUpdateInfoProvider(URLGetter):
             raise ProcessorError("Can't extract version info from item in feed!")
         return version
 
-    def parse_feed_xml(self, data):
-        """Parses feed xml to make sure valid xml, and checks each item for it's channel.
-        (if wanted)."""
+    def parse_feed_data(self, data):
+        """Returns an array of dicts, one per update item, structured like:
+        version: 1234
+        human_version: 1.2.3.4 (optional)
+        url: http://download/url.dmg
+        minimum_os_version: 10.7 (optional)
+        channel: beta (optional)
+        description_data: HTML description for update (optional)
+        description_url: URL given by the sparkle:releaseNotesLink element
+                         (optional)
 
-        feed_data = []
+        Note: Descriptions may be either given as a URL (usually the case) or as
+        raw HTML. We store one or the other rather than doing many GETs for
+        metadata we're never going to use. If it's a URL, this must be handled
+        by whoever calls this function."""
 
         try:
             xmldata = ElementTree.fromstring(data)
@@ -214,54 +224,19 @@ class SparkleUpdateInfoProvider(URLGetter):
         if not items:
             raise ProcessorError("No channel items were found in appcast feed.")
 
-        for item_elem in items:
-            # if we are to look for a specific channel
-            if "update_channel" in self.env:
-                # attempt to get the sparkle:channel element
-                item_channel = item_elem.find(f"{{{self.xmlns}}}channel")
-                # if no sparkle:channel element defined, or doesn't match the wanted channel
-                if (
-                    item_channel is None
-                    or item_channel.text != self.env["update_channel"]
-                ):
-                    continue
-                else:
-                    feed_data = self.parse_feed_data(item_elem)
-            # if no update channel
-            else:
-                feed_data = self.parse_feed_data(item_elem)
-
-        # if we do not have feed_data
-        if not feed_data:
-            raise ProcessorError("Could not obtain valid data from appcast feed.")
-        return feed_data
-
-    def parse_feed_data(self, item_elem):
-        """Returns an array of dicts, one per update item, structured like:
-        version: 1234
-        human_version: 1.2.3.4 (optional)
-        url: http://download/url.dmg
-        minimum_os_version: 10.7 (optional)
-        description_data: HTML description for update (optional)
-        description_url: URL given by the sparkle:releaseNotesLink element
-                         (optional)
-
-        Note: Descriptions may be either given as a URL (usually the case) or as
-        raw HTML. We store one or the other rather than doing many GETs for
-        metadata we're never going to use. If it's a URL, this must be handled
-        by whoever calls this function."""
-
         versions = []
+        for item_elem in items:
+            # Skip items with no enclosure
+            enclosure = item_elem.find("enclosure")
+            if enclosure is None:
+                continue
 
-        enclosure = item_elem.find("enclosure")
-
-        if enclosure is not None:
             item = {}
-
             item["url"] = self.build_url(enclosure)
+            item["version"] = self.determine_version(enclosure, item["url"])
 
             # version and shortVersionString can be either in item or in enclosure
-            # https://sparkle-project.org/documentation/publishing/
+            # https://sparkle-project.org/documentation/publishing/#update-your-appcast
             version = item_elem.find(f"{{{self.xmlns}}}version")
             if version is not None:
                 item["version"] = version.text
@@ -279,6 +254,10 @@ class SparkleUpdateInfoProvider(URLGetter):
             if min_version is not None:
                 item["minimum_os_version"] = min_version.text
 
+            channel = item_elem.find(f"{{{self.xmlns}}}channel")
+            if channel is not None:
+                item["channel"] = channel.text
+
             description_elem = item_elem.find(f"{{{self.xmlns}}}releaseNotesLink")
             # Strip possible surrounding whitespace around description_url
             # element text as we'll be passing this as an argument to a
@@ -288,6 +267,7 @@ class SparkleUpdateInfoProvider(URLGetter):
 
             if item_elem.find("description") is not None:
                 item["description_data"] = item_elem.find("description").text
+
             versions.append(item)
 
         return versions
@@ -347,10 +327,20 @@ class SparkleUpdateInfoProvider(URLGetter):
         self.xmlns = self.env.get("alternate_xmlns_url", DEFAULT_XMLNS)
 
         data = self.get_feed_data(self.env.get("appcast_url"))
-        items = self.parse_feed_xml(data)
+        items = self.parse_feed_data(data)
+        self.output(f"Items in feed: {len(items)}", verbose_level=1)
 
-        sorted_items = sorted(items, key=lambda a: APLooseVersion(a["version"]))
-        latest = sorted_items[-1]
+        # Filter items to desired channel
+        channel_name = self.env.get("update_channel") or "default"
+        if self.env.get("update_channel"):
+            items = [x for x in items if x.get("channel") == self.env["update_channel"]]
+        else:
+            items = [x for x in items if not x.get("channel")]
+        self.output(f"Items in {channel_name} channel: {len(items)}", verbose_level=1)
+        if not items:
+            raise ProcessorError(f"No items were found in {channel_name} channel.")
+
+        latest = max(items, key=lambda x: APLooseVersion(x["version"]))
         self.output(f"Version retrieved from appcast: {latest['version']}")
         if latest.get("human_version"):
             self.output(


### PR DESCRIPTION
## Summary

PR #834 introduced a bug in which only the _last_ item in a Sparkle feed was evaluated. This PR offers another method to accomplish the same goals for #834, while hopefully avoiding any regressions.

## 834 Regression

Just prior to #834's merge, SparkleUpdateInfoProvider correctly evaluated the "latest" version available in a multi-item Sparkle feed, as demonstrated below (2.2.0 is the latest version):

```
% git checkout 2007b522bded3d35509affc088f0e4b7f505ec35
HEAD is now at 2007b52 Autopkginstalld fix (#838)

% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Elliot Jordan/Recipe Robot.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Elliot Jordan/Recipe Robot.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Elliot Jordan/Recipe Robot.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': '[https://homebysix.github.io/recipe-robot/appcast.xml'}}](https://homebysix.github.io/recipe-robot/appcast.xml'%7D%7D)
SparkleUpdateInfoProvider: Version retrieved from appcast: 2.2.0
SparkleUpdateInfoProvider: Found URL https://github.com/homebysix/recipe-robot/releases/download/v2.2.0/RecipeRobot-2.2.0.dmg
{'Output': {'url': 'https://github.com/homebysix/recipe-robot/releases/download/v2.2.0/RecipeRobot-2.2.0.dmg',
            'version': '2.2.0'}}
URLDownloader
{'Input': {'filename': 'Recipe Robot-2.2.0.dmg',
           'url': '[https://github.com/homebysix/recipe-robot/releases/download/v2.2.0/RecipeRobot-2.2.0.dmg'}}](https://github.com/homebysix/recipe-robot/releases/download/v2.2.0/RecipeRobot-2.2.0.dmg'%7D%7D)
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.foo.download.RecipeRobot/downloads/Recipe Robot-2.2.0.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.foo.download.RecipeRobot/downloads/Recipe '
                        'Robot-2.2.0.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.RecipeRobot/receipts/Recipe Robot.download-receipt-20221128-112420.plist

Nothing downloaded, packaged or imported.
```

However, immediately after #834's merge, SparkleUpdateInfoProvider seems to only evaluate the last item in the feed, regardless of whether that item is the latest or earliest version of the software, as seen below (0.2.0 is the last item in the feed):

```
% git checkout 9c38c1d6dab87c28f31189b9df4f338904888ca4
Previous HEAD position was 2007b52 Autopkginstalld fix (#838)
HEAD is now at 9c38c1d Merge pull request #834 from macmule/master

% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Elliot Jordan/Recipe Robot.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Elliot Jordan/Recipe Robot.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Elliot Jordan/Recipe Robot.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': '[https://homebysix.github.io/recipe-robot/appcast.xml'}}](https://homebysix.github.io/recipe-robot/appcast.xml'%7D%7D)
SparkleUpdateInfoProvider: Version retrieved from appcast: 0.2.0
SparkleUpdateInfoProvider: Found URL https://github.com/homebysix/recipe-robot/releases/download/v0.2.0/RecipeRobot-0.2.0.dmg
{'Output': {'url': 'https://github.com/homebysix/recipe-robot/releases/download/v0.2.0/RecipeRobot-0.2.0.dmg',
            'version': '0.2.0'}}
URLDownloader
{'Input': {'filename': 'Recipe Robot-0.2.0.dmg',
           'url': '[https://github.com/homebysix/recipe-robot/releases/download/v0.2.0/RecipeRobot-0.2.0.dmg'}}](https://github.com/homebysix/recipe-robot/releases/download/v0.2.0/RecipeRobot-0.2.0.dmg'%7D%7D)
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.foo.download.RecipeRobot/downloads/Recipe Robot-0.2.0.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.foo.download.RecipeRobot/downloads/Recipe '
                        'Robot-0.2.0.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.RecipeRobot/receipts/Recipe Robot.download-receipt-20221128-112437.plist

Nothing downloaded, packaged or imported.
```

What led me to this discovery was CodeSignatureVerifier failing for a large number of recipes I was running during [Recipe Robot](https://github.com/homebysix/recipe-robot) functional testing (due to older releases of many apps, including Recipe Robot itself, being signed differently or unsigned).

## New approach

I started again from commit 2007b522bded3d35509affc088f0e4b7f505ec35 and approached channel support by adding a `item['channel']` value for each item in the feed that has a `<sparkle:channel>` element specified. Then, I filtered the feed items to the desired channel in the `main` function prior to using `max()` to evaluate the latest item.

This approach doesn't add any new functions to SparkleUpdateInfoProvider and reads a little easier than the two-function approach in #834. It has the beneficial side effect of omitting channel-specific items from consideration when no channel is specified, which would otherwise cause unwanted behavior if a beta item is listed as the "latest" in a given feed.

I tried to find as many Sparkle feeds that have a `<sparkle:channel>` specified for at least one item. I found 3 in the wild and 1 in Sparkle's documentation:
- https://raw.githubusercontent.com/dataJAR/Munki-Catalog-Browser/appcast/appcast.xml
- https://raw.githubusercontent.com/dataJAR/Jamf-Switcher/appcast/appcast.xml
- https://www.lemkesoft.info/sparkle/cadintosh/cadintosh.xml
- https://github.com/sparkle-project/Sparkle/blob/8cd13b0cfd8cb721a3221e1dc52c02f8473cda6a/TestApplication/sparkletestcast.xml

Some of these have a single `<channel>` element to contain all items regardless of which `<sparkle:channel>` they're in, and some have separate `<channel>` elements organized by `<sparkle:channel>`. This pull request should work fine with either method, as the Sparkle framework itself does.

I also added some output (verbose level ≥ 1) that lists the number of items in the Sparkle feed and in the desired channel, which should help with troubleshooting now that it's possible for a ProcessorError to be raised if a feed doesn't contain any items with the specified channel.

## Testing

### 1A: Single `<channel>` feed, no `update_channel`

**Feed URL:** https://s3-us-west-2.amazonaws.com/updateinfo.devmate.com/com.macpaw.site.theunarchiver/updates.xml
**Feed contents:** 11 items, all in default channel
**Expected behavior:** SparkleUpdateInfoProvider provides latest version 4.3.5
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq '~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver
.download.recipe'
Processing ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'curl/7.43.0'},
           'appcast_url': 'https://updates.devmate.com/com.macpaw.site.theunarchiver.xml'}}
SparkleUpdateInfoProvider: Items in feed: 11
SparkleUpdateInfoProvider: Items in default channel: 11
SparkleUpdateInfoProvider: Version retrieved from appcast: 139
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 4.3.5
SparkleUpdateInfoProvider: Found URL https://dl.devmate.com/com.macpaw.site.theunarchiver/139/1652457131/TheUnarchiver-139.zip
{'Output': {'url': 'https://dl.devmate.com/com.macpaw.site.theunarchiver/139/1652457131/TheUnarchiver-139.zip',
            'version': '4.3.5'}}
URLDownloader
{'Input': {'url': 'https://dl.devmate.com/com.macpaw.site.theunarchiver/139/1652457131/TheUnarchiver-139.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 09 Nov 2022 14:15:21 GMT
URLDownloader: Storing new ETag header: "92f77d443ec29c6ae5ff3715f677bb06"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/downloads/TheUnarchiver-139.zip
{'Output': {'download_changed': True,
            'etag': '"92f77d443ec29c6ae5ff3715f677bb06"',
            'last_modified': 'Wed, 09 Nov 2022 14:15:21 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/downloads/TheUnarchiver-139.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/downloads/TheUnarchiver-139.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/receipts/TheUnarchiver.download-receipt-20221128-145112.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/downloads/TheUnarchiver-139.zip
```

### 1B: Single `<channel>` feed, blank `update_channel` input

**Feed URL:**
**Feed contents:** 11 items, all in default channel
**Expected behavior:** SparkleUpdateInfoProvider provides latest version 4.3.5
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe"
Processing ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'curl/7.43.0'},
           'appcast_url': 'https://updates.devmate.com/com.macpaw.site.theunarchiver.xml',
           'update_channel': ''}}
SparkleUpdateInfoProvider: Items in feed: 11
SparkleUpdateInfoProvider: Items in default channel: 11
SparkleUpdateInfoProvider: Version retrieved from appcast: 139
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 4.3.5
SparkleUpdateInfoProvider: Found URL https://dl.devmate.com/com.macpaw.site.theunarchiver/139/1652457131/TheUnarchiver-139.zip
{'Output': {'url': 'https://dl.devmate.com/com.macpaw.site.theunarchiver/139/1652457131/TheUnarchiver-139.zip',
            'version': '4.3.5'}}
URLDownloader
{'Input': {'url': 'https://dl.devmate.com/com.macpaw.site.theunarchiver/139/1652457131/TheUnarchiver-139.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/downloads/TheUnarchiver-139.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/downloads/TheUnarchiver-139.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/receipts/TheUnarchiver.download-receipt-20221128-145343.plist

Nothing downloaded, packaged or imported.
```

### 1C: Single `<channel>` feed, `update_channel` set to `beta`

**Feed URL:**
**Feed contents:** 11 items, all in default channel
**Expected behavior:** SparkleUpdateInfoProvider raises ProcessorError
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe"
Processing ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'curl/7.43.0'},
           'appcast_url': 'https://updates.devmate.com/com.macpaw.site.theunarchiver.xml',
           'update_channel': 'beta'}}
SparkleUpdateInfoProvider: Items in feed: 11
SparkleUpdateInfoProvider: Items in beta channel: 0
No items were found in beta channel.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/receipts/TheUnarchiver.download-receipt-20221128-145636.plist

The following recipes failed:
    ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe
        Error in com.github.autopkg.download.TheUnarchiver: Processor: SparkleUpdateInfoProvider: Error: No items were found in beta channel.

Nothing downloaded, packaged or imported.
```

### 1D: Single `<channel>` feed, `update_channel` set to `bogus`

**Feed URL:**
**Feed contents:** 11 items, all in default channel
**Expected behavior:** SparkleUpdateInfoProvider raises ProcessorError
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe"
Processing ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_request_headers': {'User-Agent': 'curl/7.43.0'},
           'appcast_url': 'https://updates.devmate.com/com.macpaw.site.theunarchiver.xml',
           'update_channel': 'bogus'}}
SparkleUpdateInfoProvider: Items in feed: 11
SparkleUpdateInfoProvider: Items in bogus channel: 0
No items were found in bogus channel.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.download.TheUnarchiver/receipts/TheUnarchiver.download-receipt-20221128-145818.plist

The following recipes failed:
    ~/Library/AutoPkg/Recipes/The Unarchiver/TheUnarchiver.download.recipe
        Error in com.github.autopkg.download.TheUnarchiver: Processor: SparkleUpdateInfoProvider: Error: No items were found in bogus channel.

Nothing downloaded, packaged or imported.
```

### 2A: Multi `<channel>` feed, no `update_channel`

**Feed URL:** https://raw.githubusercontent.com/dataJAR/Munki-Catalog-Browser/appcast/appcast.xml
**Feed contents:** 2 items: 1 in default channel, 1 in `beta` channel
**Expected behavior:** SparkleUpdateInfoProvider provides latest version 1.3 (non-beta)
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.githubusercontent.com/dataJAR/Munki-Catalog-Browser/appcast/appcast.xml'}}
SparkleUpdateInfoProvider: Items in feed: 2
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 93
SparkleUpdateInfoProvider: Found URL https://github.com/dataJAR/Munki-Catalog-Browser/releases/download/1.3/Munki.Catalog.Browser.zip
{'Output': {'url': 'https://github.com/dataJAR/Munki-Catalog-Browser/releases/download/1.3/Munki.Catalog.Browser.zip',
            'version': '93'}}
URLDownloader
{'Input': {'filename': 'Munki Catalog Browser-93.zip',
           'url': 'https://github.com/dataJAR/Munki-Catalog-Browser/releases/download/1.3/Munki.Catalog.Browser.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/downloads/Munki Catalog Browser-93.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/downloads/Munki '
                        'Catalog Browser-93.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/receipts/Munki Catalog Browser.download-receipt-20221128-150250.plist

Nothing downloaded, packaged or imported.
```

### 2B: Multi `<channel>` feed, blank `update_channel` input

**Feed URL:** https://raw.githubusercontent.com/dataJAR/Munki-Catalog-Browser/appcast/appcast.xml
**Feed contents:** 2 items: 1 in default channel, 1 in `beta` channel
**Expected behavior:** SparkleUpdateInfoProvider provides latest version 1.3 (non-beta)
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.githubusercontent.com/dataJAR/Munki-Catalog-Browser/appcast/appcast.xml',
           'update_channel': ''}}
SparkleUpdateInfoProvider: Items in feed: 2
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 93
SparkleUpdateInfoProvider: Found URL https://github.com/dataJAR/Munki-Catalog-Browser/releases/download/1.3/Munki.Catalog.Browser.zip
{'Output': {'url': 'https://github.com/dataJAR/Munki-Catalog-Browser/releases/download/1.3/Munki.Catalog.Browser.zip',
            'version': '93'}}
URLDownloader
{'Input': {'filename': 'Munki Catalog Browser-93.zip',
           'url': 'https://github.com/dataJAR/Munki-Catalog-Browser/releases/download/1.3/Munki.Catalog.Browser.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/downloads/Munki Catalog Browser-93.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/downloads/Munki '
                        'Catalog Browser-93.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/receipts/Munki Catalog Browser.download-receipt-20221128-150335.plist

Nothing downloaded, packaged or imported.
```

### 2C: Multi `<channel>` feed, `update_channel` set to `beta`

**Feed URL:** https://raw.githubusercontent.com/dataJAR/Munki-Catalog-Browser/appcast/appcast.xml
**Feed contents:** 2 items: 1 in default channel, 1 in `beta` channel
**Expected behavior:** SparkleUpdateInfoProvider provides latest version 1.3-beta1
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.githubusercontent.com/dataJAR/Munki-Catalog-Browser/appcast/appcast.xml',
           'update_channel': 'beta'}}
SparkleUpdateInfoProvider: Items in feed: 2
SparkleUpdateInfoProvider: Items in beta channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 93
SparkleUpdateInfoProvider: Found URL https://github.com/dataJAR/Munki-Catalog-Browser/releases/download/1.3-beta1/Munki.Catalog.Browser.zip
{'Output': {'url': 'https://github.com/dataJAR/Munki-Catalog-Browser/releases/download/1.3-beta1/Munki.Catalog.Browser.zip',
            'version': '93'}}
URLDownloader
{'Input': {'filename': 'Munki Catalog Browser-93.zip',
           'url': 'https://github.com/dataJAR/Munki-Catalog-Browser/releases/download/1.3-beta1/Munki.Catalog.Browser.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 28 Oct 2022 13:28:26 GMT
URLDownloader: Storing new ETag header: "0x8DAB8E84BB11758"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/downloads/Munki Catalog Browser-93.zip
{'Output': {'download_changed': True,
            'etag': '"0x8DAB8E84BB11758"',
            'last_modified': 'Fri, 28 Oct 2022 13:28:26 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/downloads/Munki '
                        'Catalog Browser-93.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/downloads/Munki '
                                                                        'Catalog '
                                                                        'Browser-93.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/receipts/Munki Catalog Browser.download-receipt-20221128-150414.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/downloads/Munki Catalog Browser-93.zip
```

### 2D: Multi `<channel>` feed, `update_channel` set to `bogus`

**Feed URL:** https://raw.githubusercontent.com/dataJAR/Munki-Catalog-Browser/appcast/appcast.xml
**Feed contents:** 2 items: 1 in default channel, 1 in `beta` channel
**Expected behavior:** SparkleUpdateInfoProvider raises ProcessorError
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://raw.githubusercontent.com/dataJAR/Munki-Catalog-Browser/appcast/appcast.xml',
           'update_channel': 'bogus'}}
SparkleUpdateInfoProvider: Items in feed: 2
SparkleUpdateInfoProvider: Items in bogus channel: 0
No items were found in bogus channel.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.MunkiCatalogBrowser/receipts/Munki Catalog Browser.download-receipt-20221128-150450.plist

The following recipes failed:
    ~/Library/AutoPkg/Recipes/Data JAR/Munki Catalog Browser.download.recipe
        Error in com.github.foo.download.MunkiCatalogBrowser: Processor: SparkleUpdateInfoProvider: Error: No items were found in bogus channel.

Nothing downloaded, packaged or imported.
```

### 3A: Single `<channel>` feed, `<sparkle:channel>` used, no `update_channel`

**Feed URL:** https://www.lemkesoft.info/sparkle/cadintosh/cadintosh.xml
**Feed contents:** 17 items: 16 in default channel, 1 in `beta` channel
**Expected behavior:** SparkleUpdateInfoProvider provides latest version 8.8.2
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.lemkesoft.info/sparkle/cadintosh/cadintosh.xml'}}
SparkleUpdateInfoProvider: Items in feed: 17
SparkleUpdateInfoProvider: Items in default channel: 16
SparkleUpdateInfoProvider: Version retrieved from appcast: 653
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 8.8.2
SparkleUpdateInfoProvider: Found URL https://www.lemkesoft.info/files/cadintosh/cad8_build653.zip
{'Output': {'url': 'https://www.lemkesoft.info/files/cadintosh/cad8_build653.zip',
            'version': '8.8.2'}}
URLDownloader
{'Input': {'filename': 'CADintosh X-8.8.2.gzip',
           'url': 'https://www.lemkesoft.info/files/cadintosh/cad8_build653.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/downloads/CADintosh X-8.8.2.gzip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/downloads/CADintosh '
                        'X-8.8.2.gzip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/receipts/CADintosh X.download-receipt-20221128-150609.plist

Nothing downloaded, packaged or imported.
```

### 3B: Single `<channel>` feed, `<sparkle:channel>` used, blank `update_channel` input

**Feed URL:** https://www.lemkesoft.info/sparkle/cadintosh/cadintosh.xml
**Feed contents:** 17 items: 16 in default channel, 1 in `beta` channel
**Expected behavior:** SparkleUpdateInfoProvider provides latest version 8.8.2
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.lemkesoft.info/sparkle/cadintosh/cadintosh.xml',
           'update_channel': ''}}
SparkleUpdateInfoProvider: Items in feed: 17
SparkleUpdateInfoProvider: Items in default channel: 16
SparkleUpdateInfoProvider: Version retrieved from appcast: 653
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 8.8.2
SparkleUpdateInfoProvider: Found URL https://www.lemkesoft.info/files/cadintosh/cad8_build653.zip
{'Output': {'url': 'https://www.lemkesoft.info/files/cadintosh/cad8_build653.zip',
            'version': '8.8.2'}}
URLDownloader
{'Input': {'filename': 'CADintosh X-8.8.2.gzip',
           'url': 'https://www.lemkesoft.info/files/cadintosh/cad8_build653.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/downloads/CADintosh X-8.8.2.gzip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/downloads/CADintosh '
                        'X-8.8.2.gzip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/receipts/CADintosh X.download-receipt-20221128-150724.plist

Nothing downloaded, packaged or imported.
```

### 3C: Single `<channel>` feed, `<sparkle:channel>` used, `update_channel` set to `beta`

**Feed URL:** https://www.lemkesoft.info/sparkle/cadintosh/cadintosh.xml
**Feed contents:** 17 items: 16 in default channel, 1 in `beta` channel
**Expected behavior:** SparkleUpdateInfoProvider provides latest beta version 8.8.3
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.lemkesoft.info/sparkle/cadintosh/cadintosh.xml',
           'update_channel': 'beta'}}
SparkleUpdateInfoProvider: Items in feed: 17
SparkleUpdateInfoProvider: Items in beta channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 656
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 8.8.3
SparkleUpdateInfoProvider: Found URL https://www.lemkesoft.org/beta/cad8_build656.zip
{'Output': {'url': 'https://www.lemkesoft.org/beta/cad8_build656.zip',
            'version': '8.8.3'}}
URLDownloader
{'Input': {'filename': 'CADintosh X-8.8.3.gzip',
           'url': 'https://www.lemkesoft.org/beta/cad8_build656.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/downloads/CADintosh X-8.8.3.gzip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/downloads/CADintosh '
                        'X-8.8.3.gzip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/receipts/CADintosh X.download-receipt-20221128-150842.plist

Nothing downloaded, packaged or imported.
```

### 3D: Single `<channel>` feed, `<sparkle:channel>` used, `update_channel` set to `bogus`

**Feed URL:** https://www.lemkesoft.info/sparkle/cadintosh/cadintosh.xml
**Feed contents:** 17 items: 16 in default channel, 1 in `beta` channel
**Expected behavior:** SparkleUpdateInfoProvider raises ProcessorError
**Actual behavior:** ✅ Same as expected
**Test output below:**

```
% ./Code/autopkg run -vvcq "~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe"
Processing ~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe...
WARNING: ~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.lemkesoft.info/sparkle/cadintosh/cadintosh.xml',
           'update_channel': 'bogus'}}
SparkleUpdateInfoProvider: Items in feed: 17
SparkleUpdateInfoProvider: Items in bogus channel: 0
No items were found in bogus channel.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.foo.download.CADintoshX/receipts/CADintosh X.download-receipt-20221128-150911.plist

The following recipes failed:
    ~/Library/AutoPkg/Recipes/Lemke Software/CADintosh X.download.recipe
        Error in com.github.foo.download.CADintoshX: Processor: SparkleUpdateInfoProvider: Error: No items were found in bogus channel.

Nothing downloaded, packaged or imported.
```

### 4: Random SparkleUpdateInfoProvider recipe tests

I ran this version of SparkleUpdateInfoProvider against 100 randomly chosen (but operational as of AutoPkg 2.7) Sparkle-feed-using download recipes in the AutoPkg org with no `update_channel` specified. I repeated these runs with `update_channel` set to `bogus`. In all cases, the expected results were seen.

| Recipe path                                                                                       |     No Channel     |  `bogus` Channel   |
| ------------------------------------------------------------------------------------------------- | :----------------: | :----------------: |
| arubdesu-recipes/Reflector/Reflector.download.recipe                                              | Passed as expected | Failed as expected |
| jleggat-recipes/SequelPro/SequelPro.download.recipe                                               | Passed as expected | Failed as expected |
| homebysix-recipes/CocoaRestClient/CocoaRestClient.download.recipe                                 | Passed as expected | Failed as expected |
| jazzace-recipes/GardenGnome/Pano2VR.download.recipe                                               | Passed as expected | Failed as expected |
| homebysix-recipes/LiteratureAndLatte/Scapple.download.recipe                                      | Passed as expected | Failed as expected |
| recipes/XLD/XLD.download.recipe                                                                   | Passed as expected | Failed as expected |
| macprince-recipes/Kuta Software/Infinite Precalculus.download.recipe                              | Passed as expected | Failed as expected |
| moofit-recipes/CloudMounter/CloudMounter.download.recipe                                          | Passed as expected | Failed as expected |
| dataJAR-recipes/Noun Project/Noun Project.download.recipe                                         | Passed as expected | Failed as expected |
| dataJAR-recipes/BrightPay UK 2021-22/BrightPay UK 2021-22.download.recipe                         | Passed as expected | Failed as expected |
| ahousseini-recipes/Script Debugger/Script Debugger.download.recipe                                | Passed as expected | Failed as expected |
| dataJAR-recipes/QLab5/QLab5.download.recipe                                                       | Passed as expected | Failed as expected |
| homebysix-recipes/AppZapper/AppZapper.download.recipe                                             | Passed as expected | Failed as expected |
| homebysix-recipes/InsiliCo/CodeCookbookforSwift.download.recipe                                   | Passed as expected | Failed as expected |
| hjuutilainen-recipes/Kapeli/Dash3.download.recipe                                                 | Passed as expected | Failed as expected |
| macprince-recipes/Kuta Software/Infinite Pre-Algebra.download.recipe                              | Passed as expected | Failed as expected |
| homebysix-recipes/FontFinagler/FontFinagler.download.recipe                                       | Passed as expected | Failed as expected |
| dataJAR-recipes/Catalyst Prepare/Catalyst Prepare.download.recipe                                 | Passed as expected | Failed as expected |
| vmiller-recipes/SimBio/SimUText 2021-2022.download.recipe                                         | Passed as expected | Failed as expected |
| foigus-recipes/X-Rite/i1Studio.download.recipe                                                    | Passed as expected | Failed as expected |
| orchard-recipes/ReflectorTeacher/ReflectorTeacher.download.recipe                                 | Passed as expected | Failed as expected |
| recipes/The Unarchiver/TheUnarchiver.download.recipe                                              | Passed as expected | Failed as expected |
| jaharmi-recipes/RogueAmoeba/SoundSource.download.recipe                                           | Passed as expected | Failed as expected |
| dataJAR-recipes/Any Video Converter Free for Mac/Any Video Converter Free for Mac.download.recipe | Passed as expected | Failed as expected |
| flammable-recipes/Macroplant LLC/iExplorer.download.recipe                                        | Passed as expected | Failed as expected |
| jaharmi-recipes/MOSO/Xmplify.download.recipe                                                      | Passed as expected | Failed as expected |
| ygini-recipes/Techno-Grafik Christian Lackner eU/iTaskX3.download.recipe                          | Passed as expected | Failed as expected |
| moofit-recipes/BlueJeans/bluejeans.download.recipe                                                | Passed as expected | Failed as expected |
| andrewvalentine-recipes/FBMacMessenger/FBMacMessenger.download.recipe                             | Passed as expected | Failed as expected |
| homebysix-recipes/ClamXav/ClamXav.download.recipe                                                 | Passed as expected | Failed as expected |
| keeleysam-recipes/CoRD/CoRD.download.recipe                                                       | Passed as expected | Failed as expected |
| dataJAR-recipes/Narrated/Narrated.download.recipe                                                 | Passed as expected | Failed as expected |
| hjuutilainen-recipes/Kaleidoscope/Kaleidoscope.download.recipe                                    | Passed as expected | Failed as expected |
| hjuutilainen-recipes/GitUp/GitUp.download.recipe                                                  | Passed as expected | Failed as expected |
| homebysix-recipes/Royal/RoyalTSX.download.recipe                                                  | Passed as expected | Failed as expected |
| flammable-recipes/Syntax Highlight/Syntax Highlight.download.recipe                               | Passed as expected | Failed as expected |
| peetinc-recipes/MacUpdater/MacUpdater.download.recipe                                             | Passed as expected | Failed as expected |
| bochoven-recipes/SURFdrive/surfdrive.download.recipe                                              | Passed as expected | Failed as expected |
| foigus-recipes/BohemianCoding/Sketch.download.recipe                                              | Passed as expected | Failed as expected |
| homebysix-recipes/Screens/Screens.download.recipe                                                 | Passed as expected | Failed as expected |
| andrewvalentine-recipes/PocketCasts/PocketCasts.download.recipe                                   | Passed as expected | Failed as expected |
| homebysix-recipes/MacPaw/CleanMyMac2.download.recipe                                              | Passed as expected | Failed as expected |
| watchmanmonitoring-recipes/backupminder/BackupMinder.download.recipe                              | Passed as expected | Failed as expected |
| dataJAR-recipes/reMarkable/reMarkable.download.recipe                                             | Passed as expected | Failed as expected |
| keeleysam-recipes/Mailplane/Mailplane3.download.recipe                                            | Passed as expected | Failed as expected |
| ahousseini-recipes/STARFACE/STARFACE.download.recipe                                              | Passed as expected | Failed as expected |
| n8felton-recipes/PAUP/PAUP.download.recipe                                                        | Passed as expected | Failed as expected |
| timsutton-recipes/HopperDisassembler/HopperDisassembler4.download.recipe                          | Passed as expected | Failed as expected |
| golbiga-recipes/Airtool/Airtool.download.recipe                                                   | Passed as expected | Failed as expected |
| foigus-recipes/Invision/CraftManager.download.recipe                                              | Passed as expected | Failed as expected |
| ctueck-recipes/Syncthing/Syncthing.download.recipe                                                | Passed as expected | Failed as expected |
| macprince-recipes/Adrian Granados/WiFi Explorer Pro.download.recipe                               | Passed as expected | Failed as expected |
| homebysix-recipes/InsiliCo/iSwift.download.recipe                                                 | Passed as expected | Failed as expected |
| ahousseini-recipes/MountainDuck/MountainDuck.download.recipe                                      | Passed as expected | Failed as expected |
| flammable-recipes/Bananafish Software/Spillo.download.recipe                                      | Passed as expected | Failed as expected |
| rtrouton-recipes/iMazingProfileEditor/iMazingProfileEditor.download.recipe                        | Passed as expected | Failed as expected |
| homebysix-recipes/SuperMegaUltraGroovy/TapeDeck.download.recipe                                   | Passed as expected | Failed as expected |
| jaharmi-recipes/Boinx/BoinxTV.download.recipe                                                     | Passed as expected | Failed as expected |
| andrewvalentine-recipes/Texts/Texts.download.recipe                                               | Passed as expected | Failed as expected |
| wegotoeleven-recipes/Docker/DockerUniversal.download.recipe.yaml                                  | Passed as expected | Failed as expected |
| peetinc-recipes/OndrejFlorian/VipRiser.download.recipe                                            | Passed as expected | Failed as expected |
| ahousseini-recipes/Comic Life/Comic Life.download.recipe                                          | Passed as expected | Failed as expected |
| vmiller-recipes/SimBio/SimUText.download.recipe                                                   | Passed as expected | Failed as expected |
| dataJAR-recipes/FontLab 7-Trial/FontLab 7-Trial.download.recipe                                   | Passed as expected | Failed as expected |
| ahousseini-recipes/Transfer/Transfer.download.recipe                                              | Passed as expected | Failed as expected |
| macprince-recipes/Tupil/Beamer.download.recipe                                                    | Passed as expected | Failed as expected |
| hjuutilainen-recipes/BibDesk/BibDesk.download.recipe                                              | Passed as expected | Failed as expected |
| macvfx-recipes/CompressorRepair/CompressorRepair.download.recipe                                  | Passed as expected | Failed as expected |
| homebysix-recipes/iManage/iManageWorkDesktop.download.recipe                                      | Passed as expected | Failed as expected |
| watchmanmonitoring-recipes/monitoringclient/MonitoringClient.download.recipe                      | Passed as expected | Failed as expected |
| jaharmi-recipes/Bahoom/HyperSwitch.download.recipe                                                | Passed as expected | Failed as expected |
| ahousseini-recipes/ElmediaPlayer/ElmediaPlayer.download.recipe                                    | Passed as expected | Failed as expected |
| dataJAR-recipes/Osculator 3/Osculator 3.download.recipe                                           | Passed as expected | Failed as expected |
| dataJAR-recipes/Hudl SportsCode 12/Hudl SportsCode 12.download.recipe                             | Passed as expected | Failed as expected |
| homebysix-recipes/Tunabelly/SilentStart.download.recipe                                           | Passed as expected | Failed as expected |
| dataJAR-recipes/Connect Fonts/Connect Fonts.download.recipe                                       | Passed as expected | Failed as expected |
| timsutton-recipes/Glyphs/Glyphs2.download.recipe                                                  | Passed as expected | Failed as expected |
| foigus-recipes/AdrianStutz/MPlayerOSXExtended.download.recipe                                     | Passed as expected | Failed as expected |
| homebysix-recipes/CaseApps/Tags.download.recipe                                                   | Passed as expected | Failed as expected |
| jaharmi-recipes/AkihiroNoguchi/Shiori.download.recipe                                             | Passed as expected | Failed as expected |
| kevinmcox-recipes/Yuji Tachikawa/MenuMeters.download.recipe                                       | Passed as expected | Failed as expected |
| dataJAR-recipes/Blue Jeans Scheduler for Mac/Blue Jeans Scheduler for Mac.download.recipe         | Passed as expected | Failed as expected |
| macprince-recipes/Edovia/Screens Connect.download.recipe                                          | Passed as expected | Failed as expected |
| homebysix-recipes/Warewolf/Espresso.download.recipe                                               | Passed as expected | Failed as expected |
| peetinc-recipes/Jumpcut/Jumpcut.download.recipe                                                   | Passed as expected | Failed as expected |
| jaharmi-recipes/AptonicLimited/Dropzone.download.recipe                                           | Passed as expected | Failed as expected |
| keeleysam-recipes/SublimeText/SublimeText3.download.recipe                                        | Passed as expected | Failed as expected |
| macprince-recipes/Corsair Memory Inc/ElgatoControlCenter.download.recipe                          | Passed as expected | Failed as expected |
| homebysix-recipes/Reinvented/Together.download.recipe                                             | Passed as expected | Failed as expected |
| homebysix-recipes/XcodesApp/XcodesApp.download.recipe                                             | Passed as expected | Failed as expected |
| macvfx-recipes/X27/X27.download.recipe                                                            | Passed as expected | Failed as expected |
| precursorca-recipes/St. Clair Software/Go64.download.recipe                                       | Passed as expected | Failed as expected |
| n8felton-recipes/Flixel/Cinemagraph Pro.download.recipe                                           | Passed as expected | Failed as expected |
| faumac-recipes/Sourcetree/Sourcetree.download.recipe                                              | Passed as expected | Failed as expected |
| dataJAR-recipes/Suitcase Fusion 21/Suitcase Fusion 21.download.recipe                             | Passed as expected | Failed as expected |
| ahousseini-recipes/StatusBuddy/StatusBuddy.download.recipe                                        | Passed as expected | Failed as expected |
| hjuutilainen-recipes/CheatSheet/CheatSheet.download.recipe                                        | Passed as expected | Failed as expected |
| jazzace-recipes/X-Rite/i1profiler.download.recipe                                                 | Passed as expected | Failed as expected |
| homebysix-recipes/Reinvented/Feeder4.download.recipe                                              | Passed as expected | Failed as expected |
| homebysix-recipes/Endurance/Endurance.download.recipe                                             | Passed as expected | Failed as expected |
