### PR TITLE
Add IGNORE_GITHUB_TOKEN option to GitHubReleasesInfoProvider

### DIFF
--- a/Code/autopkglib/GitHubReleasesInfoProvider.py
+++ b/Code/autopkglib/GitHubReleasesInfoProvider.py
@@ -96,6 +96,18 @@ class GitHubReleasesInfoProvider(Processor):
                 "takes precedence over this value."
             ),
         },
+        "IGNORE_GITHUB_TOKEN": {
+            "required": False,
+            "default": False,
+            "description": (
+                "If set to True, completely disables the use of GitHub "
+                "authentication tokens, regardless of any token files or "
+                "AutoPkg preferences. This is useful for situations where "
+                "a recipe accessing a public GitHub repository would fail "
+                "when a token is present for a private GitHub Enterprise "
+                "server."
+            ),
+        },
     }
     output_variables = {
         "release_notes": {
@@ -129,11 +141,19 @@ class GitHubReleasesInfoProvider(Processor):
         be of the form 'user/repo'"""
         releases = None
         curl_opts = self.env.get("curl_opts")
+
+        # Check if GitHub token should be disabled
+        # `github_token_path` is set to an empty string instead of None so that
+        # autopkglib.github.GitHubSession does not require any changes.
+        github_token_path = ''
+        if not self.env.get("IGNORE_GITHUB_TOKEN"):
+            github_token_path = self.env["GITHUB_TOKEN_PATH"]
+
         github = autopkglib.github.GitHubSession(
             self.env["CURL_PATH"],
             curl_opts,
             self.env["GITHUB_URL"],
-            self.env["GITHUB_TOKEN_PATH"],
+            github_token_path,
         )
         releases_uri = f"/repos/{repo}/releases"
         if latest_only:


### PR DESCRIPTION
Related to discussion in Slack https://macadmins.slack.com/archives/C056155B4/p1733954427657999

Currently, the `GitHubReleasesInfoProvider` reads the contents of `~/.autopkg_gh_token`, if present, or a custom path specified by the `GITHUB_TOKEN_PATH` input variable. This token is used for authentication on all API requests to GitHub.

Additionally, this processor can be used to access repositories hosted on private GitHub Enterprise instances by providing a `GITHUB_URL` input variable.

However, there’s a specific scenario where an admin wants to run a list of recipes that reference private GitHub Enterprise repositories using a valid token _and_ other recipes that reference public GitHub repositories in the same AutoPkg run. The admin would write their token for their private GitHub Enterprise instance to the known (or custom) path. Since the path exists, the token is sent for all requests, but this causes requests to public GitHub repositories to fail because the token is invalid for that use.

To address this issue, this PR introduces a new `IGNORE_GITHUB_TOKEN` input variable to `GitHubReleasesInfoProvider`. This variable allows for a per-recipe override of ignoring the presence of a GitHub token. When set to `True`, the processor disregards the authentication token regardless of the presence of a token path on disk. The default value for this variable is `False` to avoid affecting any existing recipes.

By enabling this variable, the admin can set their private token and access private GitHub Enterprise resources as expected. However, they can also disable token authentication for any overrides that access public repositories in the same recipe list.

--- 

An example override:

```
Identifier: local.download.Rectangle
Input:
  NAME: Rectangle
  PRERELEASE: ''
ParentRecipe: com.github.dataJAR-recipes.download.Rectangle
[truncated]
```

If we write an example token to disk via `echo 'INVALID_TOKEN' > ~/.autopkg_gh_token`, we'll see it used in the resulting curl command:

```
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/URLGetter.py", line 172, in execute_curl
    result = subprocess.run(
  File "/Library/AutoPkg/Python3/Python.framework/Versions/3.10/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/usr/bin/curl', '--location', '--silent', '--show-error', '--fail', '--dump-header', '-', '-X', 'GET', '--header', 'User-Agent: AutoPkg', '--header', 'Accept: application/vnd.github.v3+json', '--header', 'Authorization: token INVALID_TOKEN', '--url', 'https://api.github.com/repos/rxhanson/Rectangle/releases', '--output', '/var/folders/sd/_3ff253n67lgx8w8c4g3mpth0000gn/T/tmp7sijkkaj']' returned non-zero exit status 56.
```

If we add the new `IGNORE_GITHUB_TOKEN` variable to the override:

```
Identifier: local.download.Rectangle
Input:
  NAME: Rectangle
  PRERELEASE: ''
  IGNORE_GITHUB_TOKEN: true
ParentRecipe: com.github.dataJAR-recipes.download.Rectangle
[truncated]
```

We see the recipe succeed:

```
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '[\S]+\.dmg' among asset(s): Rectangle0.85.dmg, Rectangle91-86.delta, Rectangle91-87.delta, Rectangle91-88.delta, Rectangle91-89.delta, Rectangle91-90.delta
```