### PR TITLE
Update GitHubReleasesInfoProvider.py to allow and exclude draft relea…

### DIFF
--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -40,6 +40,12 @@ class GitHubReleasesInfoProvider(Processor):
             "required": True,
             "description": ("Name of a GitHub user and repo, ie. 'MagerValp/AutoDMG'"),
         },
+        "include_drafts": {
+            "required": False,
+            "description": (
+                "If set to True or a non-empty value, include drafts."
+            ),
+        },        
         "include_prereleases": {
             "required": False,
             "description": (
@@ -164,6 +170,8 @@ class GitHubReleasesInfoProvider(Processor):
                 break
             if rel["prerelease"] and not self.env.get("include_prereleases"):
                 continue
+            if rel["draft"] and not self.env.get("include_drafts"):
+                continue                
 
             assets = rel.get("assets")
             if not assets:


### PR DESCRIPTION
Github has now allowed for draft releases and in doing so has the possibility to return and non production ready package. To offset this, this PR is introducing a boolean like `prerelease`. Which defaults to ignoring `drafts` but allows the users to grab them, if desired.