### PR TITLE
Fix curl command error in URLDownloader.prefetch_filename()

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -172,7 +172,7 @@ class URLDownloader(URLGetter):
     def prefetch_filename(self):
         """Attempt to find filename in HTTP headers."""
         curl_cmd = self.prepare_base_curl_cmd()
-        curl_cmd.extend(["--head", "--request", "GET"])
+        curl_cmd.extend(["--head"])
 
         raw_headers = self.download_with_curl(curl_cmd)
         header = self.parse_headers(raw_headers)


### PR DESCRIPTION
This reverts https://github.com/autopkg/autopkg/pull/626 which was added due to https://github.com/autopkg/autopkg/issues/624. 

Previously, combining `--head` and `--request GET` allowed curl to perform a GET request and stop after receiving the headers. This workaround was added to handle servers that return HTTP Forbidden or incorrect headers for a HEAD request. However, with the update to curl 8.6.0 on macOS 14.5, this combination results in an error ("curl: (8) Weird server reply").