### PR TITLE
Automatic reformatting from black pre-commit hook

### DIFF
--- a/Code/tests/test_autopkg_other.py
+++ b/Code/tests/test_autopkg_other.py
@@ -286,15 +286,14 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info with no arguments prints tool info."""
         argv = ["autopkg", "info"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.print_tool_info"
-        ) as mock_print_tool_info:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.print_tool_info") as mock_print_tool_info,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser.add_option = unittest.mock.Mock()
@@ -319,15 +318,14 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info with single recipe that is found."""
         argv = ["autopkg", "info", "TestRecipe"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_info"
-        ) as mock_get_recipe_info:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_info") as mock_get_recipe_info,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser.add_option = unittest.mock.Mock()
@@ -360,15 +358,14 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info with single recipe that is not found."""
         argv = ["autopkg", "info", "NonExistentRecipe"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_info"
-        ) as mock_get_recipe_info:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_info") as mock_get_recipe_info,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser.add_option = unittest.mock.Mock()
@@ -401,11 +398,12 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info with too many arguments."""
         argv = ["autopkg", "info", "Recipe1", "Recipe2"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.log_err"
-        ) as mock_log_err:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser.add_option = unittest.mock.Mock()
@@ -423,15 +421,14 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info with custom override directories."""
         argv = ["autopkg", "info", "TestRecipe"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_info"
-        ) as mock_get_recipe_info:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_info") as mock_get_recipe_info,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser.add_option = unittest.mock.Mock()
@@ -464,15 +461,14 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info with custom search directories."""
         argv = ["autopkg", "info", "TestRecipe"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_info"
-        ) as mock_get_recipe_info:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_info") as mock_get_recipe_info,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser.add_option = unittest.mock.Mock()
@@ -505,15 +501,14 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info with quiet option disables suggestions and GitHub search."""
         argv = ["autopkg", "info", "TestRecipe"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_info"
-        ) as mock_get_recipe_info:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_info") as mock_get_recipe_info,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser.add_option = unittest.mock.Mock()
@@ -546,15 +541,14 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info with pull option enables auto-pull."""
         argv = ["autopkg", "info", "TestRecipe"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_info"
-        ) as mock_get_recipe_info:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_info") as mock_get_recipe_info,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser.add_option = unittest.mock.Mock()
@@ -587,15 +581,14 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info with both quiet and pull options."""
         argv = ["autopkg", "info", "TestRecipe"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_info"
-        ) as mock_get_recipe_info:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_info") as mock_get_recipe_info,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser.add_option = unittest.mock.Mock()
@@ -628,14 +621,13 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test get_info sets up parser correctly."""
         argv = ["autopkg", "info"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ) as mock_add_options, patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.get_override_dirs"
-        ), patch(
-            "autopkg.get_search_dirs"
-        ), patch(
-            "autopkg.print_tool_info"
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options") as mock_add_options,
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.get_override_dirs"),
+            patch("autopkg.get_search_dirs"),
+            patch("autopkg.print_tool_info"),
         ):
 
             mock_parser = unittest.mock.Mock()
@@ -686,17 +678,15 @@ class TestAutoPkgOther(unittest.TestCase):
             "pathname": {"description": "Path to downloaded file"}
         }
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -744,18 +734,15 @@ class TestAutoPkgOther(unittest.TestCase):
 
         mock_recipe = {"Process": []}
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.load_recipe"
-        ) as mock_load_recipe, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "builtins.print"
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("builtins.print"),
         ):
 
             mock_parser = unittest.mock.Mock()
@@ -790,11 +777,12 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test processor_info with no processor name."""
         argv = ["autopkg", "processor-info"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.log_err"
-        ) as mock_log_err:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -814,11 +802,12 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test processor_info with too many arguments."""
         argv = ["autopkg", "processor-info", "URLDownloader", "ExtraArg"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.log_err"
-        ) as mock_log_err:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -841,17 +830,15 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test processor_info with unknown processor."""
         argv = ["autopkg", "processor-info", "UnknownProcessor"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "autopkg.log_err"
-        ) as mock_log_err:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -875,17 +862,15 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test processor_info when get_processor raises AttributeError."""
         argv = ["autopkg", "processor-info", "BadProcessor"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "autopkg.log_err"
-        ) as mock_log_err:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -916,17 +901,15 @@ class TestAutoPkgOther(unittest.TestCase):
         mock_processor.input_variables = {}
         mock_processor.output_variables = {}
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -958,17 +941,15 @@ class TestAutoPkgOther(unittest.TestCase):
         mock_processor.input_variables = {}
         mock_processor.output_variables = {}
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -999,17 +980,15 @@ class TestAutoPkgOther(unittest.TestCase):
         del mock_processor.input_variables  # Remove input_variables attribute
         mock_processor.output_variables = {}
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -1039,17 +1018,15 @@ class TestAutoPkgOther(unittest.TestCase):
         mock_processor.input_variables = {}
         del mock_processor.output_variables  # Remove output_variables attribute
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -1098,17 +1075,15 @@ class TestAutoPkgOther(unittest.TestCase):
             },
         }
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -1161,12 +1136,12 @@ class TestAutoPkgOther(unittest.TestCase):
         mock_processor.input_variables = {}
         mock_processor.output_variables = {}
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.add_search_and_override_dir_options"
-        ), patch("autopkg.common_parse") as mock_common_parse, patch(
-            "autopkg.get_processor"
-        ) as mock_get_processor, patch(
-            "builtins.print"
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_processor") as mock_get_processor,
+            patch("builtins.print"),
         ):
 
             mock_parser = unittest.mock.Mock()
@@ -1193,13 +1168,12 @@ class TestAutoPkgOther(unittest.TestCase):
 
         mock_processor_names = ["URLDownloader", "CodeSignatureVerifier", "Copier"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.processor_names"
-        ) as mock_processor_names_func, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.processor_names") as mock_processor_names_func,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -1234,13 +1208,12 @@ class TestAutoPkgOther(unittest.TestCase):
         # Unsorted list of processors
         mock_processor_names = ["ZebraProcessor", "AlphaProcessor", "BetaProcessor"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.processor_names"
-        ) as mock_processor_names_func, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.processor_names") as mock_processor_names_func,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -1260,13 +1233,12 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test list_processors with empty processor list."""
         argv = ["autopkg", "list-processors"]
 
-        with patch("autopkg.gen_common_parser") as mock_parser_gen, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.processor_names"
-        ) as mock_processor_names_func, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser_gen,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.processor_names") as mock_processor_names_func,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = unittest.mock.Mock()
             mock_parser_gen.return_value = mock_parser
@@ -1287,11 +1259,14 @@ class TestAutoPkgOther(unittest.TestCase):
         recipe = {"RECIPE_PATH": "/recipes/TestApp.recipe"}
         env = {"RECIPE_SEARCH_DIRS": ["/search/dir1", "/search/dir2"]}
 
-        with patch("os.path.dirname") as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch("os.path.exists") as mock_exists, patch(
-            "os.path.join"
-        ) as mock_join:
+        with (
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
+        ):
 
             mock_dirname.return_value = "/recipes"
             mock_extract.return_value = ("TestProcessor", None)
@@ -1325,9 +1300,13 @@ class TestAutoPkgOther(unittest.TestCase):
         recipe = {"RECIPE_PATH": "/recipes/TestApp.recipe"}
         env = {"RECIPE_SEARCH_DIRS": ["/search/dir1"]}
 
-        with patch("os.path.dirname") as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch("os.path.exists") as mock_exists:
+        with (
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("os.path.exists") as mock_exists,
+        ):
 
             mock_dirname.return_value = "/recipes"
             mock_extract.return_value = ("NonExistentProcessor", None)
@@ -1343,15 +1322,15 @@ class TestAutoPkgOther(unittest.TestCase):
         recipe = {"RECIPE_PATH": "/recipes/TestApp.recipe"}
         env = {"RECIPE_SEARCH_DIRS": ["/search/dir1", "/search/dir2"]}
 
