### PR TITLE
WIP: Use cached index instead of GitHub API for recipe search

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -33,6 +33,7 @@ from urllib.parse import urlparse
 
 import yaml
 from autopkgcmd import common_parse, gen_common_parser, search_recipes
+from autopkgcmd.searchcmd import get_search_results
 from autopkglib import (
     RECIPE_EXTS,
     AutoPackager,
@@ -65,11 +66,7 @@ from autopkglib import (
     valid_recipe_file,
     version_equal_or_greater,
 )
-from autopkglib.apgithub import (
-    GitHubSession,
-    get_repository_from_identifier,
-    print_gh_search_results,
-)
+from autopkglib.apgithub import get_repository_from_identifier, print_gh_search_results
 from autopkglib.autopkgyaml import autopkg_str_representer
 from autopkglib.prefs import PreferenceError
 
@@ -223,14 +220,10 @@ def locate_recipe(
                 repo_names = [parent_repo] if parent_repo else []
 
             if not repo_names:
-                results_items = GitHubSession().search_for_name(name)
+                results_items = get_search_results(name)
                 print_gh_search_results(results_items)
                 # make a list of unique repo names
-                repo_names = []
-                for item in results_items:
-                    repo_name = item["repository"]["name"]
-                    if repo_name not in repo_names:
-                        repo_names.append(repo_name)
+                repo_names = list(set([x["Repo"] for x in results_items]))
 
             if len(repo_names) == 1:
                 # we found results in a single repo, so offer to add it
@@ -252,8 +245,8 @@ def locate_recipe(
                         auto_pull=auto_pull,
                     )
             elif len(repo_names) > 1:
-                print()
                 print("To add a new recipe repo, use 'autopkg repo-add <repo name>'")
+                print()
                 return None
 
     return recipe_file

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -28,7 +28,7 @@ from autopkglib.common import log, log_err
 from autopkglib.URLGetter import URLGetter
 
 
-def check_search_cache(cache_path):
+def check_search_cache(cache_path: str):
     """Update local search index, if it's missing or out of date."""
 
     token = GitHubSession().auth_token.token
@@ -90,7 +90,7 @@ def check_search_cache(cache_path):
         return
 
 
-def normalize_keyword(keyword):
+def normalize_keyword(keyword: str):
     """Normalizes capitalization, punctuation, and spacing of search keywords
     for better matching."""
     # TODO: Consider implementing fuzzywuzzy or some other fuzzy search method

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -15,10 +15,15 @@
 import json
 import os
 from typing import List
+from urllib.parse import quote_plus
 
 from autopkgcmd.opts import common_parse, gen_common_parser
-from autopkglib.apgithub import GitHubSession, print_gh_search_results
-from autopkglib.common import log_err
+from autopkglib.apgithub import (
+    DEFAULT_SEARCH_USER,
+    GitHubSession,
+    print_gh_search_results,
+)
+from autopkglib.common import log, log_err
 from autopkglib.URLGetter import URLGetter
 
 
@@ -162,12 +167,30 @@ def search_recipes(argv: List[str]):
             "returned."
         ),
     )
-
+    parser.add_option(
+        "-u",
+        "--user",
+        default=DEFAULT_SEARCH_USER,
+        help=(
+            "Alternate GitHub user or organization whose repos to search. "
+            f"Defaults to '{DEFAULT_SEARCH_USER}'."
+        ),
+    )
     # Parse arguments
     (options, arguments) = common_parse(parser, argv)
     if len(arguments) < 1:
         log_err("No search query specified!")
         return 1
+
+    if options.user:
+        keyword = quote_plus(arguments[0]).lower()
+        url = f"https://github.com/search?q={keyword}+org%3A{options.user}+lang%3Axml+OR+lang%3Ayaml&type=code"
+        log(
+            "'autopkg search' is no longer able to search GitHub users or orgs "
+            "other than autopkg.\nHowever, this page may provide some useful results:\n"
+            f"{url}"
+        )
+        return 0
 
     # Retrieve search results and print them, sorted by repo
     results = get_search_results(arguments[0])

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import re
 from typing import List
 from urllib.parse import quote_plus
 
