### PR TITLE
Add back error handing to address issue 822

### DIFF
--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -168,6 +168,7 @@ class URLGetter(Processor):
 
     def execute_curl(self, curl_cmd, text=True):
         """Execute curl command. Return stdout, stderr and return code."""
+        errors = "ignore" if text else None
         try:
             result = subprocess.run(
                 curl_cmd,
@@ -175,6 +176,7 @@ class URLGetter(Processor):
                 capture_output=True,
                 check=True,
                 text=text,
+                errors=errors,
             )
         except subprocess.CalledProcessError as e:
             self.output(f"ERROR: {e.stderr.removeprefix('curl: ')}")


### PR DESCRIPTION
This addresses issue #822 by adding back in the two lines of code from https://github.com/autopkg/autopkg/commit/ce72f18af711b8c3269fc399424f7859bc8e1b0b that we removed in a later commit.

I've been running this patch locally for several months without issue.  I've attached a before and after verbose run on a recipe that triggers the problem.
[output-before.txt](https://github.com/autopkg/autopkg/files/10239748/output-before.txt)
[output-after.txt](https://github.com/autopkg/autopkg/files/10239750/output-after.txt)