-        with patch("os.path.dirname") as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch(
-            "autopkg.find_recipe_by_identifier"
-        ) as mock_find_recipe, patch(
-            "os.path.exists"
-        ) as mock_exists, patch(
-            "os.path.join"
-        ) as mock_join:
+        with (
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("autopkg.find_recipe_by_identifier") as mock_find_recipe,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
+        ):
 
             mock_dirname.side_effect = lambda path: {
                 "/recipes/TestApp.recipe": "/recipes",
@@ -1388,11 +1367,14 @@ class TestAutoPkgOther(unittest.TestCase):
         }
         env = {"RECIPE_SEARCH_DIRS": ["/search/dir1"]}
 
-        with patch("os.path.dirname") as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch("os.path.exists") as mock_exists, patch(
-            "os.path.join"
-        ) as mock_join:
+        with (
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
+        ):
 
             def dirname_side_effect(path):
                 dirname_map = {
@@ -1420,15 +1402,15 @@ class TestAutoPkgOther(unittest.TestCase):
         recipe = {"RECIPE_PATH": "/recipes/TestApp.recipe"}
         env = None
 
-        with patch("autopkg.get_pref") as mock_get_pref, patch(
-            "os.path.dirname"
-        ) as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch(
-            "os.path.exists"
-        ) as mock_exists, patch(
-            "os.path.join"
-        ) as mock_join:
+        with (
+            patch("autopkg.get_pref") as mock_get_pref,
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
+        ):
 
             mock_get_pref.return_value = ["/default/search/dir"]
             mock_dirname.return_value = "/recipes"
@@ -1452,11 +1434,14 @@ class TestAutoPkgOther(unittest.TestCase):
         }
         env = {"RECIPE_SEARCH_DIRS": ["/search/dir1"]}
 
-        with patch("os.path.dirname") as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch("os.path.exists") as mock_exists, patch(
-            "os.path.join"
-        ) as mock_join:
+        with (
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
+        ):
 
             mock_dirname.side_effect = lambda path: {
                 "/recipes/TestApp.recipe": "/recipes",
@@ -1489,15 +1474,15 @@ class TestAutoPkgOther(unittest.TestCase):
         recipe = {"RECIPE_PATH": "/recipes/TestApp.recipe"}
         env = {"RECIPE_SEARCH_DIRS": ["/search/dir1"]}
 
-        with patch("os.path.dirname") as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch(
-            "autopkg.find_recipe_by_identifier"
-        ) as mock_find_recipe, patch(
-            "os.path.exists"
-        ) as mock_exists, patch(
-            "os.path.join"
-        ) as mock_join:
+        with (
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("autopkg.find_recipe_by_identifier") as mock_find_recipe,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
+        ):
 
             mock_dirname.return_value = "/recipes"
             mock_extract.return_value = ("TestProcessor", "com.missing.recipe")
@@ -1521,11 +1506,14 @@ class TestAutoPkgOther(unittest.TestCase):
         }
         env = {"RECIPE_SEARCH_DIRS": ["/search/dir1"]}
 
-        with patch("os.path.dirname") as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch("os.path.exists") as mock_exists, patch(
-            "os.path.join"
-        ) as mock_join:
+        with (
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
+        ):
 
             mock_dirname.return_value = "/recipes"
             mock_extract.return_value = ("TestProcessor", None)
@@ -1548,15 +1536,15 @@ class TestAutoPkgOther(unittest.TestCase):
         }
         env = {"RECIPE_SEARCH_DIRS": ["/search1", "/search2"]}
 
-        with patch("os.path.dirname") as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch(
-            "autopkg.find_recipe_by_identifier"
-        ) as mock_find_recipe, patch(
-            "os.path.exists"
-        ) as mock_exists, patch(
-            "os.path.join"
-        ) as mock_join:
+        with (
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("autopkg.find_recipe_by_identifier") as mock_find_recipe,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
+        ):
 
             def dirname_side_effect(path):
                 dirname_map = {
@@ -1597,15 +1585,15 @@ class TestAutoPkgOther(unittest.TestCase):
         recipe = {"RECIPE_PATH": "/recipes/TestApp.recipe"}
         env = None
 
-        with patch("autopkg.get_pref") as mock_get_pref, patch(
-            "os.path.dirname"
-        ) as mock_dirname, patch(
-            "autopkg.extract_processor_name_with_recipe_identifier"
-        ) as mock_extract, patch(
-            "os.path.exists"
-        ) as mock_exists, patch(
-            "os.path.join"
-        ) as mock_join:
+        with (
+            patch("autopkg.get_pref") as mock_get_pref,
+            patch("os.path.dirname") as mock_dirname,
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
+        ):
 
             mock_get_pref.return_value = None  # No search dirs in prefs
             mock_dirname.return_value = "/recipes"
@@ -1892,10 +1880,11 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test main() shows warning when running as root on macOS."""
         argv = ["autopkg", "version"]
 
-        with patch("autopkg.is_mac", return_value=True), patch(
-            "os.getuid", return_value=0
-        ), patch("autopkg.log_err") as mock_log_err, patch(
-            "autopkg.print_version", return_value=0
+        with (
+            patch("autopkg.is_mac", return_value=True),
+            patch("os.getuid", return_value=0),
+            patch("autopkg.log_err") as mock_log_err,
+            patch("autopkg.print_version", return_value=0),
         ):
 
             autopkg.main(argv)
@@ -1912,10 +1901,11 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test main() doesn't show root warning when not running as root."""
         argv = ["autopkg", "version"]
 
-        with patch("autopkg.is_mac", return_value=True), patch(
-            "os.getuid", return_value=1000
-        ), patch("autopkg.log_err") as mock_log_err, patch(
-            "autopkg.print_version", return_value=0
+        with (
+            patch("autopkg.is_mac", return_value=True),
+            patch("os.getuid", return_value=1000),
+            patch("autopkg.log_err") as mock_log_err,
+            patch("autopkg.print_version", return_value=0),
         ):
 
             autopkg.main(argv)

--- a/Code/tests/test_autopkg_overrides.py
+++ b/Code/tests/test_autopkg_overrides.py
@@ -49,19 +49,15 @@ class TestAutoPkgOverrides(unittest.TestCase):
             ],
         }
 
-        with patch.object(autopkg, "getsha256hash") as mock_hash, patch.object(
-            autopkg, "get_git_commit_hash"
-        ) as mock_git_hash, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "get_identifier"
-        ) as mock_get_identifier, patch.object(
-            autopkg, "core_processor_names"
-        ) as mock_core_processors, patch.object(
-            autopkg, "find_processor_path"
-        ) as mock_find_processor, patch.object(
-            autopkg, "os_path_compressuser"
-        ) as mock_compress:
+        with (
+            patch.object(autopkg, "getsha256hash") as mock_hash,
+            patch.object(autopkg, "get_git_commit_hash") as mock_git_hash,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_identifier") as mock_get_identifier,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "find_processor_path") as mock_find_processor,
+            patch.object(autopkg, "os_path_compressuser") as mock_compress,
+        ):
 
             mock_hash.side_effect = ["recipe_hash", "parent_hash", "processor_hash"]
             mock_git_hash.side_effect = ["recipe_git", "parent_git", "processor_git"]
@@ -98,21 +94,16 @@ class TestAutoPkgOverrides(unittest.TestCase):
             "Process": [{"Processor": "MissingProcessor"}],
         }
 
-        with patch.object(autopkg, "getsha256hash") as mock_hash, patch.object(
-            autopkg, "get_git_commit_hash"
-        ) as mock_git_hash, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "get_identifier"
-        ) as mock_get_identifier, patch.object(
-            autopkg, "core_processor_names"
-        ) as mock_core_processors, patch.object(
-            autopkg, "find_processor_path"
-        ) as mock_find_processor, patch.object(
-            autopkg, "os_path_compressuser"
-        ) as mock_compress, patch.object(
-            autopkg, "log_err"
-        ) as mock_log_err:
+        with (
+            patch.object(autopkg, "getsha256hash") as mock_hash,
+            patch.object(autopkg, "get_git_commit_hash") as mock_git_hash,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_identifier") as mock_get_identifier,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "find_processor_path") as mock_find_processor,
+            patch.object(autopkg, "os_path_compressuser") as mock_compress,
+            patch.object(autopkg, "log_err") as mock_log_err,
+        ):
 
             mock_hash.return_value = "recipe_hash"
             mock_git_hash.return_value = "recipe_git"
