### PR TITLE
Updating to pull cert bundle from SSL_CERT_FILE if set

### DIFF
--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -331,10 +331,15 @@ class URLDownloaderPython(URLDownloader):
         return ctx
 
     def ssl_context_certifi(self):
-        """ssl context using certifi CAs"""
+        """SSL context using certifi CAs or custom CAs if the env SSL_CERT_FILE is set"""
         # this doesn't need to be a class method
         # https://stackoverflow.com/questions/24374400/verifying-https-certificates-with-urllib-request
-        return ssl.create_default_context(cafile=certifi.where())
+        ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        ctx.load_verify_locations(cafile=certifi.where())
+        if (cafile := os.environ.get("SSL_CERT_FILE")) is not None:
+            ctx.load_verify_locations(cafile=cafile)
+
+        return ctx
 
     def download_and_hash(self, file_save_path):
         """stream down file from url and calculate size & hashes"""

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -22,6 +22,7 @@ from hashlib import md5, sha1, sha256
 from urllib.request import Request, urlopen
 
 import certifi
+from autopkglib import Processor, ProcessorError
 from autopkglib.URLDownloader import URLDownloader
 
 __all__ = ["URLDownloaderPython"]
@@ -337,8 +338,12 @@ class URLDownloaderPython(URLDownloader):
         ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
         ctx.load_verify_locations(cafile=certifi.where())
         if (cafile := os.environ.get("SSL_CERT_FILE")) is not None:
+            self.output(f"SSL_CERT_FILE={cafile}", 1)
+            if not os.path.isfile(cafile):
+                raise ProcessorError(f"Certificate file '{cafile}' does not exist.")
+            if not os.access(cafile, os.R_OK):
+                raise ProcessorError(f"Certificate file '{cafile}' is not readable.")
             ctx.load_verify_locations(cafile=cafile)
-
         return ctx
 
     def download_and_hash(self, file_save_path):


### PR DESCRIPTION
This PR adds a small change into `ssl_context_certifi(self)` that will use the certificate bundle defined in the `SSL_CERT_FILE` environment variable if set.

It's common for SSL Inspection to be used on corp networks and this allows users to use this processor without needing to disable SSL validation with the `disable_ssl_validation` input.