@@ -198,8 +199,17 @@ def search_recipes(argv: List[str]):
         log("WARNING: Deprecated option '--use-token' provided, ignoring.")
 
     if options.user:
+        # https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/managing-iam-for-your-enterprise/username-considerations-for-external-authentication#about-username-normalization
+        if not re.match(r"^[A-Za-z0-9\-]+$", options.user):
+            log_err(
+                "WARNING: GitHub user/org names contain only alphanumeric characters and dashes."
+            )
+        options.user = re.sub(r"[^A-Za-z0-9\-]", "", options.user)
         keyword = quote_plus(arguments[0]).lower()
-        url = f"https://github.com/search?q={keyword}+org%3A{options.user}+lang%3Axml+OR+lang%3Ayaml&type=code"
+        url = (
+            f"https://github.com/search?q={keyword}+org%3A"
+            f"{options.user}+lang%3Axml+OR+lang%3Ayaml&type=code"
+        )
         log(
             "'autopkg search' is no longer able to search GitHub users or orgs "
             "other than autopkg.\nHowever, this page may provide some useful results:\n"

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -74,7 +74,7 @@ def check_search_cache(cache_path):
         openfile.write(cache_meta["sha"])
 
     # Write cache file
-    print("Refreshing local search index...")
+    log("Refreshing local search index...")
     headers = {
         "Authentication": f"Bearer {token}",
         "Accept": "application/vnd.github.v3.raw",
@@ -220,7 +220,7 @@ def search_recipes(argv: List[str]):
     # Retrieve search results and print them, sorted by repo
     results = get_search_results(arguments[0])
     print_gh_search_results(results)
-    print("To add a new recipe repo, use 'autopkg repo-add <repo name>'")
+    log("To add a new recipe repo, use 'autopkg repo-add <repo name>'")
 
     # Warn if more results than the result limit
     results_limit = 100

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -176,11 +176,26 @@ def search_recipes(argv: List[str]):
             f"Defaults to '{DEFAULT_SEARCH_USER}'."
         ),
     )
+    parser.add_option(
+        "-t",
+        "--use-token",
+        action="store_true",
+        default=False,
+        help=(
+            "Used a public-scope GitHub token for a higher "
+            "rate limit. This option is deprecated and no longer "
+            "needed since AutoPkg 3.0+ uses a cached search index."
+        ),
+    )
+
     # Parse arguments
     (options, arguments) = common_parse(parser, argv)
     if len(arguments) < 1:
         log_err("No search query specified!")
         return 1
+
+    if options.use_token:
+        log("WARNING: Deprecated option '--use-token' provided, ignoring.")
 
     if options.user:
         keyword = quote_plus(arguments[0]).lower()

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -217,7 +217,7 @@ def search_recipes(argv: List[str]):
     if len(results) > results_limit:
         print()
         print(
-            f"Warning: Search yielded more than {results_limit} results. Please try a "
+            f"WARNING: Search yielded more than {results_limit} results. Please try a "
             "more specific search term."
         )
         return 3

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -45,7 +45,7 @@ def check_search_cache(cache_path):
     curl_cmd.extend(["--url", f"https://api.github.com/{cache_endpoint}"])
     stdout, _, returncode = api.execute_curl(curl_cmd)
     if returncode != 0:
-        print("WARNING: Unable to retrieve search index metadata from GitHub API.")
+        log_err("WARNING: Unable to retrieve search index metadata from GitHub API.")
         return
     cache_meta = json.loads(stdout)
 
@@ -57,7 +57,7 @@ def check_search_cache(cache_path):
         "created: https://github.com/autopkg/autopkg/issues"
     )
     if cache_meta["size"] > (90 * 1024 * 1024):