@@ -175,13 +166,11 @@ class TestAutoPkgOverrides(unittest.TestCase):
             "ParentRecipeTrustInfo": {"test": "info"},
         }
 
-        with patch.object(
-            autopkg, "recipe_in_override_dir"
-        ) as mock_in_override, patch.object(
-            autopkg, "recipe_from_external_repo"
-        ) as mock_external, patch.object(
-            autopkg, "get_pref"
-        ) as mock_get_pref:
+        with (
+            patch.object(autopkg, "recipe_in_override_dir") as mock_in_override,
+            patch.object(autopkg, "recipe_from_external_repo") as mock_external,
+            patch.object(autopkg, "get_pref") as mock_get_pref,
+        ):
 
             mock_in_override.return_value = True
             mock_external.return_value = True
@@ -200,17 +189,13 @@ class TestAutoPkgOverrides(unittest.TestCase):
             "ParentRecipeTrustInfo": {"test": "info"},
         }
 
-        with patch.object(
-            autopkg, "recipe_in_override_dir"
-        ) as mock_in_override, patch.object(
-            autopkg, "recipe_from_external_repo"
-        ) as mock_external, patch.object(
-            autopkg, "get_pref"
-        ) as mock_get_pref, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "get_trust_info"
-        ) as mock_get_trust_info:
+        with (
+            patch.object(autopkg, "recipe_in_override_dir") as mock_in_override,
+            patch.object(autopkg, "recipe_from_external_repo") as mock_external,
+            patch.object(autopkg, "get_pref") as mock_get_pref,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_trust_info") as mock_get_trust_info,
+        ):
 
             mock_in_override.return_value = True
             mock_external.return_value = False
@@ -232,19 +217,14 @@ class TestAutoPkgOverrides(unittest.TestCase):
             },
         }
 
-        with patch.object(
-            autopkg, "recipe_in_override_dir"
-        ) as mock_in_override, patch.object(
-            autopkg, "recipe_from_external_repo"
-        ) as mock_external, patch.object(
-            autopkg, "get_pref"
-        ) as mock_get_pref, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "get_trust_info"
-        ) as mock_get_trust_info, patch.object(
-            autopkg, "find_processor_path"
-        ) as mock_find_processor:
+        with (
+            patch.object(autopkg, "recipe_in_override_dir") as mock_in_override,
+            patch.object(autopkg, "recipe_from_external_repo") as mock_external,
+            patch.object(autopkg, "get_pref") as mock_get_pref,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_trust_info") as mock_get_trust_info,
+            patch.object(autopkg, "find_processor_path") as mock_find_processor,
+        ):
 
             mock_in_override.return_value = True
             mock_external.return_value = False
@@ -268,31 +248,20 @@ class TestAutoPkgOverrides(unittest.TestCase):
         mock_parent_recipe = {"Identifier": "com.test.parent"}
         mock_trust_info = {"test": "info"}
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "locate_recipe"
-        ) as mock_locate_recipe, patch.object(
-            autopkg, "recipe_from_file"
-        ) as mock_recipe_from_file, patch.object(
-            autopkg, "recipe_in_override_dir"
-        ) as mock_in_override, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "get_trust_info"
-        ) as mock_get_trust_info, patch.object(
-            autopkg, "plist_serializer"
-        ) as mock_plist_serializer, patch(
-            "builtins.open", mock_open()
-        ) as _:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "locate_recipe") as mock_locate_recipe,
+            patch.object(autopkg, "recipe_from_file") as mock_recipe_from_file,
+            patch.object(autopkg, "recipe_in_override_dir") as mock_in_override,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_trust_info") as mock_get_trust_info,
+            patch.object(autopkg, "plist_serializer") as mock_plist_serializer,
+            patch("builtins.open", mock_open()) as _,
+        ):
 
             mock_parser = Mock()
             mock_parser_gen.return_value = mock_parser
@@ -319,15 +288,12 @@ class TestAutoPkgOverrides(unittest.TestCase):
     @patch("sys.argv", ["autopkg", "update-trust-info"])
     def test_update_trust_info_no_recipes(self):
         """Test update_trust_info command with no recipe names provided."""
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "log_err"
-        ) as mock_log_err:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "log_err") as mock_log_err,
+        ):
 
             mock_parser = Mock()
             mock_parser_gen.return_value = mock_parser
@@ -348,23 +314,16 @@ class TestAutoPkgOverrides(unittest.TestCase):
             "ParentRecipeTrustInfo": {"test": "info"},
         }
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "verify_parent_trust"
-        ) as mock_verify_trust, patch.object(
-            autopkg, "log"
-        ) as mock_log:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "verify_parent_trust") as mock_verify_trust,
+            patch.object(autopkg, "log") as mock_log,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -395,23 +354,16 @@ class TestAutoPkgOverrides(unittest.TestCase):
             "ParentRecipe": "com.test.parent",
         }
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "verify_parent_trust"
-        ) as mock_verify_trust, patch.object(
-            autopkg, "log_err"
-        ) as mock_log_err:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "verify_parent_trust") as mock_verify_trust,
+            patch.object(autopkg, "log_err") as mock_log_err,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -448,33 +400,22 @@ class TestAutoPkgOverrides(unittest.TestCase):
 
     def test_make_override_success_plist_format(self):
         """Test successful override creation in plist format."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.load_recipe"
-        ) as mock_load_recipe, patch(
-            "autopkg.get_identifier"
-        ) as mock_get_identifier, patch(
-            "autopkg.get_trust_info"
-        ) as mock_get_trust_info, patch(
-            "autopkg.remove_recipe_extension"
-        ) as mock_remove_recipe_ext, patch(
-            "autopkg.log"
-        ), patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.exists"
-        ) as mock_exists, patch(
-            "builtins.open", mock_open()
-        ), patch(
-            "plistlib.dump"
-        ) as mock_plist_dump, patch(
-            "autopkg.plist_serializer"
-        ) as mock_plist_serializer:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.get_trust_info") as mock_get_trust_info,
+            patch("autopkg.remove_recipe_extension") as mock_remove_recipe_ext,
+            patch("autopkg.log"),
+            patch("os.path.isfile") as mock_isfile,
+            patch("os.path.exists") as mock_exists,
+            patch("builtins.open", mock_open()),
+            patch("plistlib.dump") as mock_plist_dump,
+            patch("autopkg.plist_serializer") as mock_plist_serializer,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -520,33 +461,22 @@ class TestAutoPkgOverrides(unittest.TestCase):
 
     def test_make_override_success_yaml_format(self):
         """Test successful override creation in yaml format."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.load_recipe"
-        ) as mock_load_recipe, patch(
-            "autopkg.get_identifier"
-        ) as mock_get_identifier, patch(
-            "autopkg.get_trust_info"
-        ) as mock_get_trust_info, patch(
-            "autopkg.remove_recipe_extension"
-        ) as mock_remove_recipe_ext, patch(
-            "autopkg.log"
-        ), patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.exists"
-        ) as mock_exists, patch(
-            "builtins.open", mock_open()
-        ), patch(
-            "yaml.dump"
-        ) as mock_yaml_dump, patch(
-            "autopkg.plist_serializer"
-        ) as mock_plist_serializer:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.get_trust_info") as mock_get_trust_info,
+            patch("autopkg.remove_recipe_extension") as mock_remove_recipe_ext,
+            patch("autopkg.log"),
+            patch("os.path.isfile") as mock_isfile,
+            patch("os.path.exists") as mock_exists,
+            patch("builtins.open", mock_open()),
+            patch("yaml.dump") as mock_yaml_dump,
+            patch("autopkg.plist_serializer") as mock_plist_serializer,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -592,9 +522,10 @@ class TestAutoPkgOverrides(unittest.TestCase):
 
     def test_make_override_no_arguments(self):
         """Test make_override with no recipe arguments."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -608,9 +539,10 @@ class TestAutoPkgOverrides(unittest.TestCase):
 
     def test_make_override_multiple_arguments(self):
         """Test make_override with multiple recipe arguments."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -626,9 +558,11 @@ class TestAutoPkgOverrides(unittest.TestCase):
 
     def test_make_override_absolute_path_error(self):
         """Test make_override with absolute path recipe name."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch("os.path.isfile") as mock_isfile:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("os.path.isfile") as mock_isfile,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -645,18 +579,14 @@ class TestAutoPkgOverrides(unittest.TestCase):
 
     def test_make_override_recipe_not_found(self):
         """Test make_override when recipe cannot be found."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.load_recipe"
