### PR TITLE
Add curl_common_opts to prefetech_filename

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -174,6 +174,8 @@ class URLDownloader(URLGetter):
         """Attempt to find filename in HTTP headers."""
         curl_cmd = self.prepare_base_curl_cmd()
         curl_cmd.extend(["--head"])
+        # Add the common options
+        self.add_curl_common_opts(curl_cmd)
 
         raw_headers = self.download_with_curl(curl_cmd)
         header = self.parse_headers(raw_headers)


### PR DESCRIPTION
This allows for request_headers to be added to the curl command so that headers such as `Authorization` will be included while attempting to prefetch the filename, otherwise the prefetch will fail.