### PR TITLE
change default dmg format and allow modern compression types

### DIFF
--- a/Code/autopkglib/DmgCreator.py
+++ b/Code/autopkglib/DmgCreator.py
@@ -23,7 +23,7 @@ from autopkglib import Processor, ProcessorError
 __all__ = ["DmgCreator"]
 
 DEFAULT_DMG_FORMAT = "ULFO"
-DEFAULT_DMG_FILESYSTEM = "HFS+"
+DEFAULT_DMG_FILESYSTEM = "APFS"
 DEFAULT_ZLIB_LEVEL = 5
 
 

--- a/Code/autopkglib/DmgCreator.py
+++ b/Code/autopkglib/DmgCreator.py
@@ -22,7 +22,7 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["DmgCreator"]
 
-DEFAULT_DMG_FORMAT = "UDZO"
+DEFAULT_DMG_FORMAT = "ULFO"
 DEFAULT_DMG_FILESYSTEM = "HFS+"
 DEFAULT_ZLIB_LEVEL = 5
 
@@ -93,6 +93,8 @@ class DmgCreator(Processor):
             "UDxx",
             "UDSP",
             "UDSB",
+            "ULFO",
+            "ULMO",
         ]
 
         dmg_format = self.env.get("dmg_format", DEFAULT_DMG_FORMAT)

--- a/Code/autopkglib/DmgCreator.py
+++ b/Code/autopkglib/DmgCreator.py
@@ -46,7 +46,8 @@ class DmgCreator(Processor):
         "dmg_filesystem": {
             "required": False,
             "description": (
-                f"The dmg filesystem. Defaults to {DEFAULT_DMG_FILESYSTEM}."
+                f"The dmg filesystem. Defaults to {DEFAULT_DMG_FILESYSTEM}. "
+                "Note: APFS requires macOS 10.13 or later to mount."
             ),
             "default": DEFAULT_DMG_FILESYSTEM,
         },


### PR DESCRIPTION
- UDZO compression has been marked as deprecated for years now
- ULFO compression is the "new" default and supports macOS 10.11 and higher
- ULMO compression is the "newest" and supports macOS 10.15 and higher

I would personally prefer ULMO as the default DMG format, but there is a significant performance penalty when creating the DMGs. I have only tested the performance on my fully managed macbook pro from 2019, but it was probably a 3x difference in the autopkg runs.

Example:
- Xcode 15
  - 3.18 GB Xcode_15.xip
  - 11.46 GB Xcode.app
  - 4.51 GB Xcode-UDZO.dmg (HFS+)
  - 4.41 GB Xcode-ULFO.dmg (HFS+)
  - 4.09 GB Xcode-ULMO.dmg (HFS+)
  - 4.08 GB Xcode-ULMO.dmg (APFS)

I'm wondering if there is more compression work that can be done here to get similar compression ratios to the original xip format that Apple utilizes.

from the manpage

```
COMPATIBILITY
     OS X 10.11 introduced lzfse compression in the ULFO format, providing faster, more efficient
     compression and smaller images compared to UDZO.  These images are also supported in-kernel, but will
     not work on any earlier versions of the OS.

     macOS 10.12 included a pre-release version of the Apple File System called APFS which was meant for
     evaluation and development purposes only.  Files stored in APFS-based images may not be accessible in
     future releases of macOS, and won't work in past ones.  All data to be stored in APFS volumes should
     be backed up prior to using APFS and regularly backed up while using APFS.

     macOS 10.15:

           •   Introduced lzma compression in the ULMO format, providing smaller images compared to ULFO.
               These images are not supported in-kernel, and will not work on any earlier versions of the
               OS.

           •   Deprecated OS 9-style dual-fork file support (hdiutil flatten/unflatten).

           •   Removed the deprecated "hdiutil internet-enable" command and the IDME attach flags.

     macOS 11.0:

           •   Removed support for DiskCopy42, DART and NDIF formats.

           •   Removed support for AppleSingle and MacBinary encodings.

           •   Removed the deprecated OS 9-style dual-fork file support (hdiutil flatten/unflatten).

           •   Default file system for new images has changed to APFS (instead of an empty disk image with
               no partition map). To create an empty disk image add "-layout NONE" to the creation flags.
               This change does not apply to images created with -srcfolder or -srcdevice arguments.

     macOS 12.0:

           •   Deprecated UDBZ format (bzip2 compression).

           •   Deprecated segmented UDIF images (hdiutil segment, -segmentSize argument in hdiutil create &
               convert).

           •   Deprecated hdiutil udifrez/udifderez (embed and extract resources).

     macOS 13.0:

           •   Removed the option "encrypted-encoding-version". All new encrypted images are created with
               encrypted encoding version 2.
               
WHAT'S NEW
     macOS 10.15 added ULMO format images compressed with lzma.  These images are smaller than comparable
     ULFO images compressed with lzfse.  These images are not supported in-kernel, and are not usable on
     earlier OSes.

     macOS 10.12 introduced the pre-release APFS for evaluation (see COMPATIBILITY above).  10.12 also
     added an option to disable atomic copying during image from folder operations, -noatomic, which may
     result in slightly faster image creation.  pmap added a new switch, -diagnostic, which captures
     troubleshooting information for Boot Camp configurations.

     OS X 10.11 added ULFO format images compressed with lzfse.  These images are more efficient and
     smaller than comparable UDZO images compressed with zlib, and retain kernel compatibility, but are not
     usable on earlier OSes.
```