### PR TITLE
Don't add etag/last_modified headers if CHECK_FILESIZE_ONLY == True

### DIFF
--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -78,7 +78,7 @@ class URLGetter(Processor):
             self.existing_file_size = os.path.getsize(filename)
             etag = self.getxattr(self.xattr_etag)
             last_modified = self.getxattr(self.xattr_last_modified)
-            if not self.env["CHECK_FILESIZE_ONLY"]:
+            if not self.env.get("CHECK_FILESIZE_ONLY"):
                 if etag:
                     headers["If-None-Match"] = etag
                 if last_modified:

--- a/Code/autopkglib/URLGetter.py
+++ b/Code/autopkglib/URLGetter.py
@@ -78,10 +78,11 @@ class URLGetter(Processor):
             self.existing_file_size = os.path.getsize(filename)
             etag = self.getxattr(self.xattr_etag)
             last_modified = self.getxattr(self.xattr_last_modified)
-            if etag:
-                headers["If-None-Match"] = etag
-            if last_modified:
-                headers["If-Modified-Since"] = last_modified
+            if not self.env["CHECK_FILESIZE_ONLY"]:
+                if etag:
+                    headers["If-None-Match"] = etag
+                if last_modified:
+                    headers["If-Modified-Since"] = last_modified
         return headers
 
     def clear_header(self, header):


### PR DESCRIPTION
So, this may be an _extremely_ rare issue...but came across it on the recipe `com.github.moofit-recipes.download.MirrorOp` and I described it in https://github.com/autopkg/moofit-recipes/pull/126.

To re-cap here:

The web server is not accepting, or allowing, the etag `If-None-Match` and last modified `If-Modified-Since` header checks.  If these are included, then the web server will return a 400, but if they are not, it processes the request as expected.  Not quite sure why they're not supporting this as it literally should be saving them bandwidth...

When setting `CHECK_FILESIZE_ONLY` as `True` in the `URLDownloader` processor step, the parent class `URLGetter` processor still adds the etag and last modified headers to the call.

I'm not sure if this was an oversight or by design, but as far as I know, it hasn't affected anything else for all these years...

Also not sure if this is something that the maintainers would want to merge considering how little it seems to be affecting...but I'll at least propose it here and let you decide.