### PR TITLE
Add pkg check to PkgCopier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### [2.7.3](https://github.com/autopkg/autopkg/compare/v2.7.2...HEAD) (Unreleased)
+
 ### [2.7.2](https://github.com/autopkg/autopkg/compare/v2.7.1...v2.7.2) (December 07, 2022)
 
 ### [2.7.1](https://github.com/autopkg/autopkg/compare/v2.7.1...v2.7.1) (December 06, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### [2.7.2](https://github.com/autopkg/autopkg/compare/v2.7.1...HEAD) (Unreleased)
+### [2.7.2](https://github.com/autopkg/autopkg/compare/v2.7.1...v2.7.2) (December 07, 2022)
 
 ### [2.7.1](https://github.com/autopkg/autopkg/compare/v2.7.1...v2.7.1) (December 06, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### [2.7.2](https://github.com/autopkg/autopkg/compare/v2.7.1...v2.7.2) (December 07, 2022)
 
+* Fix for SparkleUpdateInfoProvider. (https://github.com/autopkg/autopkg/pull/845)
+
+**Full Changelog**: https://github.com/autopkg/autopkg/compare/v2.71..v2.7.2
+
 ### [2.7.1](https://github.com/autopkg/autopkg/compare/v2.7.1...v2.7.1) (December 06, 2022)
 
 * GitHubReleasesInfoProvider -- add support for a "latest_only" input variable (https://github.com/autopkg/autopkg/pull/846)

--- a/Code/autopkglib/PkgCopier.py
+++ b/Code/autopkglib/PkgCopier.py
@@ -89,7 +89,7 @@ class PkgCopier(Copier):
             pkg_extensions = (".mpkg", ".pkg")
             if os.path.splitext(matched_source_path)[1] not in pkg_extensions:
                 raise ProcessorError(
-                    f"Source does not appear to be a package based on its filename: "
+                    "Source does not appear to be a package based on its filename: "
                     f"'{matched_source_path}'"
                 )
 

--- a/Code/autopkglib/PkgCopier.py
+++ b/Code/autopkglib/PkgCopier.py
@@ -85,12 +85,13 @@ class PkgCopier(Copier):
                     f"'{source_pkg}'."
                 )
 
-            # Check that the source path ends in 'pkg' (extension of .mpkg or .pkg qualifies)
-            if matched_source_path[-3:] != 'pkg':
+            # Check that the source path ends with supported extension
+            pkg_extensions = (".mpkg", ".pkg")
+            if os.path.splitext(matched_source_path)[1] not in pkg_extensions:
                 raise ProcessorError(
                     f"Source does not appear to be a package based on its filename: "
                     f"'{matched_source_path}'"
-                )				
+                )
 
             # do the copy
             pkg_path = self.env.get("pkg_path") or os.path.join(

--- a/Code/autopkglib/PkgCopier.py
+++ b/Code/autopkglib/PkgCopier.py
@@ -18,6 +18,7 @@
 import glob
 import os.path
 
+from autopkglib import ProcessorError
 from autopkglib.Copier import Copier
 
 __all__ = ["PkgCopier"]
@@ -83,6 +84,13 @@ class PkgCopier(Copier):
                     f"Using path '{matched_source_path}' matched from globbed "
                     f"'{source_pkg}'."
                 )
