### PR TITLE
Use cached index instead of GitHub API for recipe search

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -209,6 +209,7 @@ def get_identifier_from_override(override):
 
 def get_repository_from_identifier(identifier: str):
     """Get a repository name from a recipe identifier."""
+    # TODO: Switch to new indexed search.
     results = GitHubSession().search_for_name(identifier)
     # so now we have a list of items containing file names and URLs
     # we want to fetch these so we can look inside the contents for a matching
@@ -288,6 +289,7 @@ def locate_recipe(
                 repo_names = [parent_repo] if parent_repo else []
 
             if not repo_names:
+                # TODO: Switch to new indexed search.
                 results_items = GitHubSession().search_for_name(name)
                 print_gh_search_results(results_items)
                 # make a list of unique repo names

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -34,7 +34,12 @@ from typing import Optional
 from urllib.parse import quote, urlparse
 
 import yaml
-from autopkgcmd import common_parse, gen_common_parser, search_recipes
+from autopkgcmd import (
+    common_parse,
+    gen_common_parser,
+    new_search_recipes,
+    search_recipes,
+)
 from autopkglib import (
     RECIPE_EXTS,
     AutoPackager,
@@ -2735,6 +2740,11 @@ def main(argv):
         },
         "run": {"function": run_recipes, "help": "Run one or more recipes"},
         "search": {"function": search_recipes, "help": "Search for recipes on GitHub."},
+        "new-search": {
+            "function": new_search_recipes,
+            "help": "Search recipes in the AutoPkg org on GitHub using a cached index "
+            "file. (Candidate to replace the `search` verb.)",
+        },
         "update-trust-info": {
             "function": update_trust_info,
             "help": (

--- a/Code/autopkgcmd/__init__.py
+++ b/Code/autopkgcmd/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 from autopkgcmd.opts import common_parse, gen_common_parser
-from autopkgcmd.searchcmd import search_recipes
+from autopkgcmd.searchcmd import new_search_recipes, search_recipes
 
-__all__ = ["search_recipes", "gen_common_parser", "common_parse"]
+__all__ = ["new_search_recipes", "search_recipes", "gen_common_parser", "common_parse"]

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -107,9 +107,7 @@ def check_search_cache(cache_path):
     """Update local search index, if it's missing or out of date."""
 
     gh = GitHubSession()
-    cache_endpoint = (
-        "/repos/homebysix/autopkg-recipe-index/contents/index.json?ref=main"
-    )
+    cache_endpoint = "/repos/autopkg/index/contents/index.json?ref=main"
 
     # Retrieve metadata about search index file from GitHub API
     cache_meta = gh.call_api(cache_endpoint, accept="application/vnd.github.v3+json")

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -214,7 +214,7 @@ def new_search_recipes(argv: List[str]):
             result_ids.extend(identifiers)
 
     # Perform the search against other recipe info
-    searchable_keys = ("name", "description", "munki_display_name", "munki_description")
+    searchable_keys = ("name", "munki_display_name", "jamf_display_name")
     for identifier, info in search_index["identifiers"].items():
         if info.get("deprecated"):
             continue

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -241,10 +241,10 @@ def new_search_recipes(argv: List[str]):
         for i in range(0, len(header_items))
     ]
 
-    # Print result table
+    # Print result table, sorted by repo
     print()
     print(get_table_row(header_items, col_widths, header=True))
-    for row in result_items:
+    for row in sorted(result_items, key=lambda x: x[1].lower()):
         print(get_table_row(row, col_widths))
     print()
     print("To add a new recipe repo, use 'autopkg repo-add <repo name>'")

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -224,8 +224,7 @@ def new_search_recipes(argv: List[str]):
                     result_ids.append(identifier)
     if not result_ids:
         return 2
-    else:
-        result_ids = list(set(result_ids))
+    result_ids = list(set(result_ids))
 
     # Collect result info into result list
     header_items = ("Name", "Repo", "Path")

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -229,14 +229,15 @@ def new_search_recipes(argv: List[str]):
         result_ids = list(set(result_ids))
 
     # Collect result info into result list
-    header_items = ("Identifier", "Repo", "Path")
+    header_items = ("Name", "Repo", "Path")
     result_items = []
     for result_id in result_ids:
+        name = os.path.split(search_index["identifiers"][result_id]["path"])[-1]
         repo = search_index["identifiers"][result_id]["repo"]
         path = search_index["identifiers"][result_id]["path"]
         if repo.startswith("autopkg/"):
             repo = repo.replace("autopkg/", "")
-        result_items.append((result_id, repo, path))
+        result_items.append((name, repo, path))
     col_widths = [
         max([len(x[i]) for x in result_items] + [len(header_items[i])])
         for i in range(0, len(header_items))

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -127,7 +127,7 @@ def check_search_cache(cache_path):
     if cache_meta[0]["size"] > (90 * 1024 * 1024):
         print(search_index_size_msg % "nearing")
     elif cache_meta[0]["size"] > (100 * 1024 * 1024):
-        print(search_index_size_msg % "greater than")
+        log_err(search_index_size_msg % "greater than")
 
     # If cache exists locally, check whether it's current
     if os.path.isfile(cache_path) and os.path.isfile(cache_path + ".etag"):
@@ -223,6 +223,7 @@ def new_search_recipes(argv: List[str]):
                 if normalize_keyword(arguments[0]) in normalize_keyword(info[key]):
                     result_ids.append(identifier)
     if not result_ids:
+        log_err("Nothing found.")
         return 2
     result_ids = list(set(result_ids))
 

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -228,25 +228,27 @@ def new_search_recipes(argv: List[str]):
     result_ids = list(set(result_ids))
 
     # Collect result info into result list
-    header_items = ("Name", "Repo", "Path")
     result_items = []
     for result_id in result_ids:
-        name = os.path.split(search_index["identifiers"][result_id]["path"])[-1]
         repo = search_index["identifiers"][result_id]["repo"]
-        path = search_index["identifiers"][result_id]["path"]
         if repo.startswith("autopkg/"):
             repo = repo.replace("autopkg/", "")
-        result_items.append((name, repo, path))
+        result_item = {
+            "Name": os.path.split(search_index["identifiers"][result_id]["path"])[-1],
+            "Repo": repo,
+            "Path": search_index["identifiers"][result_id]["path"],
+        }
+        result_items.append(result_item)
     col_widths = [
-        max([len(x[i]) for x in result_items] + [len(header_items[i])])
-        for i in range(0, len(header_items))
+        max([len(x[k]) for x in result_items] + [len(k)])
+        for k in result_items[0].keys()
     ]
 
     # Print result table, sorted by repo
     print()
-    print(get_table_row(header_items, col_widths, header=True))
-    for row in sorted(result_items, key=lambda x: x[1].lower()):
-        print(get_table_row(row, col_widths))
+    print(get_table_row(result_items[0].keys(), col_widths, header=True))
+    for result_item in sorted(result_items, key=lambda x: x["Repo"].lower()):
+        print(get_table_row(result_item.values(), col_widths))
     print()
     print("To add a new recipe repo, use 'autopkg repo-add <repo name>'")
 


### PR DESCRIPTION
## Summary

This PR adjusts the behavior of `autopkg search` to leverage a locally cached index file instead of directly using GitHub's API to search for recipes. The index file is regenerated by GitHub Actions every 4 hours in [this repo](https://github.com/autopkg/index).

Details and test output coming soon.

## Things to consider

- Merge `new-search` verb back into `search` if it performs well enough
- Add flag for accessing old search functionality (for troubleshooting or if index becomes unavailable)
- Build test cases
- Write feature announcement
- Update index repo to reflect production use