### PR TITLE
Use expand-full switch with pkgutil

### DIFF
--- a/Code/autopkglib/FlatPkgUnpacker.py
+++ b/Code/autopkglib/FlatPkgUnpacker.py
@@ -138,7 +138,7 @@ class FlatPkgUnpacker(DmgMounter):
         try:
             pkgutilcmd = [
                 "/usr/sbin/pkgutil",
-                "--expand",
+                "--expand-full",
                 self.source_path,
                 self.env["destination_path"],
             ]


### PR DESCRIPTION
The (undocumented) expand-full switch will expand all components and better drill down into distribution-style packages.