### PR TITLE
Ensure that CACHE_DIR is an absolute path

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2174,6 +2174,7 @@ def run_recipes(argv):
     cache_dir = os.path.expanduser(cache_dir)
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir, 0o755)
+    set_pref("CACHE_DIR", os.path.abspath(cache_dir))
     current_run_results_plist = os.path.join(cache_dir, "autopkg_results.plist")
 
     run_results = []


### PR DESCRIPTION
When using relative paths for cache_dir, you can hit several strange edgecases ranging from poorly behaved processors changing the working directory to [processors assuming the paths are relative to locations other than the CWD](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/PkgCreator.py#L68-L73)

For most users they can just pass an absolute path, but if you are running autopkg from within a build system that [uses remote execution like BUCK2](https://buck2.build/docs/api/bxl/Filesystem/#filesystemabs_path_unsafe), this is not always an easy option.

Translating relative paths here should allow for better reliability and make integration with build systems that use relative paths easier.