### PR TITLE
tweak FindAndReplace.py to show output value in verbose output.

### DIFF
--- a/Code/autopkglib/FindAndReplace.py
+++ b/Code/autopkglib/FindAndReplace.py
@@ -79,7 +79,7 @@ class FindAndReplace(Processor):
         if result_output_var_name != "output_string":
             # remove output_string from output variables in case a custom one was specified.
             del self.output_variables["output_string"]
-            # set the custom or default output variable name in output_variables so it shows up in verbose output.
+            # set the custom variable name in output_variables so it shows up in verbose output.
             self.output_variables[result_output_var_name] = {
                 "description": "The result of find/replace on the input string.",
             }

--- a/Code/autopkglib/FindAndReplace.py
+++ b/Code/autopkglib/FindAndReplace.py
@@ -77,7 +77,7 @@ class FindAndReplace(Processor):
         self.env[output_var_name] = self.env["input_string"].replace(find, replace)
 
         if result_output_var_name != "output_string":
-            # remove output_string from output variables in case a custom one was specified.
+            # remove output_string from output variables because a custom one was specified.
             del self.output_variables["output_string"]
             # set the custom variable name in output_variables so it shows up in verbose output.
             self.output_variables[result_output_var_name] = {

--- a/Code/autopkglib/FindAndReplace.py
+++ b/Code/autopkglib/FindAndReplace.py
@@ -52,10 +52,8 @@ class FindAndReplace(Processor):
         },
     }
     output_variables = {
-        "result_output_var_name": {
-            "description": "Result of the find/replace operation. Note the actual name of "
-            'variable depends on the input variable "result_output_var_name" or is assigned '
-            'a default of "output_string."'
+        "output_string": {
+            "description": "The result of find/replace on the input string."
         }
     }
     description = __doc__
@@ -77,6 +75,14 @@ class FindAndReplace(Processor):
             f'and saving result to "{output_var_name}" variable.'
         )
         self.env[output_var_name] = self.env["input_string"].replace(find, replace)
+
+        if result_output_var_name != "output_string":
+            # remove output_string from output variables in case a custom one was specified.
+            del self.output_variables["output_string"]
+            # set the custom or default output variable name in output_variables so it shows up in verbose output.
+            self.output_variables[result_output_var_name] = {
+                "description": "The result of find/replace on the input string.",
+            }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
tweak FindAndReplace.py

Discussion on this in Slack DMs with @homebysix  

This allows the value of the output variable to show up in the verbose output, in a similar but simpler way to how URLTextSearcher does it. (URLTextSearcher allows multiple named group outputs in addition to the default one, FindAndReplace only allows 1 output.)