-        ) as mock_load_recipe, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "autopkg.log"
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("os.path.isfile") as mock_isfile,
+            patch("autopkg.log"),
         ):
 
             mock_parser_instance = Mock()
@@ -681,20 +611,15 @@ class TestAutoPkgOverrides(unittest.TestCase):
 
     def test_make_override_deprecated_recipe_without_ignore(self):
         """Test make_override with deprecated recipe without ignore flag."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.load_recipe"
-        ) as mock_load_recipe, patch(
-            "autopkg.get_identifier"
-        ) as mock_get_identifier, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "autopkg.log"
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("os.path.isfile") as mock_isfile,
+            patch("autopkg.log"),
         ):
 
             mock_parser_instance = Mock()
@@ -735,20 +660,15 @@ class TestAutoPkgOverrides(unittest.TestCase):
 
     def test_make_override_no_identifier(self):
         """Test make_override when recipe has no identifier."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.load_recipe"
-        ) as mock_load_recipe, patch(
-            "autopkg.get_identifier"
-        ) as mock_get_identifier, patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "autopkg.log"
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("os.path.isfile") as mock_isfile,
+            patch("autopkg.log"),
         ):
 
             mock_parser_instance = Mock()
@@ -779,33 +699,22 @@ class TestAutoPkgOverrides(unittest.TestCase):
 
     def test_make_override_force_overwrite(self):
         """Test make_override with force overwrite option."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.load_recipe"
-        ) as mock_load_recipe, patch(
-            "autopkg.get_identifier"
-        ) as mock_get_identifier, patch(
-            "autopkg.get_trust_info"
-        ) as mock_get_trust_info, patch(
-            "autopkg.remove_recipe_extension"
-        ) as mock_remove_recipe_ext, patch(
-            "autopkg.log"
-        ), patch(
-            "os.path.isfile"
-        ) as mock_isfile, patch(
-            "os.path.exists"
-        ) as mock_exists, patch(
-            "builtins.open", mock_open()
-        ), patch(
-            "plistlib.dump"
-        ) as mock_plist_dump, patch(
-            "autopkg.plist_serializer"
-        ) as mock_plist_serializer:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.get_trust_info") as mock_get_trust_info,
+            patch("autopkg.remove_recipe_extension") as mock_remove_recipe_ext,
+            patch("autopkg.log"),
+            patch("os.path.isfile") as mock_isfile,
+            patch("os.path.exists") as mock_exists,
+            patch("builtins.open", mock_open()),
+            patch("plistlib.dump") as mock_plist_dump,
+            patch("autopkg.plist_serializer") as mock_plist_serializer,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance

--- a/Code/tests/test_autopkg_recipes.py
+++ b/Code/tests/test_autopkg_recipes.py
@@ -1301,25 +1301,17 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Input": {"test_key": "test_value"},
         }
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "find_http_urls_in_recipe"
-        ) as mock_find_urls, patch.object(
-            autopkg, "core_processor_names"
-        ) as mock_core_processors, patch.object(
-            autopkg, "log"
-        ) as mock_log:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "find_http_urls_in_recipe") as mock_find_urls,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "log") as mock_log,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -1356,25 +1348,17 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Input": {},
         }
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "find_http_urls_in_recipe"
-        ) as mock_find_urls, patch.object(
-            autopkg, "core_processor_names"
-        ) as mock_core_processors, patch.object(
-            autopkg, "log"
-        ) as mock_log:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "find_http_urls_in_recipe") as mock_find_urls,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "log") as mock_log,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -1409,27 +1393,18 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Input": {"url": "http://insecure.example.com/file.dmg"},
         }
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "find_http_urls_in_recipe"
-        ) as mock_find_urls, patch.object(
-            autopkg, "core_processor_names"
-        ) as mock_core_processors, patch.object(
-            autopkg, "printplist"
-        ) as mock_printplist, patch.object(
-            autopkg, "log"
-        ) as mock_log:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "find_http_urls_in_recipe") as mock_find_urls,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "printplist") as mock_printplist,
+            patch.object(autopkg, "log") as mock_log,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -1468,25 +1443,17 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Input": {},
         }
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "find_http_urls_in_recipe"
-        ) as mock_find_urls, patch.object(
-            autopkg, "core_processor_names"
-        ) as mock_core_processors, patch.object(
-            autopkg, "log"
-        ) as mock_log:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "find_http_urls_in_recipe") as mock_find_urls,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "log") as mock_log,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -1527,25 +1494,17 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Input": {},
         }
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "find_http_urls_in_recipe"
-        ) as mock_find_urls, patch.object(
-            autopkg, "core_processor_names"
-        ) as mock_core_processors, patch.object(
-            autopkg, "log"
-        ) as mock_log:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "find_http_urls_in_recipe") as mock_find_urls,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "log") as mock_log,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -1584,25 +1543,17 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Input": {"url": "http://insecure.example.com/file.dmg"},
         }
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "find_http_urls_in_recipe"
-        ) as mock_find_urls, patch.object(
-            autopkg, "core_processor_names"
-        ) as mock_core_processors, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "find_http_urls_in_recipe") as mock_find_urls,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -1638,26 +1589,17 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Input": {},
         }
 
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "parse_recipe_list"
-        ) as mock_parse_recipe_list, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "find_http_urls_in_recipe"
-        ) as mock_find_urls, patch.object(
-            autopkg, "core_processor_names"
-        ) as mock_core_processors, patch(
-            "sys.stdout", new_callable=StringIO
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "parse_recipe_list") as mock_parse_recipe_list,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "find_http_urls_in_recipe") as mock_find_urls,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch("sys.stdout", new_callable=StringIO),
         ):
 
             mock_parser = Mock()
@@ -1691,19 +1633,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
     @patch("sys.argv", ["autopkg", "audit"])
     def test_audit_no_recipes_provided(self):
         """Test audit command with no recipes provided."""
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "log_err"
-        ) as mock_log_err:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "log_err") as mock_log_err,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -1726,21 +1663,15 @@ class TestAutoPkgRecipes(unittest.TestCase):
     @patch("sys.argv", ["autopkg", "audit", "nonexistent.recipe"])
     def test_audit_recipe_not_found(self):
         """Test audit command with a recipe that cannot be found."""
-        with patch.object(
-            autopkg, "gen_common_parser"
-        ) as mock_parser_gen, patch.object(
-            autopkg, "add_search_and_override_dir_options"
-        ), patch.object(
-            autopkg, "common_parse"
-        ) as mock_parse, patch.object(
-            autopkg, "get_override_dirs"
-        ) as mock_get_override_dirs, patch.object(
-            autopkg, "get_search_dirs"
-        ) as mock_get_search_dirs, patch.object(
-            autopkg, "load_recipe"
-        ) as mock_load_recipe, patch.object(
-            autopkg, "log_err"
-        ) as mock_log_err:
+        with (
+            patch.object(autopkg, "gen_common_parser") as mock_parser_gen,
+            patch.object(autopkg, "add_search_and_override_dir_options"),
+            patch.object(autopkg, "common_parse") as mock_parse,
+            patch.object(autopkg, "get_override_dirs") as mock_get_override_dirs,
+            patch.object(autopkg, "get_search_dirs") as mock_get_search_dirs,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "log_err") as mock_log_err,
+        ):
 
             mock_parser = Mock()
             mock_parser.add_option = Mock()
@@ -1764,17 +1695,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_basic_output(self):
         """Test list_recipes command with basic output format."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -1811,17 +1739,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_with_identifiers(self):
         """Test list_recipes command with identifiers included."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -1863,18 +1788,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_with_paths(self):
         """Test list_recipes command with paths included."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print, patch.dict(
-            "os.environ", {"HOME": "/Users/testuser"}
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+            patch.dict("os.environ", {"HOME": "/Users/testuser"}),
         ):
 
             mock_parser_instance = Mock()
