### PR TITLE
Switch to yaml.BaseLoader to prevent automatic type conversions

### DIFF
--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -141,7 +141,7 @@ def recipe_from_file(filename):
         try:
             # try to read it as yaml
             with open(filename, "rb") as f:
-                recipe_dict = yaml.load(f, Loader=yaml.FullLoader)
+                recipe_dict = yaml.load(f, Loader=yaml.BaseLoader)
             return recipe_dict
         except Exception as err:
             log_err(f"WARNING: yaml error for {filename}: {err}")


### PR DESCRIPTION
**tl/dr**:  Prevents `yaml.load` from converting values to Python types, instead all value types will be `str`'s.

**Note**:  My assumption here (going based on experience with my usage of AutoPkg over the years) is that _most, if not all_ recipe variables are written as `<string></string>` in the original XML format and so most Processors expect strings; thus on `plistlib.load` those values are parsed as Python's `str` type.  This proposal makes this same assumption, that all recipe variables should be expected to be of the Python type `str`.

**Details**:  `yaml.FullLoader` converts values to Python types, so, the following conversions happen on load of a yaml recipe file:

`  OVERRIDE_VAR_1: 42` will be `type(OVERRIDE_VAR_1) == int`
`  OVERRIDE_VAR_2:  true` will be `type(OVERRIDE_VAR_2) == bool`

When Processors most commonly expect `str` values, this raises a `TypeError`, `AttributeError`, or other similar issues.  An example with `JamfUploader`:

```
JamfPolicyUploader: Replacing any instances of 'POLICY_TRIGGER_CHECKIN' with 'true'
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "/Library/<username>/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/JamfUploaderProcessors/JamfPolicyUploader.py", line 341, in main
    template_xml = self.prepare_policy_template(
  File "/Library/<username>/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/JamfUploaderProcessors/JamfPolicyUploader.py", line 123, in prepare_policy_template
    template_contents = self.substitute_assignable_keys(
  File "/Library/<username>/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes/JamfUploaderProcessors/JamfUploaderLib/JamfUploaderBase.py", line 634, in substitute_assignable_keys
    replacement_key = escape(self.env.get(found_key))
  File "/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/xml/sax/saxutils.py", line 27, in escape
    data = data.replace("&", "&amp;")
AttributeError: 'bool' object has no attribute 'replace'
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
'bool' object has no attribute 'replace'
Failed.
```

**Additional discussion points**:

I realize this may not be the "desired" functionality, so...no issues if it is decided _not_ to merge this PR.  I will be submitting a PR to `JamfUploader` to prevent this issue _there_ as well.

However if this is considered, I want to mention:  

This is a very "heavy" approach to "fixing" this "issue."  Optionally, we could more strategically prevent conversions of _**specific**_ types instead.  If this would be more desirable, I can retool this PR as such.

Open to any feedback.