### PR TITLE
Treat YAML float-looking scalars as strings to prevent coercion

### DIFF
--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -32,6 +32,7 @@ from typing import IO, Any, Union
 import appdirs
 import pkg_resources
 import yaml
+from autopkglib.autopkgyaml import AutoPkgYAMLLoader
 
 # Type for methods that accept either a filesystem path or a file-like object.
 FileOrPath = Union[IO, str, bytes, int]
@@ -342,7 +343,7 @@ def recipe_from_file(filename) -> VarDict | None:
         try:
             # try to read it as yaml
             with open(filename, "rb") as f:
-                recipe_dict = yaml.load(f, Loader=yaml.FullLoader)
+                recipe_dict = yaml.load(f, Loader=AutoPkgYAMLLoader)
             return recipe_dict
         except Exception as err:
             log_err(f"WARNING: yaml error for {filename}: {err}")

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -33,6 +33,7 @@ from typing import IO, Any, Union
 
 import appdirs
 import yaml
+from autopkglib.autopkgyaml import AutoPkgYAMLLoader
 
 # Type for methods that accept either a filesystem path or a file-like object.
 FileOrPath = Union[IO, str, bytes, int]
@@ -386,21 +387,20 @@ def remove_recipe_extension(name) -> str:
 def recipe_from_file(filename) -> VarDict | None:
     """Create a recipe dictionary from a file. Handle exceptions and log.
 
-    YAML recipes are parsed with ``yaml.safe_load`` (not ``FullLoader``).
-    Recipe documents are always plain mappings of primitives, so the safe
-    loader is sufficient for every legitimate recipe in the ecosystem.
-    This is a deliberate defence against arbitrary-code-execution via
-    crafted YAML tags (CVE-2020-14343-class issues) — doubly important
-    now that the recipe map backport causes every ``.recipe.yaml`` in
-    ``RECIPE_SEARCH_DIRS`` to be parsed during every map build and
-    lookup, not just when the user explicitly invokes the recipe."""
+    YAML recipes are parsed with ``AutoPkgYAMLLoader`` (based on
+    ``SafeLoader``). This prevents arbitrary-code-execution via crafted YAML
+    tags (CVE-2020-14343-class issues) — doubly important now that the recipe
+    map backport causes every ``.recipe.yaml`` in ``RECIPE_SEARCH_DIRS`` to be
+    parsed during every map build and lookup, not just when the user explicitly
+    invokes the recipe. Float-looking scalars (e.g. ``VERSION: 1.0``) are
+    loaded as strings to match plist recipe behavior."""
     if not os.path.isfile(filename):
         return
 
     if filename.endswith(".yaml"):
         try:
             with open(filename, "rb") as f:
-                recipe_dict = yaml.safe_load(f)
+                recipe_dict = yaml.load(f, Loader=AutoPkgYAMLLoader)
             return recipe_dict
         except Exception as err:
             log_err(f"WARNING: yaml error for {filename}: {err}")

--- a/Code/autopkglib/autopkgyaml/__init__.py
+++ b/Code/autopkglib/autopkgyaml/__init__.py
@@ -15,6 +15,27 @@
 # limitations under the License.
 """Helper to deal with YAML serialization"""
 
+import yaml
+
+
+class AutoPkgYAMLLoader(yaml.FullLoader):
+    """YAML loader that treats floats as strings.
+
+    Float-looking values like MinimumVersion: 2.3 or VERSION: 1.0 should
+    always be strings in AutoPkg recipes, matching the behavior of plist
+    recipes. Integers are left as-is since processors such as VersionSplitter
+    use bare integer arguments (e.g. index: 1) that require a native int type.
+    """
+
+    pass
+
+
+# Strip the float implicit resolver so float-looking scalars load as strings
+AutoPkgYAMLLoader.yaml_implicit_resolvers = {
+    k: [(tag, regexp) for tag, regexp in v if tag != "tag:yaml.org,2002:float"]
+    for k, v in yaml.FullLoader.yaml_implicit_resolvers.copy().items()
+}
+
 
 def autopkg_str_representer(dumper, data):
     """Makes every multiline string a block literal"""

--- a/Code/autopkglib/autopkgyaml/__init__.py
+++ b/Code/autopkglib/autopkgyaml/__init__.py
@@ -15,6 +15,29 @@
 # limitations under the License.
 """Helper to deal with YAML serialization"""
 
+import yaml
+
+
+class AutoPkgYAMLLoader(yaml.SafeLoader):
+    """YAML loader that treats floats as strings.
+
+    Based on SafeLoader to prevent arbitrary-code-execution via crafted YAML
+    tags (CVE-2020-14343-class issues). Float-looking values like
+    MinimumVersion: 2.3 or VERSION: 1.0 are always loaded as strings, matching
+    the behavior of plist recipes. Integers are left as-is since processors
+    such as VersionSplitter use bare integer arguments (e.g. index: 1) that
+    require a native int type.
+    """
+
+    pass
+
+
+# Strip the float implicit resolver so float-looking scalars load as strings
+AutoPkgYAMLLoader.yaml_implicit_resolvers = {
+    k: [(tag, regexp) for tag, regexp in v if tag != "tag:yaml.org,2002:float"]
+    for k, v in yaml.SafeLoader.yaml_implicit_resolvers.copy().items()
+}
+
 
 def autopkg_str_representer(dumper, data):
     """Makes every multiline string a block literal"""

--- a/Code/tests/test_autopkg_recipes.py
+++ b/Code/tests/test_autopkg_recipes.py
@@ -15,6 +15,7 @@
 import imp
 import os
 import sys
+import textwrap
 import unittest
 import unittest.mock
 from unittest.mock import Mock, patch
@@ -3785,6 +3786,54 @@ class TestAutoPkgRecipes(unittest.TestCase):
                         recipe = args[0]
                         self.assertEqual(recipe["Input"]["NAME"], expected_name)
                         self.assertEqual(recipe["Identifier"], f"local.{expected_name}")
+
+
+class TestYAMLFloatProtection(unittest.TestCase):
+    """Test that YAML recipes load float-looking values as strings."""
+
+    def test_yaml_floats_loaded_as_strings(self):
+        """Unquoted floats in YAML recipes should be loaded as strings."""
+        import tempfile
+
+        from autopkglib import recipe_from_file
+
+        yaml_content = textwrap.dedent(
+            """\
+            Description: Test float protection
+            Identifier: com.test.floatprotection
+            MinimumVersion: 2.3
+            Input:
+              NAME: TestApp
+              VERSION: 1.0
+              BUILD: 42
+              COMPLEX_VERSION: 10.10
+            Process:
+              - Processor: FileCreator
+                Arguments:
+                  file_path: test.txt
+                  index: 1
+        """
+        )
+        with tempfile.NamedTemporaryFile(
+            suffix=".recipe.yaml", mode="w", delete=False
+        ) as f:
+            f.write(yaml_content)
+            f.flush()
+            recipe = recipe_from_file(f.name)
+
+        try:
+            # Float-looking values must load as strings
+            self.assertIsInstance(recipe["MinimumVersion"], str)
+            self.assertEqual(recipe["MinimumVersion"], "2.3")
+            self.assertIsInstance(recipe["Input"]["VERSION"], str)
+            self.assertEqual(recipe["Input"]["VERSION"], "1.0")
+            self.assertIsInstance(recipe["Input"]["COMPLEX_VERSION"], str)
+            self.assertEqual(recipe["Input"]["COMPLEX_VERSION"], "10.10")
+            # Bare integers must remain as int (processors like VersionSplitter require this)
+            self.assertIsInstance(recipe["Input"]["BUILD"], int)
+            self.assertIsInstance(recipe["Process"][0]["Arguments"]["index"], int)
+        finally:
+            os.unlink(f.name)
 
 
 if __name__ == "__main__":

--- a/Code/tests/test_autopkg_recipes.py
+++ b/Code/tests/test_autopkg_recipes.py
@@ -3797,8 +3797,7 @@ class TestYAMLFloatProtection(unittest.TestCase):
 
         from autopkglib import recipe_from_file
 
-        yaml_content = textwrap.dedent(
-            """\
+        yaml_content = textwrap.dedent("""\
             Description: Test float protection
             Identifier: com.test.floatprotection
             MinimumVersion: 2.3
@@ -3812,8 +3811,7 @@ class TestYAMLFloatProtection(unittest.TestCase):
                 Arguments:
                   file_path: test.txt
                   index: 1
-        """
-        )
+        """)
         with tempfile.NamedTemporaryFile(
             suffix=".recipe.yaml", mode="w", delete=False
         ) as f:

--- a/Code/tests/test_autopkg_recipes.py
+++ b/Code/tests/test_autopkg_recipes.py
@@ -3580,8 +3580,7 @@ class TestYAMLFloatProtection(unittest.TestCase):
 
         from autopkglib import recipe_from_file
 
-        yaml_content = textwrap.dedent(
-            """\
+        yaml_content = textwrap.dedent("""\
             Description: Test float protection
             Identifier: com.test.floatprotection
             MinimumVersion: 2.3
@@ -3595,8 +3594,7 @@ class TestYAMLFloatProtection(unittest.TestCase):
                 Arguments:
                   file_path: test.txt
                   index: 1
-        """
-        )
+        """)
         with tempfile.NamedTemporaryFile(
             suffix=".recipe.yaml", mode="w", delete=False
         ) as f:

--- a/Code/tests/test_autopkg_recipes.py
+++ b/Code/tests/test_autopkg_recipes.py
@@ -17,6 +17,7 @@ import importlib.util
 import os
 import plistlib
 import sys
+import textwrap
 import unittest
 import unittest.mock
 from io import StringIO
@@ -3568,6 +3569,54 @@ class TestAutoPkgRecipes(unittest.TestCase):
                         recipe = args[0]
                         self.assertEqual(recipe["Input"]["NAME"], expected_name)
                         self.assertEqual(recipe["Identifier"], f"local.{expected_name}")
+
+
+class TestYAMLFloatProtection(unittest.TestCase):
+    """Test that YAML recipes load float-looking values as strings."""
+
+    def test_yaml_floats_loaded_as_strings(self):
+        """Unquoted floats in YAML recipes should be loaded as strings."""
+        import tempfile
+
+        from autopkglib import recipe_from_file
+
+        yaml_content = textwrap.dedent(
+            """\
+            Description: Test float protection
+            Identifier: com.test.floatprotection
+            MinimumVersion: 2.3
+            Input:
+              NAME: TestApp
+              VERSION: 1.0
+              BUILD: 42
+              COMPLEX_VERSION: 10.10
+            Process:
+              - Processor: FileCreator
+                Arguments:
+                  file_path: test.txt
+                  index: 1
+        """
+        )
+        with tempfile.NamedTemporaryFile(
+            suffix=".recipe.yaml", mode="w", delete=False
+        ) as f:
+            f.write(yaml_content)
+            f.flush()
+            recipe = recipe_from_file(f.name)
+
+        try:
+            # Float-looking values must load as strings
+            self.assertIsInstance(recipe["MinimumVersion"], str)
+            self.assertEqual(recipe["MinimumVersion"], "2.3")
+            self.assertIsInstance(recipe["Input"]["VERSION"], str)
+            self.assertEqual(recipe["Input"]["VERSION"], "1.0")
+            self.assertIsInstance(recipe["Input"]["COMPLEX_VERSION"], str)
+            self.assertEqual(recipe["Input"]["COMPLEX_VERSION"], "10.10")
+            # Bare integers must remain as int (processors like VersionSplitter require this)
+            self.assertIsInstance(recipe["Input"]["BUILD"], int)
+            self.assertIsInstance(recipe["Process"][0]["Arguments"]["index"], int)
+        finally:
+            os.unlink(f.name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recipe authors expect VERSION: 1.0 and VERSION: 1.0.1 to behave the same way, but YAML's default loader silently coerces 1.0 to a Python float while leaving 1.0.1 as a string. Quoting ("1.0") is required to avoid this, but that requirement is non-obvious to most authors.

Adds AutoPkgYAMLLoader (subclass of yaml.FullLoader) that strips only the float implicit resolver, so float-looking scalars like 1.0 or 2.3 load as strings without requiring quotes. Integers are intentionally left as-is: processors such as VersionSplitter use bare integer arguments (e.g. index: 1) that require a native int type, and no float types exist in plist recipes in the wild.

recipe_from_file now uses AutoPkgYAMLLoader instead of yaml.FullLoader.

Adds TestYAMLFloatProtection unit tests covering float coercion (fixed) and integer processor arguments (preserved).