@@ -1918,19 +1839,15 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_plist_format(self):
         """Test list_recipes command with plist output format."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print, patch(
-            "plistlib.dumps"
-        ) as mock_dumps:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+            patch("plistlib.dumps") as mock_dumps,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -1965,16 +1882,13 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_show_all_with_augmented_list(self):
         """Test list_recipes command with show-all option and augmented list."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print"),
         ):
 
             mock_parser_instance = Mock()
@@ -2018,9 +1932,11 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_show_all_without_augmented_list_error(self):
         """Test list_recipes command with show-all option but no augmented list flags."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch("autopkg.log_err") as mock_log_err:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -2044,9 +1960,11 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_plist_with_identifiers_error(self):
         """Test list_recipes command with plist and identifiers options (invalid combination)."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch("autopkg.log_err") as mock_log_err:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -2072,9 +1990,11 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_plist_with_paths_error(self):
         """Test list_recipes command with plist and paths options (invalid combination)."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch("autopkg.log_err") as mock_log_err:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -2100,18 +2020,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_with_identifiers_and_paths(self):
         """Test list_recipes command with both identifiers and paths."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print, patch.dict(
-            "os.environ", {"HOME": "/Users/testuser"}
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+            patch.dict("os.environ", {"HOME": "/Users/testuser"}),
         ):
 
             mock_parser_instance = Mock()
@@ -2151,17 +2067,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_empty_recipe_list(self):
         """Test list_recipes command with empty recipe list."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -2187,12 +2100,11 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_custom_directories(self):
         """Test list_recipes command with custom override and search directories."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print"),
         ):
 
             mock_parser_instance = Mock()
