### PR TITLE
Allow .tar.xz files to be processed as .tar

### DIFF
--- a/Code/autopkglib/Unarchiver.py
+++ b/Code/autopkglib/Unarchiver.py
@@ -30,7 +30,7 @@ EXTNS = {
     "zip": ["zip"],
     "tar_gzip": ["tar.gz", "tgz"],
     "tar_bzip2": ["tar.bz2", "tbz"],
-    "tar": ["tar"],
+    "tar": ["tar", "tar.xz"],
     "gzip": ["gzip"],
 }
 


### PR DESCRIPTION
When this change was initially [proposed](https://github.com/autopkg/autopkg/pull/164) in 2015, it was problematic because xz files weren't handled the same in all Python versions that shipped with macOS. Now that autopkg ships its own Python, we're in control of that.

Keeping in WIP status until I can gather previously nonworking use cases and post test results.