+
+            # Check that the source path ends in 'pkg' (extension of .mpkg or .pkg qualifies)
+            if matched_source_path[-3:] != 'pkg':
+                raise ProcessorError(
+                    f"Source does not appear to be a package based on its filename: "
+                    f"'{matched_source_path}'"
+                )				
 
             # do the copy
             pkg_path = self.env.get("pkg_path") or os.path.join(

--- a/Code/autopkglib/version.plist
+++ b/Code/autopkglib/version.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>Version</key>
-	<string>2.7.2</string>
+	<string>2.7.3</string>
 </dict>
 </plist>


### PR DESCRIPTION
Currently, PkgCopier copies the item supplied regardless of whether it is a package or not. This PR adds a simple check on the filename of the source_pkg to see if it ends in 'pkg' (which would allow .pkg and .mpkg). It is not meant to be exhaustive, just something to highlight a recipe error.

### Code Runs
1. Current processor when user supplies a dmg instead of a pkg as the source_pkg
```
autopkg run FCPContent.pkg -p /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg -vvvv
Processing FCPContent.pkg...
{'AUTOPKG_VERSION': '2.7.2',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GIT_PATH': '/usr/local/git/bin/git',
 'NAME': 'FCPContent',
 'PARENT_RECIPES': ['/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes/AppleProVideo/FinalCutProXContent.download.recipe'],
 'PKG': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
 'RECIPE_CACHE_DIR': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent',
 'RECIPE_DIR': '/Users/apuser/Library/AutoPkg/Recipes',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/apuser/Library/AutoPkg/Recipes/FCPContent.pkg.recipe',
 'RECIPE_REPOS': {'/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes': {'URL': 'https://github.com/autopkg/jazzace-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes.git'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/apuser/Library/AutoPkg/Recipes'],
 'verbose': 4}
com.github.n8felton.shared/AppleSupportDownloadInfoProvider
{'Input': {'ARTICLE_NUMBER': '1394'}}
AppleSupportDownloadInfoProvider: Article URL: https://support.apple.com/kb/DL1394
AppleSupportDownloadInfoProvider: Download URL: https://support.apple.com/downloads/DL1394/en_US/&
AppleSupportDownloadInfoProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', '--silent', '--head', '--write-out', '%{url_effective}', '--url', 'https://support.apple.com/downloads/DL1394/en_US/&', '--output', '/dev/null']
AppleSupportDownloadInfoProvider: Full URL: https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg
AppleSupportDownloadInfoProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', 'https://support.apple.com/kb/DL1394']
AppleSupportDownloadInfoProvider: Article title: Final Cut Pro Content v1.0
AppleSupportDownloadInfoProvider: Version: 1.0
{'Output': {'article_url': 'https://support.apple.com/kb/DL1394',
            'url': 'https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg',
            'version': '1.0'}}
URLDownloader
{'Input': {'PKG': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
           'url': 'https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Given /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg, no download needed.
{'Output': {'download_changed': True,
            'pathname': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Software Update',
                                        'Apple Software Update Certification '
                                        'Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg/*.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.rgPq0o/FCPContent.pkg' matched from globbed '/private/tmp/dmg.rgPq0o/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "FCPContent.pkg":
CodeSignatureVerifier:    Status: signed Apple Software
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Software Update
CodeSignatureVerifier:        Expires: 2029-04-14 21:28:23 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E0 74 D2 04 AC 24 98 E9 DC 90 4A 7B C7 CE D8 46 41 19 B7 9D 05 66 
CodeSignatureVerifier:            80 28 92 05 83 B1 E8 96 EB B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Apple Software Update Certification Authority
CodeSignatureVerifier:        Expires: 2031-10-15 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            12 99 E9 BF E7 76 A2 9F F4 52 F8 C4 F5 E5 5F 3B 4D FD 29 34 34 9D 
CodeSignatureVerifier:            D1 85 0B 82 74 F3 5C 71 74 5C
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg',
           'source_pkg': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg/*.pkg'}}
PkgCopier: Mounted disk image /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg
PkgCopier: Using path '/private/tmp/dmg.srOvbf/FCPContent.pkg' matched from globbed '/private/tmp/dmg.srOvbf/*.pkg'.
PkgCopier: Copied /private/tmp/dmg.srOvbf/FCPContent.pkg to /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg'}}
{'ARTICLE_NUMBER': '1394',
 'AUTOPKG_VERSION': '2.7.2',
 'CHECK_FILESIZE_ONLY': False,
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GIT_PATH': '/usr/local/git/bin/git',
 'NAME': 'FCPContent',
 'PARENT_RECIPES': ['/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes/AppleProVideo/FinalCutProXContent.download.recipe'],
 'PKG': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
 'RECIPE_CACHE_DIR': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent',
 'RECIPE_DIR': '/Users/apuser/Library/AutoPkg/Recipes',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/apuser/Library/AutoPkg/Recipes/FCPContent.pkg.recipe',
 'RECIPE_REPOS': {'/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes': {'URL': 'https://github.com/autopkg/jazzace-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes.git'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/apuser/Library/AutoPkg/Recipes'],
 'article_url': 'https://support.apple.com/kb/DL1394',
 'download_changed': True,
 'etag': '',
 'expected_authority_names': ['Software Update',
                              'Apple Software Update Certification Authority',
                              'Apple Root CA'],
 'input_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg/*.pkg',
 'last_modified': '',
 'pathname': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
 'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg'},
                               'summary_text': 'The following packages were '
                                               'copied:'},
 'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg',
 'prefetch_filename': False,
 'source_pkg': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg/*.pkg',
 'url': 'https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg',
 'verbose': 4,
 'version': '1.0'}
Receipt written to /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/receipts/FCPContent-receipt-20230629-103109.plist

The following packages were copied:
    Pkg Path                                                                                          
    --------                                                                                          
    /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg
```

2. Updated processor when user supplies a dmg instead of a pkg as the source_pkg
```
autopkg run FCPContent.pkg -p /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg -vvvv
Processing FCPContent.pkg...
{'AUTOPKG_VERSION': '2.7.2',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GIT_PATH': '/usr/local/git/bin/git',
 'NAME': 'FCPContent',
 'PARENT_RECIPES': ['/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes/AppleProVideo/FinalCutProXContent.download.recipe'],
 'PKG': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
 'RECIPE_CACHE_DIR': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent',
 'RECIPE_DIR': '/Users/apuser/Library/AutoPkg/Recipes',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/apuser/Library/AutoPkg/Recipes/FCPContent.pkg.recipe',
 'RECIPE_REPOS': {'/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes': {'URL': 'https://github.com/autopkg/jazzace-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes.git'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/apuser/Library/AutoPkg/Recipes'],
 'verbose': 4}
com.github.n8felton.shared/AppleSupportDownloadInfoProvider
{'Input': {'ARTICLE_NUMBER': '1394'}}
AppleSupportDownloadInfoProvider: Article URL: https://support.apple.com/kb/DL1394
AppleSupportDownloadInfoProvider: Download URL: https://support.apple.com/downloads/DL1394/en_US/&
AppleSupportDownloadInfoProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', '--silent', '--head', '--write-out', '%{url_effective}', '--url', 'https://support.apple.com/downloads/DL1394/en_US/&', '--output', '/dev/null']
AppleSupportDownloadInfoProvider: Full URL: https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg
AppleSupportDownloadInfoProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', 'https://support.apple.com/kb/DL1394']
AppleSupportDownloadInfoProvider: Article title: Final Cut Pro Content v1.0
AppleSupportDownloadInfoProvider: Version: 1.0
{'Output': {'article_url': 'https://support.apple.com/kb/DL1394',
            'url': 'https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg',
            'version': '1.0'}}
URLDownloader
{'Input': {'PKG': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
           'url': 'https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Given /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg, no download needed.
{'Output': {'download_changed': True,
            'pathname': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Software Update',
                                        'Apple Software Update Certification '
                                        'Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg/*.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.eyEyhw/FCPContent.pkg' matched from globbed '/private/tmp/dmg.eyEyhw/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "FCPContent.pkg":
CodeSignatureVerifier:    Status: signed Apple Software
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Software Update
CodeSignatureVerifier:        Expires: 2029-04-14 21:28:23 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E0 74 D2 04 AC 24 98 E9 DC 90 4A 7B C7 CE D8 46 41 19 B7 9D 05 66 
CodeSignatureVerifier:            80 28 92 05 83 B1 E8 96 EB B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Apple Software Update Certification Authority
CodeSignatureVerifier:        Expires: 2031-10-15 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            12 99 E9 BF E7 76 A2 9F F4 52 F8 C4 F5 E5 5F 3B 4D FD 29 34 34 9D 
CodeSignatureVerifier:            D1 85 0B 82 74 F3 5C 71 74 5C
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg',
           'source_pkg': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg'}}
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "/Library/AutoPkg/autopkglib/PkgCopier.py", line 90, in main
    raise ProcessorError(
autopkglib.ProcessorError: Source does not appear to be a package based on its filename: '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg'
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
Source does not appear to be a package based on its filename: '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg'
Failed.
Receipt written to /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/receipts/FCPContent-receipt-20230630-133910.plist

The following recipes failed:
    FCPContent.pkg
        Error in com.github.jazzace.pkg.FCPContent: Processor: PkgCopier: Error: Source does not appear to be a package based on its filename: '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg'

Nothing downloaded, packaged or imported.
```

3. Updated Processor when user supplies what appears to be a pkg (same behaviour as current processor)
```
autopkg run FCPContent.pkg -p /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg -vvvv
Processing FCPContent.pkg...
{'AUTOPKG_VERSION': '2.7.2',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GIT_PATH': '/usr/local/git/bin/git',
 'NAME': 'FCPContent',
 'PARENT_RECIPES': ['/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes/AppleProVideo/FinalCutProXContent.download.recipe'],
 'PKG': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
 'RECIPE_CACHE_DIR': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent',
 'RECIPE_DIR': '/Users/apuser/Library/AutoPkg/Recipes',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/apuser/Library/AutoPkg/Recipes/FCPContent.pkg.recipe',
 'RECIPE_REPOS': {'/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes': {'URL': 'https://github.com/autopkg/jazzace-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes.git'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/apuser/Library/AutoPkg/Recipes'],
 'verbose': 4}
com.github.n8felton.shared/AppleSupportDownloadInfoProvider
{'Input': {'ARTICLE_NUMBER': '1394'}}
AppleSupportDownloadInfoProvider: Article URL: https://support.apple.com/kb/DL1394
AppleSupportDownloadInfoProvider: Download URL: https://support.apple.com/downloads/DL1394/en_US/&
AppleSupportDownloadInfoProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', '--silent', '--head', '--write-out', '%{url_effective}', '--url', 'https://support.apple.com/downloads/DL1394/en_US/&', '--output', '/dev/null']
AppleSupportDownloadInfoProvider: Full URL: https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg
AppleSupportDownloadInfoProvider: Curl command: ['/usr/bin/curl', '--compressed', '--location', 'https://support.apple.com/kb/DL1394']
AppleSupportDownloadInfoProvider: Article title: Final Cut Pro Content v1.0
AppleSupportDownloadInfoProvider: Version: 1.0
{'Output': {'article_url': 'https://support.apple.com/kb/DL1394',
            'url': 'https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg',
            'version': '1.0'}}
URLDownloader
{'Input': {'PKG': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
           'url': 'https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Given /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg, no download needed.
{'Output': {'download_changed': True,
            'pathname': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Software Update',
                                        'Apple Software Update Certification '
                                        'Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg/*.pkg'}}
CodeSignatureVerifier: Mounted disk image /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.I1Es32/FCPContent.pkg' matched from globbed '/private/tmp/dmg.I1Es32/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "FCPContent.pkg":
CodeSignatureVerifier:    Status: signed Apple Software
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Software Update
CodeSignatureVerifier:        Expires: 2029-04-14 21:28:23 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E0 74 D2 04 AC 24 98 E9 DC 90 4A 7B C7 CE D8 46 41 19 B7 9D 05 66 
CodeSignatureVerifier:            80 28 92 05 83 B1 E8 96 EB B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Apple Software Update Certification Authority
CodeSignatureVerifier:        Expires: 2031-10-15 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            12 99 E9 BF E7 76 A2 9F F4 52 F8 C4 F5 E5 5F 3B 4D FD 29 34 34 9D 
CodeSignatureVerifier:            D1 85 0B 82 74 F3 5C 71 74 5C
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PkgCopier
{'Input': {'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg',
           'source_pkg': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg/*.pkg'}}
PkgCopier: Mounted disk image /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg
PkgCopier: Using path '/private/tmp/dmg.hZHOA4/FCPContent.pkg' matched from globbed '/private/tmp/dmg.hZHOA4/*.pkg'.
PkgCopier: Copied /private/tmp/dmg.hZHOA4/FCPContent.pkg to /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg'}}
{'ARTICLE_NUMBER': '1394',
 'AUTOPKG_VERSION': '2.7.2',
 'CHECK_FILESIZE_ONLY': False,
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GIT_PATH': '/usr/local/git/bin/git',
 'NAME': 'FCPContent',
 'PARENT_RECIPES': ['/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes/AppleProVideo/FinalCutProXContent.download.recipe'],
 'PKG': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
 'RECIPE_CACHE_DIR': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent',
 'RECIPE_DIR': '/Users/apuser/Library/AutoPkg/Recipes',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/apuser/Library/AutoPkg/Recipes/FCPContent.pkg.recipe',
 'RECIPE_REPOS': {'/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes': {'URL': 'https://github.com/autopkg/jazzace-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes': {'URL': 'https://github.com/autopkg/n8felton-recipes.git'},
                  '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes.git'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.jazzace-recipes',
                        '/Users/apuser/Library/AutoPkg/RecipeRepos/com.github.autopkg.n8felton-recipes',
                        '/Users/apuser/Library/AutoPkg/Recipes'],
 'article_url': 'https://support.apple.com/kb/DL1394',
 'download_changed': True,
 'etag': '',
 'expected_authority_names': ['Software Update',
                              'Apple Software Update Certification Authority',
                              'Apple Root CA'],
 'input_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg/*.pkg',
 'last_modified': '',
 'pathname': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg',
 'pkg_copier_summary_result': {'data': {'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg'},
                               'summary_text': 'The following packages were '
                                               'copied:'},
 'pkg_path': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg',
 'prefetch_filename': False,
 'source_pkg': '/Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/downloads/FCPContent.dmg/*.pkg',
 'url': 'https://updates.cdn-apple.com/2020/macos/001-62843-20201104-a3de814d-01de-40fd-b990-3e69e17dd706/FCPContent.dmg',
 'verbose': 4,
 'version': '1.0'}
Receipt written to /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/receipts/FCPContent-receipt-20230630-134126.plist

The following packages were copied:
    Pkg Path                                                                                            
    --------                                                                                            
    /Users/apuser/Library/AutoPkg/Cache/com.github.jazzace.pkg.FCPContent/FCPContent-1.0.pkg   
```

Pkg recipe (on Runs 1 and 2, `source_pkg` is set to `%pathname%`, which ends in '.dmg'):
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>Description</key>
	<string>This recipe downloads the Final Cut Pro Supplemental Content package installer and extracts it
from the disk image (which then can be used to upload to Jamf Pro, for example).
</string>
	<key>Identifier</key>
	<string>com.github.jazzace.pkg.FCPContent</string>
	<key>Input</key>
	<dict/>
	<key>MinimumVersion</key>
	<string>2.0</string>
	<key>ParentRecipe</key>
	<string>com.github.jazzace.download.FCPContent</string>
	<key>Process</key>
	<array>
		<dict>
			<key>Processor</key>
			<string>PkgCopier</string>
			<key>Arguments</key>
			<dict>
				<key>pkg_path</key>
				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
				<key>source_pkg</key>
				<string>%pathname%/*.pkg</string>
			</dict>
		</dict>
	</array>
</dict>
</plist>
```