### PR TITLE
Changes to allow running custom processors via command line usage/arguments

### DIFF
--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -585,11 +585,17 @@ class Processor:
         if self.env is None:
             return
 
+        plist_safe = {}
+        
+        for env_key in self.env:
+            if not self.env[env_key] is None:
+                plist_safe[env_key] = self.env[env_key] 
+
         try:
             with open(self.outfile, "wb") as f:
-                plistlib.dump(self.env, f)
+                plistlib.dump(plist_safe, f)
         except TypeError:
-            plistlib.dump(self.env, self.outfile.buffer)
+            plistlib.dump(plist_safe, self.outfile.buffer)
         except BaseException as err:
             raise ProcessorError(err) from err
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -596,6 +596,9 @@ class Processor:
     def parse_arguments(self):
         """Parse arguments as key='value'."""
 
+        if self.env is None:
+            self.env = {}
+
         for arg in sys.argv[1:]:
             (key, sep, value) = arg.partition("=")
             if sep != "=":

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -648,8 +648,10 @@ class Processor:
         """Execute as a standalone binary on the commandline."""
 
         try:
-            self.read_input_plist()
-            self.parse_arguments()
+            if not sys.argv[1:]:
+                self.read_input_plist()
+            else:
+                self.parse_arguments()
             self.process()
             self.write_output_plist()
         except ProcessorError as err:


### PR DESCRIPTION
This PR contains 3 changes to `autopkglib/__init__.py` which were found to be needed in order to run a customer processor with command line usage/arguments (as per: [https://github.com/autopkg/autopkg/wiki/Developing-Custom-Processors#sample-usage---command-line-argumentsvariables](https://github.com/autopkg/autopkg/wiki/Developing-Custom-Processors#sample-usage---command-line-argumentsvariables)).

I also raised a discussion on this: [https://github.com/autopkg/autopkg/discussions/952](https://github.com/autopkg/autopkg/discussions/952)

Basically, running a custom processors with a plist works.. but found that running custom processors via command line usage/arguments did not.. and found another issue too.

I'm happy though to have this PR closed without merging, if it's decided to just drop support for custom processors via command line usage/arguments. I can then submit another PR to remove from `autopkglib/__init__.py` and update: [https://github.com/autopkg/autopkg/wiki/Developing-Custom-Processors](https://github.com/autopkg/autopkg/wiki/Developing-Custom-Processors)

The changes are in their own commits, I've linked and added the commit messages below:

- 6675343 -  Parses self.env, and creates a new dict only with keys whose value is not None.
- 9e37ddf - Resolves an "TypeError: 'NoneType' object does not support item assignment" issue when calling a custom processor via command line usage/arguments.. as self.env is empty.. so this substantiates self.env as an empty dict.. which can then be appended to.
- e9db7b2 - Resolves an issue where autopkg would appear to hang when trying to call a custom processor via command line usage/arguments.