### PR TITLE
Deprecate and neuter MunkiCatalogBuilder processor; update MunkiImporter processor

### DIFF
--- a/Code/autopkglib/MunkiCatalogBuilder.py
+++ b/Code/autopkglib/MunkiCatalogBuilder.py
@@ -15,53 +15,34 @@
 # limitations under the License.
 """See docstring for MunkiCatalogBuilder class"""
 
-import subprocess
+import os
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import Processor, remove_recipe_extension
 
 __all__ = ["MunkiCatalogBuilder"]
 
 
 class MunkiCatalogBuilder(Processor):
-    """Rebuilds Munki catalogs."""
+    """DEPRECATED. This processor now emits a warning and performs no function.
+    Previously it rebuilt Munki catalogs."""
 
-    input_variables = {
-        "MUNKI_REPO": {"required": True, "description": "Path to the Munki repo."},
-        "munki_repo_changed": {
-            "required": False,
-            "description": (
-                "If not defined or False, causes running makecatalogs to be skipped."
-            ),
-        },
-    }
+    input_variables = {}
     output_variables = {}
     description = __doc__
 
     def main(self):
-        # MunkiImporter or other processor must set
-        # env["munki_repo_changed"] = True in order for makecatalogs
-        # to run
-        if not self.env.get("munki_repo_changed"):
-            self.output("Skipping makecatalogs because repo is unchanged.")
-            return
-
-        # Generate arguments for makecatalogs.
-        args = ["/usr/local/munki/makecatalogs", self.env["MUNKI_REPO"]]
-
-        # Call makecatalogs.
-        try:
-            proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            (_, err_out) = proc.communicate()
-        except OSError as err:
-            raise ProcessorError(
-                f"makecatalog execution failed with error code {err.errno}: "
-                f"{err.strerror}"
-            ) from err
-        if proc.returncode != 0:
-            raise ProcessorError(f"makecatalogs failed: {err_out}")
-        self.output("Munki catalogs rebuilt!")
+        warning_message = self.env.get(
+            "warning_message",
+            "### The MunkiCatalogBuilder processor has been deprecated. It currently does nothing. It will be removed in the future. ###",
+        )
+        self.output(warning_message)
+        recipe_name = os.path.basename(self.env["RECIPE_PATH"])
+        recipe_name = remove_recipe_extension(recipe_name)
+        self.env["deprecation_summary_result"] = {
+            "summary_text": "The following recipes have deprecation warnings:",
+            "report_fields": ["name", "warning"],
+            "data": {"name": recipe_name, "warning": warning_message},
+        }
 
 
 if __name__ == "__main__":

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -395,8 +395,7 @@ class MunkiImporter(Processor):
                 self.env["MUNKI_REPO"], "pkgs", installer_item_location
             )
             self.env["munki_info"] = {}
-            if "munki_repo_changed" not in self.env:
-                self.env["munki_repo_changed"] = False
+            self.env["munki_repo_changed"] = False
 
             self.output(
                 f"Item {os.path.basename(self.env['pkg_path'])} already exists in the "


### PR DESCRIPTION
This PR implements some changes discussed today in the #autopkg channel in MacAdmins Slack today. Namely, it deprecates and neuters the old, mostly abandoned MunkiCatalogBuilder processor. This processor was used in only two publicly shared recipes, and repo containing those recipes is being archived.

With this change, running a recipe containing a MunkiCatalogBuilder step results in a deprecation warning and no action is performed for that step:

```
autopkg run Test.munki -v
Looking for Test.munki...
Found Test.munki in recipe map
**load_recipe time: 0.0009514169942121953
Processing Test.munki...
WARNING: Test.munki is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MunkiCatalogBuilder
MunkiCatalogBuilder: ### The MunkiCatalogBuilder processor has been deprecated. It currently does nothing. It will be removed in the future. ###
Receipt written to /Users/gneagle/Library/AutoPkg/Cache/com.github.autopkg.gneagle.test/receipts/Test-receipt-20231109-171348.plist

Nothing downloaded, packaged or imported.
```

The second change is to the MunkiImporter processor. Previously, it did not reset the value of the `munki_repo_changed` variable between recipe runs, so if you were running multiple recipes, and one changed the repo, `munki_repo_changed`  was reported as True for all remaining recipes. This behavior was intended to tell a processor to run `makecatalogs` after running a list of recipes if any of them changed the repo. But this ended up being implemented a different way that did not rely on the `munki_repo_changed` variable. Therefore, the behavior of this has been changed to reflect the documentation, that is, it reports if the current recipe caused a change to the repo.

Consider a run that runs a Firefox and a Chrome recipe. A new Firefox version is imported, but the Chrome version is already current in the repo. The prior behavior reported `munki_repo_changed` after running the Firefox recipe, and also after running the Chrome recipe.

In the new behavior, `munki_repo_changed` is reported as True only after the Firefox recipe:

```
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Firefox-119.0.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Firefox_DisneyAnimation-119.0.1.pkg
{'Output': <snip>
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Firefox_DisneyAnimation-119.0.1.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Firefox-119.0.1.plist'}}
```
followed by 
```
MunkiImporter: Item GoogleChrome.dmg already exists in the munki repo as pkgs/apps/GoogleChrome-119.0.6045.123.dmg.
{'Output': {'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/GoogleChrome-119.0.6045.123.dmg'}}
```

Note that in the results for the Chrome recipe, `munki_repo_changed` is not reported as False; instead it is not reported at all. This is because of this existing code:
https://github.com/autopkg/autopkg/blob/dev/Code/autopkglib/__init__.py#L894-L905
Which causes an output variable to be printed only if it's Python "truthy" -- that is, empty dicts, arrays, and strings will not be printed, booleans with a value of False will not be printed, and numbers with a value of 0 will not be printed. Whether or not that is behavior to address is outside the scope of this PR.