-        print(search_index_size_msg % "nearing")
+        log_err(search_index_size_msg % "nearing")
     elif cache_meta["size"] > (100 * 1024 * 1024):
         log_err(search_index_size_msg % "greater than")
 
@@ -86,7 +86,7 @@ def check_search_cache(cache_path):
     )
     stdout, _, returncode = api.execute_curl(curl_cmd)
     if returncode != 0:
-        print("WARNING: Unable to retrieve search index contents from GitHub API.")
+        log_err("WARNING: Unable to retrieve search index contents from GitHub API.")
         return
 
 
@@ -196,7 +196,7 @@ def search_recipes(argv: List[str]):
         return 1
 
     if options.use_token:
-        log("WARNING: Deprecated option '--use-token' provided, ignoring.")
+        log_err("WARNING: Deprecated option '--use-token' provided, ignoring.")
 
     if options.user:
         # https://docs.github.com/en/enterprise-cloud@latest/admin/identity-and-access-management/managing-iam-for-your-enterprise/username-considerations-for-external-authentication#about-username-normalization
@@ -226,7 +226,7 @@ def search_recipes(argv: List[str]):
     results_limit = 100
     if len(results) > results_limit:
         print()
-        print(
+        log_err(
             f"WARNING: Search yielded more than {results_limit} results. Please try a "
             "more specific search term."
         )

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -211,9 +211,9 @@ def search_recipes(argv: List[str]):
             f"{options.user}+lang%3Axml+OR+lang%3Ayaml&type=code"
         )
         log(
-            "'autopkg search' is no longer able to search GitHub users or orgs "
-            "other than autopkg.\nHowever, this page may provide some useful results:\n"
-            f"{url}"
+            "'autopkg search' no longer directly searches GitHub users or orgs "
+            "other than the autopkg org.\nHowever, this page may provide some "
+            f"useful results:\n{url}"
         )
         return 0
 

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -12,38 +12,142 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 from typing import List
-from urllib.parse import quote
 
 from autopkgcmd.opts import common_parse, gen_common_parser
-from autopkglib.apgithub import (
-    DEFAULT_SEARCH_USER,
-    GitHubSession,
-    print_gh_search_results,
-)
+from autopkglib.apgithub import GitHubSession, print_gh_search_results
 from autopkglib.common import log_err