@@ -2231,17 +2143,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_missing_identifier_in_recipe(self):
         """Test list_recipes command when recipe is missing Identifier."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -2278,17 +2187,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_missing_path_in_recipe(self):
         """Test list_recipes command when recipe is missing Path."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -2323,17 +2229,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_case_insensitive_sorting(self):
         """Test list_recipes command sorts recipes case-insensitively."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -2373,17 +2276,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_list_recipes_deduplication(self):
         """Test list_recipes command removes duplicate output strings."""
-        with patch("autopkg.gen_common_parser") as mock_parser, patch(
-            "autopkg.common_parse"
-        ) as mock_common_parse, patch(
-            "autopkg.get_override_dirs"
-        ) as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch(
-            "autopkg.get_recipe_list"
-        ) as mock_get_recipe_list, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse") as mock_common_parse,
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("autopkg.get_recipe_list") as mock_get_recipe_list,
+            patch("builtins.print") as mock_print,
+        ):
 
             mock_parser_instance = Mock()
             mock_parser.return_value = mock_parser_instance
@@ -2433,15 +2333,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [{"Processor": "URLDownloader"}],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2476,9 +2375,10 @@ class TestAutoPkgRecipes(unittest.TestCase):
         override_dirs = ["/overrides"]
         recipe_dirs = ["/recipes"]
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log_err"
-        ) as mock_log_err:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_load_recipe.return_value = None  # Recipe not found
 
@@ -2511,15 +2411,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2556,15 +2455,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             ],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2596,15 +2494,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [{"Processor": "MunkiImporter"}],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2631,15 +2528,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [{"Processor": "EndOfCheckPhase"}],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2666,15 +2562,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [{"Processor": "PkgCreator"}],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2705,17 +2600,15 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package, patch(
-            "pprint.pformat"
-        ) as mock_pformat:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+            patch("pprint.pformat") as mock_pformat,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2745,15 +2638,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2780,15 +2672,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2815,15 +2706,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ), patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log"),
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2865,15 +2755,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
             # No PARENT_RECIPES key
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2906,17 +2795,15 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Process": [],
         }
 
-        with patch("autopkg.load_recipe") as mock_load_recipe, patch(
-            "autopkg.log"
-        ) as mock_log, patch("autopkg.get_identifier") as mock_get_identifier, patch(
-            "autopkg.has_munkiimporter_step"
-        ) as mock_has_munki, patch(
-            "autopkg.has_check_phase"
-        ) as mock_has_check, patch(
-            "autopkg.builds_a_package"
-        ) as mock_builds_package, patch(
-            "pprint.pformat"
-        ) as mock_pformat:
+        with (
+            patch("autopkg.load_recipe") as mock_load_recipe,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.has_munkiimporter_step") as mock_has_munki,
+            patch("autopkg.has_check_phase") as mock_has_check,
+            patch("autopkg.builds_a_package") as mock_builds_package,
+            patch("pprint.pformat") as mock_pformat,
+        ):
 
             mock_load_recipe.return_value = mock_recipe
             mock_get_identifier.return_value = "com.example.test"
@@ -2933,11 +2820,12 @@ class TestAutoPkgRecipes(unittest.TestCase):
 
     def test_get_recipe_list_no_directories_provided(self):
         """Test get_recipe_list when no directories are provided."""
-        with patch("autopkg.get_override_dirs") as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch("os.path.isdir") as mock_isdir, patch(
-            "glob.glob"
-        ) as mock_glob:
+        with (
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("os.path.isdir") as mock_isdir,
+            patch("glob.glob") as mock_glob,
+        ):
 
             mock_get_override_dirs.return_value = ["/default/overrides"]
             mock_get_search_dirs.return_value = ["/default/recipes"]
@@ -2971,23 +2859,18 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Input": {"NAME": "CustomTestApp"},
         }
 
-        with patch("autopkg.get_override_dirs") as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch("os.path.isdir") as mock_isdir, patch(
-            "glob.glob"
-        ) as mock_glob, patch(
-            "autopkg.recipe_from_file"
-        ) as mock_recipe_from_file, patch(
-            "autopkg.valid_recipe_dict"
-        ) as mock_valid_recipe, patch(
-            "autopkg.valid_override_dict"
-        ) as mock_valid_override, patch(
-            "autopkg.get_identifier"
-        ) as mock_get_identifier, patch(
-            "autopkg.remove_recipe_extension"
-        ) as mock_remove_ext, patch(
-            "os.path.basename"
-        ) as mock_basename:
+        with (
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("os.path.isdir") as mock_isdir,
+            patch("glob.glob") as mock_glob,
+            patch("autopkg.recipe_from_file") as mock_recipe_from_file,
+            patch("autopkg.valid_recipe_dict") as mock_valid_recipe,
+            patch("autopkg.valid_override_dict") as mock_valid_override,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.remove_recipe_extension") as mock_remove_ext,
+            patch("os.path.basename") as mock_basename,
+        ):
 
             mock_get_override_dirs.return_value = override_dirs
             mock_get_search_dirs.return_value = search_dirs
@@ -3044,23 +2927,18 @@ class TestAutoPkgRecipes(unittest.TestCase):
             "Input": {"NAME": "CustomTestApp"},
         }
 
-        with patch("autopkg.get_override_dirs") as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch("os.path.isdir") as mock_isdir, patch(
-            "glob.glob"
-        ) as mock_glob, patch(
-            "autopkg.recipe_from_file"
-        ) as mock_recipe_from_file, patch(
-            "autopkg.valid_recipe_dict"
-        ) as mock_valid_recipe, patch(
-            "autopkg.valid_override_dict"
-        ) as mock_valid_override, patch(
-            "autopkg.get_identifier"
-        ) as mock_get_identifier, patch(
-            "autopkg.remove_recipe_extension"
-        ) as mock_remove_ext, patch(
-            "os.path.basename"
-        ) as mock_basename:
+        with (
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("os.path.isdir") as mock_isdir,
+            patch("glob.glob") as mock_glob,
+            patch("autopkg.recipe_from_file") as mock_recipe_from_file,
+            patch("autopkg.valid_recipe_dict") as mock_valid_recipe,
+            patch("autopkg.valid_override_dict") as mock_valid_override,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.remove_recipe_extension") as mock_remove_ext,
+            patch("os.path.basename") as mock_basename,
+        ):
 
             mock_get_override_dirs.return_value = override_dirs
             mock_get_search_dirs.return_value = search_dirs
@@ -3101,17 +2979,15 @@ class TestAutoPkgRecipes(unittest.TestCase):
         override_dirs = ["/overrides"]
         search_dirs = ["/recipes"]
 
-        with patch("autopkg.get_override_dirs") as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch("os.path.isdir") as mock_isdir, patch(
-            "glob.glob"
-        ) as mock_glob, patch(
-            "autopkg.recipe_from_file"
-        ) as mock_recipe_from_file, patch(
-            "autopkg.valid_recipe_dict"
-        ) as mock_valid_recipe, patch(
-            "autopkg.valid_override_dict"
-        ) as mock_valid_override:
+        with (
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("os.path.isdir") as mock_isdir,
+            patch("glob.glob") as mock_glob,
+            patch("autopkg.recipe_from_file") as mock_recipe_from_file,
+            patch("autopkg.valid_recipe_dict") as mock_valid_recipe,
+            patch("autopkg.valid_override_dict") as mock_valid_override,
+        ):
 
             mock_get_override_dirs.return_value = override_dirs
             mock_get_search_dirs.return_value = search_dirs
@@ -3139,23 +3015,18 @@ class TestAutoPkgRecipes(unittest.TestCase):
             # No top-level Identifier
         }
 
-        with patch("autopkg.get_override_dirs") as mock_get_override_dirs, patch(
-            "autopkg.get_search_dirs"
-        ) as mock_get_search_dirs, patch("os.path.isdir") as mock_isdir, patch(
-            "glob.glob"
-        ) as mock_glob, patch(
-            "autopkg.recipe_from_file"
-        ) as mock_recipe_from_file, patch(
-            "autopkg.valid_recipe_dict"
-        ) as mock_valid_recipe, patch(
-            "autopkg.valid_override_dict"
-        ) as mock_valid_override, patch(
-            "autopkg.get_identifier"
-        ) as mock_get_identifier, patch(
-            "autopkg.remove_recipe_extension"
-        ) as mock_remove_ext, patch(
-            "os.path.basename"
-        ) as mock_basename:
+        with (
+            patch("autopkg.get_override_dirs") as mock_get_override_dirs,
+            patch("autopkg.get_search_dirs") as mock_get_search_dirs,
+            patch("os.path.isdir") as mock_isdir,
+            patch("glob.glob") as mock_glob,
+            patch("autopkg.recipe_from_file") as mock_recipe_from_file,
+            patch("autopkg.valid_recipe_dict") as mock_valid_recipe,
+            patch("autopkg.valid_override_dict") as mock_valid_override,
+            patch("autopkg.get_identifier") as mock_get_identifier,
+            patch("autopkg.remove_recipe_extension") as mock_remove_ext,
+            patch("os.path.basename") as mock_basename,
+        ):
 
             mock_get_override_dirs.return_value = []
             mock_get_search_dirs.return_value = search_dirs
@@ -3394,17 +3265,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
         """Test new_recipe creates a basic plist recipe."""
         argv = ["autopkg", "new-recipe", "test.recipe"]
 
-        with patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.gen_common_parser"
-        ) as mock_parser, patch(
-            "builtins.open", unittest.mock.mock_open()
-        ) as mock_file, patch(
-            "autopkg.plistlib.dump"
-        ) as mock_plist_dump, patch(
-            "autopkg.log"
-        ) as mock_log, patch(
-            "autopkg.plist_serializer"
-        ) as mock_serializer:
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("builtins.open", unittest.mock.mock_open()) as mock_file,
+            patch("autopkg.plistlib.dump") as mock_plist_dump,
+            patch("autopkg.log") as mock_log,
+            patch("autopkg.plist_serializer") as mock_serializer,
+        ):
 
             # Mock parser setup
             mock_parser_obj = unittest.mock.Mock()
@@ -3440,15 +3308,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
         """Test new_recipe with custom identifier."""
         argv = ["autopkg", "new-recipe", "custom.recipe"]
 
-        with patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.gen_common_parser"
-        ) as mock_parser, patch("builtins.open", unittest.mock.mock_open()) as _, patch(
-            "autopkg.plistlib.dump"
-        ) as _, patch(
-            "autopkg.log"
-        ) as _, patch(
-            "autopkg.plist_serializer"
-        ) as mock_serializer:
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("builtins.open", unittest.mock.mock_open()) as _,
+            patch("autopkg.plistlib.dump") as _,
+            patch("autopkg.log") as _,
+            patch("autopkg.plist_serializer") as mock_serializer,
+        ):
 
             mock_parser_obj = unittest.mock.Mock()
             mock_parser.return_value = mock_parser_obj
@@ -3472,15 +3339,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
         """Test new_recipe with parent recipe identifier."""
         argv = ["autopkg", "new-recipe", "child.recipe"]
 
-        with patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.gen_common_parser"
-        ) as mock_parser, patch("builtins.open", unittest.mock.mock_open()) as _, patch(
-            "autopkg.plistlib.dump"
-        ) as _, patch(
-            "autopkg.log"
-        ) as _, patch(
-            "autopkg.plist_serializer"
-        ) as mock_serializer:
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("builtins.open", unittest.mock.mock_open()) as _,
+            patch("autopkg.plistlib.dump") as _,
+            patch("autopkg.log") as _,
+            patch("autopkg.plist_serializer") as mock_serializer,
+        ):
 
             mock_parser_obj = unittest.mock.Mock()
             mock_parser.return_value = mock_parser_obj
@@ -3504,13 +3370,13 @@ class TestAutoPkgRecipes(unittest.TestCase):
         """Test new_recipe creates YAML format recipe."""
         argv = ["autopkg", "new-recipe", "test.recipe.yaml"]
 
-        with patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.gen_common_parser"
-        ) as mock_parser, patch("builtins.open", unittest.mock.mock_open()) as _, patch(
-            "autopkg.yaml.dump"
-        ) as mock_yaml_dump, patch(
-            "autopkg.log"
-        ) as _:
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("builtins.open", unittest.mock.mock_open()) as _,
+            patch("autopkg.yaml.dump") as mock_yaml_dump,
+            patch("autopkg.log") as _,
+        ):
 
             mock_parser_obj = unittest.mock.Mock()
             mock_parser.return_value = mock_parser_obj
@@ -3537,13 +3403,13 @@ class TestAutoPkgRecipes(unittest.TestCase):
         """Test new_recipe with explicit YAML format option."""
         argv = ["autopkg", "new-recipe", "test.recipe"]
 
-        with patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.gen_common_parser"
-        ) as mock_parser, patch("builtins.open", unittest.mock.mock_open()) as _, patch(
-            "autopkg.yaml.dump"
-        ) as mock_yaml_dump, patch(
-            "autopkg.log"
-        ) as _:
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("builtins.open", unittest.mock.mock_open()) as _,
+            patch("autopkg.yaml.dump") as mock_yaml_dump,
+            patch("autopkg.log") as _,
+        ):
 
             mock_parser_obj = unittest.mock.Mock()
             mock_parser.return_value = mock_parser_obj
@@ -3564,9 +3430,11 @@ class TestAutoPkgRecipes(unittest.TestCase):
         """Test new_recipe with no recipe pathname provided."""
         argv = ["autopkg", "new-recipe"]
 
-        with patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.gen_common_parser"
-        ) as mock_parser, patch("autopkg.log_err") as mock_log_err:
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser_obj = unittest.mock.Mock()
             mock_parser.return_value = mock_parser_obj
@@ -3586,9 +3454,11 @@ class TestAutoPkgRecipes(unittest.TestCase):
         """Test new_recipe with multiple recipe pathnames provided."""
         argv = ["autopkg", "new-recipe", "recipe1.recipe", "recipe2.recipe"]
 
-        with patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.gen_common_parser"
-        ) as mock_parser, patch("autopkg.log_err") as mock_log_err:
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser_obj = unittest.mock.Mock()
             mock_parser.return_value = mock_parser_obj
@@ -3610,13 +3480,12 @@ class TestAutoPkgRecipes(unittest.TestCase):
         """Test new_recipe handles file write errors."""
         argv = ["autopkg", "new-recipe", "test.recipe"]
 
-        with patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.gen_common_parser"
-        ) as mock_parser, patch(
-            "builtins.open", side_effect=IOError("Permission denied")
-        ) as _, patch(
-            "autopkg.log_err"
-        ) as mock_log_err:
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("builtins.open", side_effect=IOError("Permission denied")) as _,
+            patch("autopkg.log_err") as mock_log_err,
+        ):
 
             mock_parser_obj = unittest.mock.Mock()
             mock_parser.return_value = mock_parser_obj
@@ -3637,15 +3506,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
         """Test new_recipe creates recipe with correct default structure."""
         argv = ["autopkg", "new-recipe", "example.recipe"]
 
-        with patch("autopkg.common_parse") as mock_parse, patch(
-            "autopkg.gen_common_parser"
-        ) as mock_parser, patch("builtins.open", unittest.mock.mock_open()) as _, patch(
-            "autopkg.plistlib.dump"
-        ) as _, patch(
-            "autopkg.log"
-        ) as _, patch(
-            "autopkg.plist_serializer"
-        ) as mock_serializer:
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("builtins.open", unittest.mock.mock_open()) as _,
+            patch("autopkg.plistlib.dump") as _,
+            patch("autopkg.log") as _,
+            patch("autopkg.plist_serializer") as mock_serializer,
+        ):
 
             mock_parser_obj = unittest.mock.Mock()
             mock_parser.return_value = mock_parser_obj
@@ -3692,14 +3560,12 @@ class TestAutoPkgRecipes(unittest.TestCase):
                 argv = ["autopkg", "new-recipe", filename]
 
                 if expected_format == "yaml":
-                    with patch("autopkg.common_parse") as mock_parse, patch(
-                        "autopkg.gen_common_parser"
-                    ) as mock_parser, patch(
-                        "builtins.open", unittest.mock.mock_open()
-                    ), patch(
-                        "autopkg.yaml.dump"
-                    ) as mock_yaml_dump, patch(
-                        "autopkg.log"
+                    with (
+                        patch("autopkg.common_parse") as mock_parse,
+                        patch("autopkg.gen_common_parser") as mock_parser,
+                        patch("builtins.open", unittest.mock.mock_open()),
+                        patch("autopkg.yaml.dump") as mock_yaml_dump,
+                        patch("autopkg.log"),
                     ):
 
                         mock_parser_obj = unittest.mock.Mock()
@@ -3720,17 +3586,14 @@ class TestAutoPkgRecipes(unittest.TestCase):
                         self.assertEqual(recipe["Input"]["NAME"], expected_name)
                         self.assertEqual(recipe["Identifier"], f"local.{expected_name}")
                 else:
-                    with patch("autopkg.common_parse") as mock_parse, patch(
-                        "autopkg.gen_common_parser"
-                    ) as mock_parser, patch(
-                        "builtins.open", unittest.mock.mock_open()
-                    ), patch(
-                        "autopkg.plistlib.dump"
-                    ), patch(
-                        "autopkg.log"
-                    ), patch(
-                        "autopkg.plist_serializer"
-                    ) as mock_serializer:
+                    with (
+                        patch("autopkg.common_parse") as mock_parse,
+                        patch("autopkg.gen_common_parser") as mock_parser,
+                        patch("builtins.open", unittest.mock.mock_open()),
+                        patch("autopkg.plistlib.dump"),
+                        patch("autopkg.log"),
+                        patch("autopkg.plist_serializer") as mock_serializer,
+                    ):
 
                         mock_parser_obj = unittest.mock.Mock()
                         mock_parser.return_value = mock_parser_obj

--- a/Code/tests/test_autopkg_repos.py
+++ b/Code/tests/test_autopkg_repos.py
@@ -121,8 +121,9 @@ class TestAutoPkgRepos(unittest.TestCase):
         mock_fetch.return_value = plistlib.dumps(recipe_plist)
 
         # Mock plistlib.loads
-        with patch("autopkg.plistlib.loads") as mock_loads, patch(
-            "sys.stdout", new_callable=StringIO
+        with (
+            patch("autopkg.plistlib.loads") as mock_loads,
+            patch("sys.stdout", new_callable=StringIO),
         ):
             mock_loads.return_value = recipe_plist
 
@@ -245,8 +246,9 @@ class TestAutoPkgRepos(unittest.TestCase):
         mock_fetch.side_effect = mock_fetch_side_effect
 
         # Mock plistlib.loads
-        with patch("autopkg.plistlib.loads") as mock_loads, patch(
-            "sys.stdout", new_callable=StringIO
+        with (
+            patch("autopkg.plistlib.loads") as mock_loads,
+            patch("sys.stdout", new_callable=StringIO),
         ):
             mock_loads.side_effect = [matching_plist]
 
@@ -330,9 +332,10 @@ class TestAutoPkgRepos(unittest.TestCase):
         mock_fetch.return_value = plistlib.dumps(recipe_plist)
 
         # Mock plistlib.loads and print
-        with patch("autopkg.plistlib.loads") as mock_loads, patch(
-            "builtins.print"
-        ) as mock_print:
+        with (
+            patch("autopkg.plistlib.loads") as mock_loads,
+            patch("builtins.print") as mock_print,
+        ):
             mock_loads.return_value = recipe_plist
 
             result = autopkg.get_repository_from_identifier("com.test.recipe")
@@ -821,9 +824,10 @@ class TestAutoPkgRepos(unittest.TestCase):
         }
         mock_get_pref.return_value = mock_recipe_repos
 
-        with patch("os.path.abspath") as mock_abspath, patch(
-            "os.path.expanduser"
-        ) as mock_expanduser:
+        with (
+            patch("os.path.abspath") as mock_abspath,
+            patch("os.path.expanduser") as mock_expanduser,
+        ):
             mock_expanduser.return_value = "/Users/test/Repos/recipes"
             mock_abspath.return_value = "/Users/test/Repos/recipes"
 

--- a/Code/tests/test_autopkg_run.py
+++ b/Code/tests/test_autopkg_run.py
@@ -59,24 +59,17 @@ class TestAutoPkgRun(unittest.TestCase):
 
         argv = ["autopkg", "install", "TestApp"]
 
-        with patch.object(autopkg, "get_override_dirs", return_value=[]), patch.object(
-            autopkg, "get_search_dirs", return_value=[]
-        ), patch.object(
-            autopkg, "get_pref", return_value=self.tmp_dir.name
-        ), patch.object(
-            autopkg, "load_recipe", return_value=None
-        ) as mock_load_recipe, patch(
-            "os.path.exists", return_value=True
-        ), patch(
-            "os.makedirs"
-        ), patch.object(
-            autopkg, "plist_serializer", return_value={}
-        ), patch.object(
-            autopkg.plistlib, "dump"
-        ), patch.object(
-            autopkg, "log_err"
-        ), patch.object(
-            autopkg, "log"
+        with (
+            patch.object(autopkg, "get_override_dirs", return_value=[]),
+            patch.object(autopkg, "get_search_dirs", return_value=[]),
+            patch.object(autopkg, "get_pref", return_value=self.tmp_dir.name),
+            patch.object(autopkg, "load_recipe", return_value=None) as mock_load_recipe,
+            patch("os.path.exists", return_value=True),
+            patch("os.makedirs"),
+            patch.object(autopkg, "plist_serializer", return_value={}),
+            patch.object(autopkg.plistlib, "dump"),
+            patch.object(autopkg, "log_err"),
+            patch.object(autopkg, "log"),
         ):
 
             # Run recipes - with mocked plistlib.dump, this should complete successfully
@@ -92,23 +85,17 @@ class TestAutoPkgRun(unittest.TestCase):
         """Test run_recipes with install verb rejects non-.install extensions."""
         argv = ["autopkg", "install", "TestApp.recipe"]
 
-        with patch.object(autopkg, "get_override_dirs", return_value=[]), patch.object(
-            autopkg, "get_search_dirs", return_value=[]
-        ), patch.object(
-            autopkg, "get_pref", return_value=self.tmp_dir.name
-        ), patch.object(
-            autopkg, "load_recipe", return_value=None
-        ), patch(
-            "os.path.exists", return_value=True
-        ), patch(
-            "os.makedirs"
-        ), patch.object(
-            autopkg, "plist_serializer", return_value={}
-        ), patch.object(
-            autopkg.plistlib, "dump"
-        ), patch.object(
-            autopkg, "log_err"
-        ) as mock_log_err:
+        with (
+            patch.object(autopkg, "get_override_dirs", return_value=[]),
+            patch.object(autopkg, "get_search_dirs", return_value=[]),
+            patch.object(autopkg, "get_pref", return_value=self.tmp_dir.name),
+            patch.object(autopkg, "load_recipe", return_value=None),
+            patch("os.path.exists", return_value=True),
+            patch("os.makedirs"),
+            patch.object(autopkg, "plist_serializer", return_value={}),
+            patch.object(autopkg.plistlib, "dump"),
+            patch.object(autopkg, "log_err") as mock_log_err,
+        ):
 
             try:
                 autopkg.run_recipes(argv)
@@ -139,9 +126,11 @@ class TestAutoPkgRun(unittest.TestCase):
             "TestApp2.recipe",
         ]
 
-        with patch.object(autopkg, "get_override_dirs", return_value=[]), patch.object(
-            autopkg, "get_search_dirs", return_value=[]
-        ), patch.object(autopkg, "log_err"):
+        with (
+            patch.object(autopkg, "get_override_dirs", return_value=[]),
+            patch.object(autopkg, "get_search_dirs", return_value=[]),
+            patch.object(autopkg, "log_err"),
+        ):
 
             result = autopkg.run_recipes(argv)
             self.assertEqual(result, -1)
@@ -150,9 +139,11 @@ class TestAutoPkgRun(unittest.TestCase):
         """Test run_recipes with invalid key=value format."""
         argv = ["autopkg", "run", "-k", "INVALID_FORMAT", "TestApp.recipe"]
 
-        with patch.object(autopkg, "get_override_dirs", return_value=[]), patch.object(
-            autopkg, "get_search_dirs", return_value=[]
-        ), patch.object(autopkg, "log_err"):
+        with (
+            patch.object(autopkg, "get_override_dirs", return_value=[]),
+            patch.object(autopkg, "get_search_dirs", return_value=[]),
+            patch.object(autopkg, "log_err"),
+        ):
 
             result = autopkg.run_recipes(argv)
             self.assertEqual(result, 1)
@@ -161,22 +152,16 @@ class TestAutoPkgRun(unittest.TestCase):
         """Test run_recipes when recipe is not found."""
         argv = ["autopkg", "run", "NonExistentRecipe.recipe"]
 
-        with patch.object(autopkg, "get_override_dirs", return_value=[]), patch.object(
-            autopkg, "get_search_dirs", return_value=[]
-        ), patch.object(
-            autopkg, "get_pref", return_value=self.tmp_dir.name
-        ), patch.object(
-            autopkg, "load_recipe", return_value=None
-        ), patch(
-            "os.path.exists", return_value=True
-        ), patch(
-            "os.makedirs"
-        ), patch.object(
-            autopkg, "plist_serializer", return_value={}
-        ), patch.object(
-            autopkg.plistlib, "dump"
-        ), patch.object(
-            autopkg, "log_err"
+        with (
+            patch.object(autopkg, "get_override_dirs", return_value=[]),
+            patch.object(autopkg, "get_search_dirs", return_value=[]),
+            patch.object(autopkg, "get_pref", return_value=self.tmp_dir.name),
+            patch.object(autopkg, "load_recipe", return_value=None),
+            patch("os.path.exists", return_value=True),
+            patch("os.makedirs"),
+            patch.object(autopkg, "plist_serializer", return_value={}),
+            patch.object(autopkg.plistlib, "dump"),
+            patch.object(autopkg, "log_err"),
         ):
 
             result = None
@@ -289,31 +274,21 @@ TestApp2.recipe
             )
 
             # Create a temporary directory for cache
-            with patch.object(
-                autopkg, "get_override_dirs", return_value=[]
-            ), patch.object(autopkg, "get_search_dirs", return_value=[]), patch.object(
-                autopkg, "get_pref", return_value=self.tmp_dir.name
-            ), patch.object(
-                autopkg, "load_recipe", return_value=mock_recipe
-            ), patch.object(
-                autopkg, "AutoPackager", return_value=mock_autopackager
-            ), patch.object(
-                autopkg, "verify_parent_trust"
-            ), patch(
-                "os.path.exists", return_value=True
-            ), patch(
-                "os.makedirs"
-            ), patch.object(
-                autopkg, "plist_serializer", return_value={}
-            ), patch.object(
-                autopkg.plistlib, "dump"
-            ), patch.object(
-                autopkg, "log"
-            ), patch.object(
-                autopkg, "log_err"
-            ), patch.object(
-                autopkg, "write_plist_exit_on_fail"
-            ) as mock_write_plist:
+            with (
+                patch.object(autopkg, "get_override_dirs", return_value=[]),
+                patch.object(autopkg, "get_search_dirs", return_value=[]),
+                patch.object(autopkg, "get_pref", return_value=self.tmp_dir.name),
+                patch.object(autopkg, "load_recipe", return_value=mock_recipe),
+                patch.object(autopkg, "AutoPackager", return_value=mock_autopackager),
+                patch.object(autopkg, "verify_parent_trust"),
+                patch("os.path.exists", return_value=True),
+                patch("os.makedirs"),
+                patch.object(autopkg, "plist_serializer", return_value={}),
+                patch.object(autopkg.plistlib, "dump"),
+                patch.object(autopkg, "log"),
+                patch.object(autopkg, "log_err"),
+                patch.object(autopkg, "write_plist_exit_on_fail") as mock_write_plist,
+            ):
 
                 # Run the function
                 result = autopkg.run_recipes(argv)

--- a/Code/tests/test_urldownloader.py
+++ b/Code/tests/test_urldownloader.py
@@ -68,17 +68,13 @@ class TestURLDownloader(unittest.TestCase):
         else:
             storage_method = "store_headers"
 
-        with patch(
-            "autopkglib.URLDownloader.download_with_curl"
-        ) as mock_download, patch(
-            "autopkglib.URLDownloader.parse_headers"
-        ) as mock_parse_headers, patch(
-            "autopkglib.URLDownloader.create_temp_file"
-        ) as mock_create_temp, patch(
-            "autopkglib.URLDownloader.move_temp_file"
-        ), patch(
-            f"autopkglib.URLDownloader.{storage_method}"
-        ) as mock_store:
+        with (
+            patch("autopkglib.URLDownloader.download_with_curl") as mock_download,
+            patch("autopkglib.URLDownloader.parse_headers") as mock_parse_headers,
+            patch("autopkglib.URLDownloader.create_temp_file") as mock_create_temp,
+            patch("autopkglib.URLDownloader.move_temp_file"),
+            patch(f"autopkglib.URLDownloader.{storage_method}") as mock_store,
+        ):
 
             mock_create_temp.return_value = temp_file
             mock_download.return_value = ""
@@ -533,16 +529,12 @@ class TestURLDownloader(unittest.TestCase):
         else:
             storage_method = "store_headers"
 
-        with patch(
-            "autopkglib.URLDownloader.download_with_curl"
-        ) as mock_download, patch(
-            "autopkglib.URLDownloader.parse_headers"
-        ) as mock_parse_headers, patch(
-            "autopkglib.URLDownloader.create_temp_file"
-        ) as mock_create_temp, patch(
-            "autopkglib.URLDownloader.move_temp_file"
-        ) as mock_move, patch(
-            f"autopkglib.URLDownloader.{storage_method}"
+        with (
+            patch("autopkglib.URLDownloader.download_with_curl") as mock_download,
+            patch("autopkglib.URLDownloader.parse_headers") as mock_parse_headers,
+            patch("autopkglib.URLDownloader.create_temp_file") as mock_create_temp,
+            patch("autopkglib.URLDownloader.move_temp_file") as mock_move,
+            patch(f"autopkglib.URLDownloader.{storage_method}"),
         ):
 
             mock_create_temp.return_value = temp_file


### PR DESCRIPTION
Running `pre-commit run --all-files` on the dev-2.x branch yields formatting changes in 6 test files.

They all resemble the following change:
```python
with patch("autopkg.plistlib.loads") as mock_loads, patch(
    "builtins.print"
) as mock_print:
```
to
```python
with (
    patch("autopkg.plistlib.loads") as mock_loads,
    patch("builtins.print") as mock_print,
):
```