### PR TITLE
Skip Sparkle feed enclosure items without a URL

### DIFF
--- a/Code/autopkglib/SparkleUpdateInfoProvider.py
+++ b/Code/autopkglib/SparkleUpdateInfoProvider.py
@@ -231,6 +231,10 @@ class SparkleUpdateInfoProvider(URLGetter):
             if enclosure is None:
                 continue
 
+            # Skip enclosures with no URL
+            if not enclosure.get("url"):
+                continue
+
             item = {}
             item["url"] = self.build_url(enclosure)
 


### PR DESCRIPTION
Resolves https://github.com/autopkg/autopkg/issues/906.

Example recipe that produces the error this PR intends to fix:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>Comment</key>
	<string>Created with Recipe Robot v2.3.0 (https://github.com/homebysix/recipe-robot)</string>
	<key>Description</key>
	<string>Downloads the latest version of Touché.</string>
	<key>Identifier</key>
	<string>com.github.homebysix.download.Touché</string>
	<key>Input</key>
	<dict>
		<key>NAME</key>
		<string>Touché</string>
	</dict>
	<key>MinimumVersion</key>
	<string>2.3</string>
	<key>Process</key>
	<array>
		<dict>
			<key>Arguments</key>
			<dict>
				<key>appcast_url</key>
				<string>https://redsweater.com/touche/appcast.php</string>
			</dict>
			<key>Processor</key>
			<string>SparkleUpdateInfoProvider</string>
		</dict>
		<dict>
			<key>Arguments</key>
			<dict>
				<key>filename</key>
				<string>%NAME%-%version%.zip</string>
			</dict>
			<key>Processor</key>
			<string>URLDownloader</string>
		</dict>
		<dict>
			<key>Processor</key>
			<string>EndOfCheckPhase</string>
		</dict>
		<dict>
			<key>Arguments</key>
			<dict>
				<key>archive_path</key>
				<string>%pathname%</string>
				<key>destination_path</key>
				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
				<key>purge_destination</key>
				<true/>
			</dict>
			<key>Processor</key>
			<string>Unarchiver</string>
		</dict>
		<dict>
			<key>Arguments</key>
			<dict>
				<key>input_path</key>
				<string>%RECIPE_CACHE_DIR%/%NAME%/Touché.app</string>
				<key>requirement</key>
				<string>identifier "com.red-sweater.touche" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "493CVA9A35"</string>
			</dict>
			<key>Processor</key>
			<string>CodeSignatureVerifier</string>
		</dict>
	</array>
</dict>
</plist>
```

Example output on the dev branch (3.0rc2):

```
% git status
On branch dev
Your branch is up to date with 'origin/dev'.

nothing to commit, working tree clean

% ./Code/autopkg run -vv "~/Library/AutoPkg/RecipeRobotTestOutput/Red Sweater Software/Touché.download.recipe"              
**load_recipe time: 0.00033066701143980026
Processing ~/Library/AutoPkg/RecipeRobotTestOutput/Red Sweater Software/Touché.download.recipe...
WARNING: ~/Library/AutoPkg/RecipeRobotTestOutput/Red Sweater Software/Touché.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://redsweater.com/touche/appcast.php'}}
can't concat str to bytes
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/receipts/Touché.download-receipt-20231015-150624.plist

The following recipes failed:
    ~/Library/AutoPkg/RecipeRobotTestOutput/Red Sweater Software/Touché.download.recipe
        Error in com.github.homebysix.download.Touché: Processor: SparkleUpdateInfoProvider: Error: can't concat str to bytes

Nothing downloaded, packaged or imported.
```

Example output after the change in this PR:

```
% git status
On branch suip-no-url
nothing to commit, working tree clean

% ./Code/autopkg run -vv "~/Library/AutoPkg/RecipeRobotTestOutput/Red Sweater Software/Touché.download.recipe"
**load_recipe time: 0.0003412499791011214
Processing ~/Library/AutoPkg/RecipeRobotTestOutput/Red Sweater Software/Touché.download.recipe...
WARNING: ~/Library/AutoPkg/RecipeRobotTestOutput/Red Sweater Software/Touché.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://redsweater.com/touche/appcast.php'}}
SparkleUpdateInfoProvider: Items in feed: 8
SparkleUpdateInfoProvider: Items in default channel: 8
SparkleUpdateInfoProvider: Version retrieved from appcast: 159
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.1.6
SparkleUpdateInfoProvider: Found URL https://redsweater.com/touche/Touche1.1.6.zip
{'Output': {'url': 'https://redsweater.com/touche/Touche1.1.6.zip',
            'version': '1.1.6'}}
URLDownloader
{'Input': {'filename': 'Touché-1.1.6.zip',
           'url': 'https://redsweater.com/touche/Touche1.1.6.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/downloads/Touché-1.1.6.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/downloads/Touché-1.1.6.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/downloads/Touché-1.1.6.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/Touché',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename Touché-1.1.6.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/downloads/Touché-1.1.6.zip to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/Touché
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/Touché/Touché.app',
           'requirement': 'identifier "com.red-sweater.touche" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"493CVA9A35"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/Touché/Touché.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/Touché/Touché.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/Touché/Touché.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.Touché/receipts/Touché.download-receipt-20231015-150636.plist

Nothing downloaded, packaged or imported.
```
