### PR TITLE
Create python wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,166 @@ autopkg.code-workspace
 # don't track package builds
 Scripts/artifacts/*
 Scripts/pkg-scripts/*
+
+### Python
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1,0 +1,17 @@
+#!/usr/local/autopkg/python
+
+import sys
+
+import autopkgcmd
+import autopkglib
+import nuget
+from autopkgcli.autopkg import main
+
+# backward compatibility
+sys.modules["autopkglib"] = autopkglib
+sys.modules["autopkigcmd"] = autopkgcmd
+sys.modules["nuget"] = nuget
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Code/autopkgcli/autopkg.py
+++ b/Code/autopkgcli/autopkg.py
@@ -2626,8 +2626,10 @@ def new_recipe(argv):
     calculate_recipe_map()
 
 
-def main(argv):
+def main():
     """Main routine"""
+    # getting cmdline args
+    argv = sys.argv
     # define our subcommands ('verbs')
     subcommands = {
         "help": {"function": display_help, "help": "Display this help"},
@@ -2722,4 +2724,4 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    sys.exit(main())

--- a/Code/tests/test_autopkglib.py
+++ b/Code/tests/test_autopkglib.py
@@ -14,18 +14,14 @@
 
 import imp
 import json
-import os
 import plistlib
 import sys
 import unittest
 from textwrap import dedent
 from unittest.mock import mock_open, patch
 
+import autopkgcli.autopkg  # noqa: F401
 import autopkglib
-
-autopkg = imp.load_source(
-    "autopkg", os.path.join(os.path.dirname(__file__), "..", "autopkg")
-)
 
 
 class TestAutoPkg(unittest.TestCase):
@@ -218,7 +214,7 @@ class TestAutoPkg(unittest.TestCase):
         new_callable=mock_open,
         read_data=download_recipe.encode("utf-8"),
     )
-    @patch("autopkg.plistlib.load")
+    @patch("autopkgcli.autopkg.plistlib.load")
     @patch("os.path.isfile")
     def test_get_identifier_from_recipe_file_returns_identifier(
         self, mock_isfile, mock_load, mock_file
@@ -234,7 +230,7 @@ class TestAutoPkg(unittest.TestCase):
         new_callable=mock_open,
         read_data=download_recipe.encode("utf-8"),
     )
-    @patch("autopkg.plistlib.load")
+    @patch("autopkgcli.autopkg.plistlib.load")
     def test_get_identifier_from_recipe_file_returns_none(self, mock_load, mock_read):
         """get_identifier_from_recipe_file should return None if no identifier."""
         mock_read.return_value = self.download_struct

--- a/Code/tests/test_expand_repo.py
+++ b/Code/tests/test_expand_repo.py
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
-import os
 import unittest
 
-autopkg = imp.load_source(
-    "autopkg", os.path.join(os.path.dirname(__file__), "..", "autopkg")
-)
+from autopkgcli import autopkg
 
 
 class TestExpandRepo(unittest.TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "autopkg"
+authors = []
+version = "2.7.3"
+description = "AutoPkg is an automation framework for macOS software packaging and distribution"
+readme = "Readme.md"
+requires-python = ">=3.10"
+license = {text = "BSD-3-Clause"}
+classifiers = [
+    "Topic :: System :: Software Distribution",
+]
+dynamic = [ "dependencies" ]
+
+[project.scripts]
+autopkg = "autopkgcli.autopkg:main"
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["gh_actions_requirements.txt"]}
+
+
+[tool.setuptools.packages.find]
+where = ["Code"]
+include = ["autopkg*", "nuget*"]
+exclude = [".tests*"]
+namespaces = false


### PR DESCRIPTION
Make it possible to produce a python wheel form this project.

Benefits:
* improved installation experience on non Darwin platforms
    ```sh
    pip install git+https://github.com/autopkg/autopkg.git@dev
    ```
* adheres more closely to PEP-338
* improved developer experience for testing:
   ```sh
   python -mvenv venv
   source venv/bin/activate
   pip install -r gh_actions_requirements.txt
   python -m build
   pip install --force dist/*.whl
   rehash
   autopkg version
   ```

Known deficiencies:
* version number in pyproject.toml is hardcoded
* wheel more than likely will not be accepted into python.org pypi server due to packages in this repo all being top-level