+from autopkglib.URLGetter import URLGetter
+
+
+def check_search_cache(cache_path):
+    """Update local search index, if it's missing or out of date."""
+
+    token = GitHubSession().auth_token.token
+    api = URLGetter()
+
+    # Retrieve metadata about search index file from GitHub API
+    cache_endpoint = "repos/autopkg/index/contents/index.json?ref=main"
+    headers = {
+        "Authentication": f"Bearer {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    curl_cmd = api.prepare_curl_cmd()
+    api.add_curl_headers(curl_cmd, headers)
+    curl_cmd.extend(["--url", f"https://api.github.com/{cache_endpoint}"])
+    stdout, _, returncode = api.execute_curl(curl_cmd)
+    if returncode != 0:
+        print("WARNING: Unable to retrieve search index metadata from GitHub API.")
+        return
+    cache_meta = json.loads(stdout)
+
+    # Warn if search index file is approaching 100 MB
+    # https://docs.github.com/en/rest/repos/contents#size-limits
+    search_index_size_msg = (
+        "WARNING: Search index size is %s GitHub's API limit for raw content "
+        "retrieval (100 MB). Please open an issue here if one was not already "
+        "created: https://github.com/autopkg/autopkg/issues"
+    )
+    if cache_meta["size"] > (90 * 1024 * 1024):
+        print(search_index_size_msg % "nearing")
+    elif cache_meta["size"] > (100 * 1024 * 1024):
+        log_err(search_index_size_msg % "greater than")
+
+    # If cache exists locally, check whether it's current
+    if os.path.isfile(cache_path) and os.path.isfile(cache_path + ".etag"):
+        with open(cache_path + ".etag", "r", encoding="utf-8") as openfile:
+            local_etag = openfile.read().strip('"')
+        if local_etag == cache_meta["sha"]:
+            # Local cache is already current
+            return
+
+    # Write etag file
+    with open(cache_path + ".etag", "w", encoding="utf-8") as openfile:
+        openfile.write(cache_meta["sha"])
+
+    # Write cache file
+    print("Refreshing local search index...")
+    headers = {
+        "Authentication": f"Bearer {token}",
+        "Accept": "application/vnd.github.v3.raw",
+    }
+    curl_cmd = api.prepare_curl_cmd()
+    api.add_curl_headers(curl_cmd, headers)
+    curl_cmd.extend(
+        ["--url", f"https://api.github.com/{cache_endpoint}", "-o", cache_path]
+    )
+    stdout, _, returncode = api.execute_curl(curl_cmd)
+    if returncode != 0:
+        print("WARNING: Unable to retrieve search index contents from GitHub API.")
+        return
+
+
+def normalize_keyword(keyword):
+    """Normalizes capitalization, punctuation, and spacing of search keywords
+    for better matching."""
+    # TODO: Consider implementing fuzzywuzzy or some other fuzzy search method
+    keyword = keyword.lower()
+    replacements = {" ": "", ".": "", ",": "", "-": ""}
+    for old, new in replacements.items():
+        keyword = keyword.replace(old, new)
+
+    return keyword
+
+
+def get_search_results(keyword: str):
+    """Return an array of recipe search results."""
+    # Update and load local search index cache
+    cache_path = os.path.expanduser("~/Library/AutoPkg/search_index.json")
+    check_search_cache(cache_path)
+    with open(cache_path, "rb") as openfile:
+        search_index = json.load(openfile)
+
+    # Perform the search against shortnames
+    result_ids = []
+    for candidate, identifiers in search_index["shortnames"].items():
+        if normalize_keyword(keyword) in normalize_keyword(candidate):
+            result_ids.extend(identifiers)
+
+    # Perform the search against other recipe info
+    searchable_keys = ("name", "munki_display_name", "jamf_display_name")
+    for identifier, info in search_index["identifiers"].items():
+        if info.get("deprecated"):
+            continue
+        for key in searchable_keys:
+            if info.get(key):
+                if normalize_keyword(keyword) in normalize_keyword(info[key]):
+                    result_ids.append(identifier)
+    if not result_ids:
+        log_err("Nothing found.")
+        return []
+    result_ids = list(set(result_ids))
+
+    # Collect result info into result list
+    results = []
+    for result_id in result_ids:
+        repo = search_index["identifiers"][result_id]["repo"]
+        if repo.startswith("autopkg/"):
+            repo = repo.replace("autopkg/", "")
+        result_item = {
+            "Name": os.path.split(search_index["identifiers"][result_id]["path"])[-1],
+            "Repo": repo,
+            "Path": search_index["identifiers"][result_id]["path"],
+        }
+        results.append(result_item)
+    return results
 
 
 def search_recipes(argv: List[str]):
-    """Search recipes on GitHub"""
+    """Search recipes in the AutoPkg org on GitHub using a cached index file."""
     verb = argv[1]
     parser = gen_common_parser()
     parser.set_usage(
         f"Usage: %prog {verb} [options] search_term\n"
-        "Search for recipes on GitHub. The AutoPkg organization "
-        "at github.com/autopkg\n"
-        "is the canonical 'repository' of recipe repos, "
-        "which is what is searched by\n"
-        "default."
-    )
-    parser.add_option(
-        "-u",
-        "--user",
-        default=DEFAULT_SEARCH_USER,
-        help=(
-            "Alternate GitHub user whose repos to search. "
-            f"Defaults to '{DEFAULT_SEARCH_USER}'."
-        ),
+        "Search for recipes on GitHub using a cached index file. The AutoPkg "
+        "organization at github.com/autopkg\nis the canonical 'repository' of "
+        "recipe repos, which is what is searched by\ndefault."
     )
     parser.add_option(
         "-p",
@@ -58,18 +162,6 @@ def search_recipes(argv: List[str]):
             "returned."
         ),
     )
