### PR TITLE
Allow custom output variable name for FindAndReplace Processor

### DIFF
--- a/Code/autopkglib/FindAndReplace.py
+++ b/Code/autopkglib/FindAndReplace.py
@@ -44,6 +44,11 @@ class FindAndReplace(Processor):
             "description": 'The string that you want to replace the "find" '
             "string with.",
         },
+        "replace_output_var": {
+            "required": False,
+            "default": "output_string",
+            "description": "Variable to store the output to, defaults to `output_string`",
+        },
     }
     output_variables = {
         "output_string": {
@@ -56,10 +61,21 @@ class FindAndReplace(Processor):
         """Main process."""
 
         input_string = self.env["input_string"]
+        
+        # get name of variable to store output
+        replace_output_var = self.env.get("replace_output_var", "output_string")
+        
         find = self.env["find"]
         replace = self.env["replace"]
         self.output(f'Replacing "{find}" with "{replace}" in "{input_string}".')
-        self.env["output_string"] = self.env["input_string"].replace(find, replace)
+        self.env[replace_output_var] = self.env["input_string"].replace(find, replace)
+
+        # remove output_string from output variables in case a custom one was specified.
+        del self.output_variables["output_string"]
+        # set the custom or default output variable name in output_variables so it shows up in verbose output.
+        self.output_variables[replace_output_var] = {
+            "description": "The result of find/replace on the input string.",
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add ability to set custom output variable name.

I was already doing basically the same thing in some of my other processors, so I basically lift and shifted the code to this one.

Example output from a [test recipe](https://github.com/jgstew/jgstew-recipes/blob/main/Recipes-Examples/FindAndReplace.test.recipe.yaml):

```
Processing com.github.jgstew.test.FindAndReplace...
WARNING: com.github.jgstew.test.FindAndReplace is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
FindAndReplace
{'Input': {'find': '_',
           'input_string': '1_2_3',
           'replace': '.',
           'replace_output_var': 'version'}}
FindAndReplace: Replacing "_" with "." in "1_2_3".
{'Output': {'version': '1.2.3'}}
com.github.jgstew.SharedProcessors/AssertInputContainsString
{'Input': {'assert_string': '1.2.3', 'input_string': '1.2.3'}}
AssertInputContainsString: No value supplied for raise_error, setting default value of: True
AssertInputContainsString: `1.2.3` must contain `1.2.3`
{'Output': {'assert_result': 'found!'}}
```