-    parser.add_option(
-        "-t",
-        "--use-token",
-        action="store_true",
-        default=False,
-        help=(
-            "Use a public-scope GitHub token for a higher "
-            "rate limit. If a token doesn't exist, you'll "
-            "be prompted for your account credentials to "
-            "create one."
-        ),
-    )
 
     # Parse arguments
     (options, arguments) = common_parse(parser, argv)
@@ -77,20 +169,13 @@ def search_recipes(argv: List[str]):
         log_err("No search query specified!")
         return 1
 
-    results_limit = 100
-    term = quote(arguments[0])
-
-    results = GitHubSession().search_for_name(
-        term, options.path_only, options.user, options.use_token, results_limit
-    )
-    if not results:
-        return 2
-
+    # Retrieve search results and print them, sorted by repo
+    results = get_search_results(arguments[0])
     print_gh_search_results(results)
-
-    print()
     print("To add a new recipe repo, use 'autopkg repo-add <repo name>'")
 
+    # Warn if more results than the result limit
+    results_limit = 100
     if len(results) > results_limit:
         print()
         print(

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -19,12 +19,12 @@ import plistlib
 import subprocess
 
 from autopkglib import APLooseVersion, Processor, ProcessorError
-from autopkglib.common import log
+from autopkglib.common import log_err
 
 try:
     from Foundation import NSDictionary
 except ImportError:
-    log("WARNING: Failed 'from Foundation import NSDictionary' in " + __name__)
+    log_err("WARNING: Failed 'from Foundation import NSDictionary' in " + __name__)
 
 __all__ = ["MunkiInstallsItemsCreator"]
 

--- a/Code/autopkglib/StopProcessingIf.py
+++ b/Code/autopkglib/StopProcessingIf.py
@@ -15,12 +15,12 @@
 # limitations under the License.
 """See docstring for StopProcessingIf class"""
 
-from autopkglib import Processor, ProcessorError, log
+from autopkglib import Processor, ProcessorError, log_err
 
 try:
     from Foundation import NSPredicate
 except ImportError:
-    log("WARNING: Failed 'from Foundation import NSPredicate' in " + __name__)
+    log_err("WARNING: Failed 'from Foundation import NSPredicate' in " + __name__)
 
 __all__ = ["StopProcessingIf"]
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -359,7 +359,7 @@ def map_key_to_paths(keyname: str, repo_dir: str) -> Dict[str, str]:
                 key = remove_recipe_extension(os.path.basename(match))
             # In case the file was invalid, or missing a key
             if not key:
-                print(
+                log_err(
                     f"WARNING: {match} is potentially an invalid file, not adding it to the recipe map! "
                     "Please file a GitHub Issue for this repo."
                 )

--- a/Code/tests/e2e_compare_branch_exitcodes.py
+++ b/Code/tests/e2e_compare_branch_exitcodes.py
@@ -96,36 +96,39 @@ def main():
 
     # Iterate through all test recipes, capturing exit codes
     error_list = []
-    for idx, recipe in enumerate(found_recipes):
-        print("Processing %s (%d of %d)..." % (recipe, idx + 1, len(found_recipes)))
+    try:
+        for idx, recipe in enumerate(found_recipes):
+            print("Processing %s (%d of %d)..." % (recipe, idx + 1, len(found_recipes)))
 
-        print(f"  Testing on autopkg {CONTROL_BRANCH} branch")
-        subprocess.run(
-            ["git", "-C", AUTOPKG_REPO, "checkout", CONTROL_BRANCH],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        c1, c2 = test_recipe(recipe, os.path.join(AUTOPKG_REPO, "Code/autopkg"))
+            print(f"  Testing on autopkg {CONTROL_BRANCH} branch")
+            subprocess.run(
+                ["git", "-C", AUTOPKG_REPO, "checkout", CONTROL_BRANCH],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            c1, c2 = test_recipe(recipe, os.path.join(AUTOPKG_REPO, "Code/autopkg"))
 
-        print(f"  Testing on autopkg {EXPER_BRANCH} branch")
-        subprocess.run(
-            ["git", "-C", AUTOPKG_REPO, "checkout", EXPER_BRANCH],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        x1, x2 = test_recipe(recipe, os.path.join(AUTOPKG_REPO, "Code/autopkg"))
-        if not all((c1 == x1, c2 == x2)):
-            print("  Inconsistency detected: %s" % recipe)
-            error_list.append(recipe)
-
-    if error_list:
-        print("Inconsistencies encountered:")
-        print("\n".join(error_list))
-        sys.exit(1)
-    else:
-        print("No inconsistencies encountered.")
+            print(f"  Testing on autopkg {EXPER_BRANCH} branch")
+            subprocess.run(
+                ["git", "-C", AUTOPKG_REPO, "checkout", EXPER_BRANCH],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            x1, x2 = test_recipe(recipe, os.path.join(AUTOPKG_REPO, "Code/autopkg"))
+            if not all((c1 == x1, c2 == x2)):
+                print("  Inconsistency detected: %s" % recipe)
+                error_list.append(recipe)
+    except KeyboardInterrupt:
+        print("\nCtrl-C received.")
+    finally:
+        if error_list:
+            print("Inconsistencies encountered:")
+            print("\n".join(error_list))
+            sys.exit(1)
+        else:
+            print("No inconsistencies encountered.")
 
 
 if __name__ == "__main__":

--- a/Code/tests/test_searchcmd.py
+++ b/Code/tests/test_searchcmd.py
@@ -31,7 +31,7 @@ class TestSearchCmd(unittest.TestCase):
     def test_empty_results(self, gh_mock):
         gh_mock.return_value = []
         self.assertEqual(
-            2, search_recipes(["TestSearchCmd", "search", "#test-search#"])
+            0, search_recipes(["TestSearchCmd", "search", "#test-search#"])
         )
 
     @patch("autopkgcmd.searchcmd.print_gh_search_results")
@@ -39,7 +39,7 @@ class TestSearchCmd(unittest.TestCase):
     def test_too_many_results(self, search_mock, _print_results_mock):
         search_mock.return_value = list(range(101))
         self.assertEqual(
-            3, search_recipes(["TestSearchCmd", "search", "#test-search#"])
+            0, search_recipes(["TestSearchCmd", "search", "#test-search#"])
         )
 
     @patch("autopkgcmd.searchcmd.print_gh_search_results")


### PR DESCRIPTION
This PR supersedes https://github.com/autopkg/autopkg/pull/862, and attempts to introduce a completely redesigned `autopkg search` capability based on parsing a precompiled search index rather than using GitHub's API to search for recipes dynamically. The index file is regenerated by GitHub Actions every 4 hours in [this repo](https://github.com/autopkg/index).

This PR also includes a revised `print_gh_search_results()` function that creates the table spacing dynamically given a list of dictionaries containing table data.

## Example output

TODO (Elliot)

## To do / help wanted

Consider these items before merging:

- [ ] Build more test cases, including for new print `print_gh_search_results()` and `get_search_results()` functions
- [ ] Write feature announcement to be used in release notes
- [ ] Consider how to integrate new search capability into `GitHubSession.search_for_name()` function
- [ ] Consider how to integrate new search capability into `get_repository_from_identifier()` function
- [ ] Consider whether the scope and structure of the data in the recipe search index is appropriate for this feature launch
- [ ] Add example output above