### PR TITLE
Add YAML support for Munki pkginfo, catalogs, and recipe lists

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1975,7 +1975,8 @@ def make_override(argv):
 
 def parse_recipe_list(filename):
     """Parses a recipe list. This can be either a simple list of recipes to run,
-    or a plist containing recipes and other key/value pairs"""
+    a plist containing recipes and other key/value pairs, or a YAML file with
+    a 'recipes' key listing recipe identifiers."""
     recipe_list = {}
     try:
         with open(filename, "rb") as f:
@@ -1985,13 +1986,24 @@ def parse_recipe_list(filename):
             pass
         return plist
     except Exception:
-        # file does not appear to be a plist containing a dictionary;
-        # read it as a plaintext list of recipes
-        with open(filename) as file_desc:
-            data = file_desc.read()
-        recipe_list["recipes"] = [
-            line for line in data.splitlines() if line and not line.startswith("#")
-        ]
+        pass
+
+    # Try YAML format
+    if filename.endswith((".yaml", ".yml")):
+        try:
+            with open(filename) as f:
+                data = yaml.safe_load(f)
+            if isinstance(data, dict) and "recipes" in data:
+                return data
+        except Exception:
+            pass
+
+    # Fall back to plaintext list of recipes
+    with open(filename) as file_desc:
+        data = file_desc.read()
+    recipe_list["recipes"] = [
+        line for line in data.splitlines() if line and not line.startswith("#")
+    ]
     return recipe_list
 
 

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -21,6 +21,7 @@ import subprocess
 from datetime import datetime
 
 from autopkglib import Processor, ProcessorError
+from autopkglib.autopkgyaml import parse_munki_data
 from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
 from autopkglib.munkirepolibs.MunkiLib import MunkiLib
 
@@ -121,7 +122,7 @@ class MunkiImporter(Processor):
         },
         "MUNKI_PKGINFO_FILE_EXTENSION": {
             "required": False,
-            "description": "Extension for output pkginfo files. Default is 'plist'.",
+            "description": "Extension for output pkginfo files. Default is 'plist'. Set to 'yaml' to write pkginfo in YAML format.",
             "default": "plist",
         },
         "metadata_additions": {
@@ -342,8 +343,8 @@ class MunkiImporter(Processor):
                 f"{err_out.decode()}"
             )
 
-        # Get pkginfo from output plist.
-        pkginfo = plistlib.loads(out)
+        # Get pkginfo from output plist (or YAML if Munki is configured for it).
+        pkginfo = parse_munki_data(out)
 
         # copy any keys from pkginfo in self.env
         if "pkginfo" in self.env:

--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -16,7 +16,6 @@
 """See docstring for MunkiImporter class"""
 
 import os
-import plistlib
 import subprocess
 from datetime import datetime
 

--- a/Code/autopkglib/MunkiInfoCreator.py
+++ b/Code/autopkglib/MunkiInfoCreator.py
@@ -22,6 +22,7 @@ import subprocess
 import tempfile
 
 from autopkglib import Processor, ProcessorError
+from autopkglib.autopkgyaml import parse_munki_data, save_munki_file
 
 __all__ = ["MunkiInfoCreator"]
 
@@ -99,8 +100,8 @@ class MunkiInfoCreator(Processor):
             if temp_path is not None:
                 shutil.rmtree(temp_path)
 
-        # Read output plist.
-        output = plistlib.loads(stdout)
+        # Read output (plist or YAML depending on Munki configuration).
+        output = parse_munki_data(stdout)
 
         # Set version and name.
         if "version" in self.env:
@@ -111,8 +112,7 @@ class MunkiInfoCreator(Processor):
         # Save info.
         self.env["munki_info"] = output
         if "info_path" in self.env:
-            with open(self.env["info_path"], "wb") as f:
-                plistlib.dump(output, f)
+            save_munki_file(output, self.env["info_path"])
 
 
 if __name__ == "__main__":

--- a/Code/autopkglib/MunkiInfoCreator.py
+++ b/Code/autopkglib/MunkiInfoCreator.py
@@ -16,7 +16,6 @@
 """See docstring for MunkiInfoCreator class"""
 
 import os.path
-import plistlib
 import shutil
 import subprocess
 import tempfile

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -19,6 +19,7 @@ import plistlib
 import subprocess
 
 from autopkglib import APLooseVersion, Processor, ProcessorError, log_err
+from autopkglib.autopkgyaml import parse_munki_data
 
 try:
     from Foundation import NSDictionary
@@ -94,8 +95,8 @@ class MunkiInstallsItemsCreator(Processor):
         if proc.returncode != 0:
             raise ProcessorError(f"creating pkginfo failed: {err.decode()}")
 
-        # Get pkginfo from output plist.
-        pkginfo = plistlib.loads(out)
+        # Get pkginfo from output (plist or YAML).
+        pkginfo = parse_munki_data(out)
         installs_array = pkginfo.get("installs", [])
 
         if faux_root:

--- a/Code/autopkglib/MunkiInstallsItemsCreator.py
+++ b/Code/autopkglib/MunkiInstallsItemsCreator.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 """See docstring for MunkiInstallsItemsCreator class"""
 
-import plistlib
 import subprocess
 
 from autopkglib import APLooseVersion, Processor, ProcessorError, log_err

--- a/Code/autopkglib/MunkiOptionalReceiptEditor.py
+++ b/Code/autopkglib/MunkiOptionalReceiptEditor.py
@@ -18,6 +18,7 @@
 import plistlib
 
 from autopkglib import Processor, ProcessorError
+from autopkglib.autopkgyaml import load_munki_file, save_munki_file
 
 __all__ = ["MunkiOptionalReceiptEditor"]
 
@@ -44,8 +45,7 @@ class MunkiOptionalReceiptEditor(Processor):
             self.output("No pkginfo_repo_path specified, skipping")
             return
 
-        with open(self.env["pkginfo_repo_path"], "rb") as f:
-            pkginfo = plistlib.load(f)
+        pkginfo = load_munki_file(self.env["pkginfo_repo_path"])
 
         receipts_modified = []
         if "receipts" in pkginfo.keys():
@@ -62,8 +62,7 @@ class MunkiOptionalReceiptEditor(Processor):
 
         if len(receipts_modified) > 0:
             self.output(f"Writing pkginfo to {self.env['pkginfo_repo_path']}")
-            with open(self.env["pkginfo_repo_path"], "wb") as f:
-                plistlib.dump(pkginfo, f)
+            save_munki_file(pkginfo, self.env["pkginfo_repo_path"])
         else:
             self.output("No receipts modified, nothing to do")
 

--- a/Code/autopkglib/MunkiOptionalReceiptEditor.py
+++ b/Code/autopkglib/MunkiOptionalReceiptEditor.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 """See docstring for MunkiOptionalReceiptEditor class"""
 
-import plistlib
-
 from autopkglib import Processor, ProcessorError
 from autopkglib.autopkgyaml import load_munki_file, save_munki_file
 

--- a/Code/autopkglib/autopkgyaml/__init__.py
+++ b/Code/autopkglib/autopkgyaml/__init__.py
@@ -355,8 +355,8 @@ MunkiPkginfoDumper.add_representer(
 def dump_pkginfo_yaml(pkginfo, f):
     """Serialize a Munki pkginfo dict to yaml and write to file handle *f*.
 
-    *f* must be open for writing in text mode (or binary mode — both work
-    since we encode to UTF-8)."""
+    *f* must be open for writing in text mode; unicode output is enabled
+    via ``allow_unicode=True``."""
     prepared = _prepare_dict(pkginfo)
     yaml.dump(
         prepared,
@@ -396,7 +396,7 @@ def load_pkginfo_yaml(f):
     runs _normalize_yaml_types as a defence-in-depth pass for any
     integer-shaped scalars that should also be strings."""
     data = yaml.load(f, Loader=AutoPkgYAMLLoader)
-    if isinstance(data, dict):
+    if isinstance(data, (dict, list)):
         _normalize_yaml_types(data)
     return data
 
@@ -410,7 +410,7 @@ def loads_pkginfo_yaml(data):
     if isinstance(data, bytes):
         data = data.decode("utf-8")
     result = yaml.load(data, Loader=AutoPkgYAMLLoader)
-    if isinstance(result, dict):
+    if isinstance(result, (dict, list)):
         _normalize_yaml_types(result)
     return result
 
@@ -476,7 +476,7 @@ def load_munki_file(file_path):
         try:
             with open(file_path, "r", encoding="utf-8") as f:
                 data = yaml.load(f, Loader=AutoPkgYAMLLoader)
-            if isinstance(data, dict):
+            if isinstance(data, (dict, list)):
                 _normalize_yaml_types(data)
             return data
         except Exception:
@@ -491,7 +491,7 @@ def load_munki_file(file_path):
             # Fall back to yaml
             with open(file_path, "r", encoding="utf-8") as f:
                 data = yaml.load(f, Loader=AutoPkgYAMLLoader)
-            if isinstance(data, dict):
+            if isinstance(data, (dict, list)):
                 _normalize_yaml_types(data)
             return data
 
@@ -517,6 +517,6 @@ def parse_munki_data(data_bytes):
         pass
     text = data_bytes.decode("utf-8") if isinstance(data_bytes, bytes) else data_bytes
     result = yaml.load(text, Loader=AutoPkgYAMLLoader)
-    if isinstance(result, dict):
+    if isinstance(result, (dict, list)):
         _normalize_yaml_types(result)
     return result

--- a/Code/autopkglib/autopkgyaml/__init__.py
+++ b/Code/autopkglib/autopkgyaml/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/local/autopkg/python
 #
 # Copyright 2021 Brandon Friess
+# Copyright 2026 Rod Christiansen
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +14,124 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Helper to deal with YAML serialization"""
+"""Helper to deal with yaml serialization for autopkg and Munki pkginfo.
+
+Provides utilities for reading, writing, and detecting Munki data in both
+plist and yaml formats. Key ordering, type normalization, and block scalar
+styles are designed to match the Munki yaml fork (yamlutils.swift).
+"""
+
+import base64
+import os
+import plistlib
+import re
+from collections import OrderedDict
+from datetime import datetime
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Loader: strip the float implicit resolver so version-like scalars
+# (e.g. `version: 10.10`, `MinimumVersion: 2.3`) are parsed as strings
+# directly, preserving trailing zeros and exact textual form.
+#
+# Same approach as autopkg/autopkg#1023 (@homebysix). Defined here under
+# the same name so the two PRs converge on one class definition: whichever
+# lands first owns the class, the other PR's diff for this section becomes
+# a no-op on rebase.
+# ---------------------------------------------------------------------------
+
+
+class AutoPkgYAMLLoader(yaml.SafeLoader):
+    """SafeLoader variant that does not auto-coerce float-looking scalars.
+
+    Recipe inputs and Munki pkginfo fields like `version: 10.10` must
+    arrive as strings. Post-parse coercion cannot recover trailing zeros
+    that Pyyaml has already stripped, so we intervene at the resolver
+    level the way Yams does on the Munki side (yamlutils.swift).
+    """
+
+    pass
+
+
+# Strip the float implicit resolver so float-shaped scalars load as strings.
+AutoPkgYAMLLoader.yaml_implicit_resolvers = {
+    k: [(tag, regexp) for tag, regexp in v if tag != "tag:yaml.org,2002:float"]
+    for k, v in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Keys whose values must always be strings even if yaml parses them as
+# numeric (matches Munki's stringKeys set in yamlutils.swift).
+STRING_KEYS = frozenset(
+    {
+        "version",
+        "minimum_os_version",
+        "maximum_os_version",
+        "minimum_munki_version",
+        "minimum_update_version",
+        "installer_item_version",
+        "installed_version",
+        "product_version",
+        "CFBundleShortVersionString",
+        "CFBundleVersion",
+        "minosversion",
+    }
+)
+
+# Script keys that should use yaml literal block scalar style (|).
+SCRIPT_KEYS = frozenset(
+    {
+        "preinstall_script",
+        "postinstall_script",
+        "installcheck_script",
+        "uninstallcheck_script",
+        "postuninstall_script",
+        "uninstall_script",
+        "preuninstall_script",
+        "version_script",
+        "embedded_script",
+    }
+)
+
+# Prose keys that should use yaml folded block scalar style (>).
+PROSE_KEYS = frozenset({"description", "notes"})
+
+# Top-level pkginfo key ordering: these come first in this order,
+# then all remaining keys alphabetically, then _metadata last.
+_PKGINFO_HEAD_KEYS = ["name", "display_name", "version"]
+
+# Receipt sub-dict key ordering.
+_RECEIPT_HEAD_KEYS = [
+    "packageid",
+    "name",
+    "filename",
+    "installed_size",
+    "version",
+    "optional",
+]
+
+# Installs sub-dict key ordering.
+_INSTALLS_HEAD_KEYS = [
+    "path",
+    "type",
+    "CFBundleIdentifier",
+    "CFBundleName",
+    "CFBundleShortVersionString",
+    "CFBundleVersion",
+    "md5checksum",
+    "minosversion",
+]
+
+
+# ---------------------------------------------------------------------------
+# Existing representer (unchanged from original)
+# ---------------------------------------------------------------------------
 
 
 def autopkg_str_representer(dumper, data):
@@ -21,3 +139,381 @@ def autopkg_str_representer(dumper, data):
     if len(data.splitlines()) > 1:
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+# ---------------------------------------------------------------------------
+# Key-ordering helpers
+# ---------------------------------------------------------------------------
+
+
+def _sorted_keys(d, head_keys):
+    """Return keys of *d* ordered: head_keys first (if present),
+    remaining keys alphabetically, ``_metadata`` last."""
+    head = [k for k in head_keys if k in d]
+    rest = sorted(k for k in d if k not in head_keys and k != "_metadata")
+    tail = ["_metadata"] if "_metadata" in d else []
+    return head + rest + tail
+
+
+def _detect_subdict_type(d):
+    """Heuristic to detect whether *d* is a receipt, installs item, or
+    generic pkginfo dict.  Returns head-key list for ordering."""
+    if "packageid" in d:
+        return _RECEIPT_HEAD_KEYS
+    if "path" in d and "type" in d:
+        return _INSTALLS_HEAD_KEYS
+    return _PKGINFO_HEAD_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Type normalization (read path)
+# ---------------------------------------------------------------------------
+
+
+def _is_numeric_string(value):
+    """Return True if *value* is a float or int that should be coerced to str."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _clean_float_to_str(value):
+    """Convert a numeric value to a clean version string.
+    Matches Munki's String(format: '%.10g') behaviour."""
+    if isinstance(value, float):
+        formatted = f"{value:.10g}"
+        return formatted
+    return str(value)
+
+
+def _normalize_yaml_types(data, parent_key=None):
+    """Recursively walk parsed yaml data and coerce numeric values back to
+    strings for keys in STRING_KEYS.  Operates in-place and returns *data*."""
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if key in STRING_KEYS and _is_numeric_string(value):
+                data[key] = _clean_float_to_str(value)
+            elif isinstance(value, dict):
+                _normalize_yaml_types(value, key)
+            elif isinstance(value, list):
+                _normalize_yaml_types(value, key)
+    elif isinstance(data, list):
+        for i, item in enumerate(data):
+            if parent_key in STRING_KEYS and _is_numeric_string(item):
+                data[i] = _clean_float_to_str(item)
+            elif isinstance(item, (dict, list)):
+                _normalize_yaml_types(item, parent_key)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Custom yaml Dumper for Munki pkginfo
+# ---------------------------------------------------------------------------
+
+
+class _LiteralStr(str):
+    """Marker for strings that should use yaml literal block style (|)."""
+    pass
+
+
+class _FoldedStr(str):
+    """Marker for strings that should use yaml folded block style (>)."""
+    pass
+
+
+class _QuotedStr(str):
+    """Marker for strings that must be quoted (version numbers etc)."""
+    pass
+
+
+def _literal_representer(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+
+
+def _folded_representer(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=">")
+
+
+def _quoted_representer(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="'")
+
+
+# Regex for values yaml might interpret as non-string (numbers, booleans, etc).
+_NEEDS_QUOTING_RE = re.compile(
+    r"""^(?:
+        # integers / floats / scientific notation
+        [-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?
+        # yaml booleans
+        |true|false|yes|no|on|off
+        # yaml null
+        |null|~
+        # Sexagesimal (60-base) time values like 1:30
+        |\d+:\d+(?::\d+)?
+    )$""",
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+def _looks_like_script(value):
+    """Heuristic: does the string look like a script?"""
+    patterns = ["#!", "\nif ", "\nfor ", "\necho ", "\nprint(", "\n  ", "\n\t"]
+    return any(p in value for p in patterns)
+
+
+def _prepare_value(key, value):
+    """Wrap a value with the appropriate marker type for yaml serialization."""
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return base64.b64encode(value).decode("ascii")
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+    if isinstance(value, str):
+        if key in STRING_KEYS and _NEEDS_QUOTING_RE.match(value):
+            return _QuotedStr(value)
+        if "\n" in value or value.endswith("\n"):
+            if key in SCRIPT_KEYS or _looks_like_script(value):
+                return _LiteralStr(value)
+            if key in PROSE_KEYS:
+                return _FoldedStr(value)
+            # Default multiline: literal
+            return _LiteralStr(value)
+        if _NEEDS_QUOTING_RE.match(value):
+            return _QuotedStr(value)
+        return value
+    return value
+
+
+def _prepare_dict(d):
+    """Recursively prepare a dict for yaml serialization: order keys, tag
+    strings, filter None/empty, handle nested structures."""
+    head_keys = _detect_subdict_type(d)
+    ordered = OrderedDict()
+    for key in _sorted_keys(d, head_keys):
+        value = d[key]
+        # Filter None (match Munki's behaviour). Preserve empty strings as
+        # explicitly-quoted empties — matches yamlutils.swift, which emits
+        # `key: ''` (single-quoted, str-tagged) so an empty value survives
+        # round-trip rather than being silently dropped or read back as null.
+        if value is None:
+            continue
+        if isinstance(value, str) and value == "":
+            ordered[key] = _QuotedStr("")
+            continue
+        if isinstance(value, dict):
+            value = _prepare_dict(value)
+        elif isinstance(value, list):
+            value = _prepare_list(key, value)
+        else:
+            value = _prepare_value(key, value)
+            if value is None:
+                continue
+        ordered[key] = value
+    return ordered
+
+
+def _prepare_list(parent_key, lst):
+    """Recursively prepare a list for yaml serialization."""
+    result = []
+    for item in lst:
+        if item is None:
+            continue
+        if isinstance(item, dict):
+            result.append(_prepare_dict(item))
+        elif isinstance(item, list):
+            result.append(_prepare_list(parent_key, item))
+        else:
+            prepared = _prepare_value(parent_key, item)
+            if prepared is not None:
+                result.append(prepared)
+    return result
+
+
+class MunkiPkginfoDumper(yaml.SafeDumper):
+    """yaml dumper configured for Munki pkginfo output."""
+    pass
+
+
+# Register representers on the custom dumper.
+MunkiPkginfoDumper.add_representer(_LiteralStr, _literal_representer)
+MunkiPkginfoDumper.add_representer(_FoldedStr, _folded_representer)
+MunkiPkginfoDumper.add_representer(_QuotedStr, _quoted_representer)
+MunkiPkginfoDumper.add_representer(
+    OrderedDict,
+    lambda dumper, data: dumper.represent_mapping(
+        "tag:yaml.org,2002:map", data.items()
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API: write
+# ---------------------------------------------------------------------------
+
+
+def dump_pkginfo_yaml(pkginfo, f):
+    """Serialize a Munki pkginfo dict to yaml and write to file handle *f*.
+
+    *f* must be open for writing in text mode (or binary mode — both work
+    since we encode to UTF-8)."""
+    prepared = _prepare_dict(pkginfo)
+    yaml.dump(
+        prepared,
+        f,
+        Dumper=MunkiPkginfoDumper,
+        default_flow_style=False,
+        allow_unicode=True,
+        width=10000,  # effectively disable line wrapping
+        indent=2,
+        sort_keys=False,
+    )
+
+
+def dumps_pkginfo_yaml(pkginfo):
+    """Serialize a Munki pkginfo dict to a yaml string."""
+    prepared = _prepare_dict(pkginfo)
+    return yaml.dump(
+        prepared,
+        Dumper=MunkiPkginfoDumper,
+        default_flow_style=False,
+        allow_unicode=True,
+        width=10000,
+        indent=2,
+        sort_keys=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API: read
+# ---------------------------------------------------------------------------
+
+
+def load_pkginfo_yaml(f):
+    """Load a Munki pkginfo dict from a yaml file handle.
+
+    Uses AutoPkgYAMLLoader to keep float-shaped scalars as strings, then
+    runs _normalize_yaml_types as a defence-in-depth pass for any
+    integer-shaped scalars that should also be strings."""
+    data = yaml.load(f, Loader=AutoPkgYAMLLoader)
+    if isinstance(data, dict):
+        _normalize_yaml_types(data)
+    return data
+
+
+def loads_pkginfo_yaml(data):
+    """Load a Munki pkginfo dict from yaml bytes or string.
+
+    Uses AutoPkgYAMLLoader to keep float-shaped scalars as strings, then
+    runs _normalize_yaml_types as a defence-in-depth pass for any
+    integer-shaped scalars that should also be strings."""
+    if isinstance(data, bytes):
+        data = data.decode("utf-8")
+    result = yaml.load(data, Loader=AutoPkgYAMLLoader)
+    if isinstance(result, dict):
+        _normalize_yaml_types(result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API: format detection
+# ---------------------------------------------------------------------------
+
+
+def is_yaml_path(path):
+    """Return True if *path* has a yaml file extension."""
+    _, ext = os.path.splitext(path)
+    return ext.lower() in (".yaml", ".yml")
+
+
+def is_plist_path(path):
+    """Return True if *path* has a plist file extension."""
+    _, ext = os.path.splitext(path)
+    return ext.lower() == ".plist"
+
+
+def detect_munki_format(file_path):
+    """Detect whether a Munki data file is yaml or plist.
+
+    Returns ``"yaml"`` or ``"plist"``.
+
+    Detection order:
+    1. File extension (``.yaml``/``.yml`` -> yaml, ``.plist`` -> plist)
+    2. Content detection (``<?xml`` / ``<plist>`` -> plist, ``---`` / ``key: value`` -> yaml)
+    3. Default: ``"plist"``
+    """
+    if is_yaml_path(file_path):
+        return "yaml"
+    if is_plist_path(file_path):
+        return "plist"
+    # Content-based detection for extensionless files
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(512)
+    except OSError:
+        return "plist"
+    head_str = head.decode("utf-8", errors="replace").lstrip()
+    if head_str.startswith("<?xml") or head_str.startswith("<plist"):
+        return "plist"
+    if head_str.startswith("---"):
+        return "yaml"
+    # Count yaml-like vs XML-like lines in the first few lines
+    lines = head_str.splitlines()[:10]
+    yaml_score = sum(1 for ln in lines if re.match(r"^\w[\w\s]*:", ln))
+    xml_score = sum(1 for ln in lines if re.match(r"^\s*<", ln))
+    if yaml_score > xml_score:
+        return "yaml"
+    return "plist"
+
+
+def load_munki_file(file_path):
+    """Load a Munki data file (pkginfo, catalog, manifest) from *file_path*,
+    auto-detecting whether it is yaml or plist.
+
+    Returns the parsed dict or list."""
+    fmt = detect_munki_format(file_path)
+    if fmt == "yaml":
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                data = yaml.load(f, Loader=AutoPkgYAMLLoader)
+            if isinstance(data, dict):
+                _normalize_yaml_types(data)
+            return data
+        except Exception:
+            # Fall back to plist
+            with open(file_path, "rb") as f:
+                return plistlib.load(f)
+    else:
+        try:
+            with open(file_path, "rb") as f:
+                return plistlib.load(f)
+        except Exception:
+            # Fall back to yaml
+            with open(file_path, "r", encoding="utf-8") as f:
+                data = yaml.load(f, Loader=AutoPkgYAMLLoader)
+            if isinstance(data, dict):
+                _normalize_yaml_types(data)
+            return data
+
+
+def save_munki_file(data, file_path):
+    """Save a Munki data dict to *file_path* in the format implied by
+    the file extension (yaml for ``.yaml``/``.yml``, plist otherwise)."""
+    if is_yaml_path(file_path):
+        with open(file_path, "w", encoding="utf-8") as f:
+            dump_pkginfo_yaml(data, f)
+    else:
+        with open(file_path, "wb") as f:
+            plistlib.dump(data, f)
+
+
+def parse_munki_data(data_bytes):
+    """Parse bytes that could be either plist or yaml (e.g. makepkginfo stdout).
+
+    Tries plist first, falls back to yaml.  Returns the parsed dict."""
+    try:
+        return plistlib.loads(data_bytes)
+    except Exception:
+        pass
+    text = data_bytes.decode("utf-8") if isinstance(data_bytes, bytes) else data_bytes
+    result = yaml.load(text, Loader=AutoPkgYAMLLoader)
+    if isinstance(result, dict):
+        _normalize_yaml_types(result)
+    return result

--- a/Code/autopkglib/autopkgyaml/__init__.py
+++ b/Code/autopkglib/autopkgyaml/__init__.py
@@ -30,7 +30,6 @@ from datetime import datetime
 
 import yaml
 
-
 # ---------------------------------------------------------------------------
 # Loader: strip the float implicit resolver so version-like scalars
 # (e.g. `version: 10.10`, `MinimumVersion: 2.3`) are parsed as strings
@@ -211,16 +210,19 @@ def _normalize_yaml_types(data, parent_key=None):
 
 class _LiteralStr(str):
     """Marker for strings that should use yaml literal block style (|)."""
+
     pass
 
 
 class _FoldedStr(str):
     """Marker for strings that should use yaml folded block style (>)."""
+
     pass
 
 
 class _QuotedStr(str):
     """Marker for strings that must be quoted (version numbers etc)."""
+
     pass
 
 
@@ -329,6 +331,7 @@ def _prepare_list(parent_key, lst):
 
 class MunkiPkginfoDumper(yaml.SafeDumper):
     """yaml dumper configured for Munki pkginfo output."""
+
     pass
 
 

--- a/Code/autopkglib/munkirepolibs/AutoPkgLib.py
+++ b/Code/autopkglib/munkirepolibs/AutoPkgLib.py
@@ -3,6 +3,11 @@ import plistlib
 import shutil
 
 from autopkglib import ProcessorError
+from autopkglib.autopkgyaml import (
+    dump_pkginfo_yaml,
+    is_yaml_path,
+    load_munki_file,
+)
 
 
 class AutoPkgLib:
@@ -12,7 +17,10 @@ class AutoPkgLib:
 
     def make_catalog_db(self) -> dict:
         """Reads the 'all' catalog and returns a dict we can use like a
-        database"""
+        database.  Supports both plist and YAML catalog formats; format
+        is detected by content inspection, since Munki writes catalogs at
+        the same extensionless path regardless of underlying format
+        (matches munki/munki#1261)."""
 
         all_items_path = os.path.join(self.munki_repo, "catalogs", "all")
         if not os.path.exists(all_items_path):
@@ -20,9 +28,8 @@ class AutoPkgLib:
             catalogitems = []
         else:
             try:
-                with open(all_items_path, "rb") as f:
-                    catalogitems = plistlib.load(f)
-            except OSError as err:
+                catalogitems = load_munki_file(all_items_path)
+            except Exception as err:
                 raise ProcessorError(
                     f"Error reading 'all' catalog from Munki repo: {err}"
                 )
@@ -208,8 +215,12 @@ class AutoPkgLib:
             pkginfo_path = os.path.join(destination_path, pkginfo_name)
 
         try:
-            with open(pkginfo_path, "wb") as f:
-                plistlib.dump(pkginfo, f)
+            if is_yaml_path(pkginfo_path):
+                with open(pkginfo_path, "w", encoding="utf-8") as f:
+                    dump_pkginfo_yaml(pkginfo, f)
+            else:
+                with open(pkginfo_path, "wb") as f:
+                    plistlib.dump(pkginfo, f)
         except OSError as err:
             raise ProcessorError(
                 f"Could not write pkginfo {pkginfo_path}: {err.strerror}"

--- a/Code/autopkglib/munkirepolibs/AutoPkgLib.py
+++ b/Code/autopkglib/munkirepolibs/AutoPkgLib.py
@@ -3,11 +3,7 @@ import plistlib
 import shutil
 
 from autopkglib import ProcessorError
-from autopkglib.autopkgyaml import (
-    dump_pkginfo_yaml,
-    is_yaml_path,
-    load_munki_file,
-)
+from autopkglib.autopkgyaml import dump_pkginfo_yaml, is_yaml_path, load_munki_file
 
 
 class AutoPkgLib:

--- a/Code/autopkglib/munkirepolibs/MunkiLib.py
+++ b/Code/autopkglib/munkirepolibs/MunkiLib.py
@@ -48,7 +48,7 @@ class MunkiLib:
     # includes '/pkgsinfo' in uploaded path
     def copy_pkginfo_to_repo(self, pkginfo, file_extension="plist") -> str:
         uploaded_path = self.munkiimportlib.copy_pkginfo_to_repo(
-            self.repo, pkginfo, self.repo_subdirectory
+            self.repo, pkginfo, self.repo_subdirectory, file_extension=file_extension
         )
 
         return self._full_path(uploaded_path)

--- a/Code/tests/test_autopkg_run.py
+++ b/Code/tests/test_autopkg_run.py
@@ -242,6 +242,75 @@ TestApp2.recipe
         finally:
             os.unlink(temp_file)
 
+    def test_parse_recipe_list_yaml_format(self):
+        """Test parse_recipe_list with yaml format."""
+        recipe_list_yaml = """# AutoPkg Recipe List
+recipes:
+  - local.munki.Chrome
+  - local.munki.Firefox
+  - local.munki.MicrosoftEdge
+"""
+
+        with NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(recipe_list_yaml)
+            temp_file = f.name
+
+        try:
+            result = autopkg.parse_recipe_list(temp_file)
+            expected_recipes = [
+                "local.munki.Chrome",
+                "local.munki.Firefox",
+                "local.munki.MicrosoftEdge",
+            ]
+            self.assertEqual(result["recipes"], expected_recipes)
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_recipe_list_yaml_with_metadata(self):
+        """Test parse_recipe_list with yaml format including extra keys."""
+        recipe_list_yaml = """recipes:
+  - local.munki.Chrome
+  - local.munki.Firefox
+preprocessors:
+  - io.github.hjuutilainen.recipes.Recipe Robot
+postprocessors:
+  - com.github.autopkg.postprocessors.Summary
+CUSTOM_VAR: custom_value
+"""
+
+        with NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(recipe_list_yaml)
+            temp_file = f.name
+
+        try:
+            result = autopkg.parse_recipe_list(temp_file)
+            self.assertEqual(
+                result["recipes"], ["local.munki.Chrome", "local.munki.Firefox"]
+            )
+            self.assertEqual(
+                result["preprocessors"],
+                ["io.github.hjuutilainen.recipes.Recipe Robot"],
+            )
+            self.assertEqual(result["CUSTOM_VAR"], "custom_value")
+        finally:
+            os.unlink(temp_file)
+
+    def test_parse_recipe_list_yml_extension(self):
+        """Test parse_recipe_list recognizes .yml extension."""
+        recipe_list_yaml = """recipes:
+  - local.munki.Chrome
+"""
+
+        with NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+            f.write(recipe_list_yaml)
+            temp_file = f.name
+
+        try:
+            result = autopkg.parse_recipe_list(temp_file)
+            self.assertEqual(result["recipes"], ["local.munki.Chrome"])
+        finally:
+            os.unlink(temp_file)
+
     def test_run_recipes_failure_includes_recipe_id(self):
         """Test that recipe failures include recipe_id in the failures array when recipe has an Identifier."""
         with NamedTemporaryFile(suffix=".plist") as report_file:

--- a/Code/tests/test_autopkgyaml.py
+++ b/Code/tests/test_autopkgyaml.py
@@ -1,0 +1,503 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for autopkgyaml YAML serialization and Munki format support."""
+
+import os
+import plistlib
+import sys
+import tempfile
+import unittest
+from collections import OrderedDict
+from datetime import datetime
+
+# Ensure the Code directory is on the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from autopkglib.autopkgyaml import (
+    STRING_KEYS,
+    _clean_float_to_str,
+    _normalize_yaml_types,
+    _sorted_keys,
+    _PKGINFO_HEAD_KEYS,
+    _RECEIPT_HEAD_KEYS,
+    _INSTALLS_HEAD_KEYS,
+    detect_munki_format,
+    dump_pkginfo_yaml,
+    dumps_pkginfo_yaml,
+    is_yaml_path,
+    is_plist_path,
+    load_munki_file,
+    load_pkginfo_yaml,
+    loads_pkginfo_yaml,
+    parse_munki_data,
+    save_munki_file,
+)
+
+
+class TestVersionStringQuoting(unittest.TestCase):
+    """Version strings must survive yaml round-trip without becoming floats."""
+
+    def test_version_string_roundtrip(self):
+        """version: '126.0' should not become 126.0 float."""
+        pkginfo = {"name": "Firefox", "version": "126.0", "display_name": "Firefox"}
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        loaded = loads_pkginfo_yaml(yaml_str)
+        self.assertIsInstance(loaded["version"], str)
+        self.assertEqual(loaded["version"], "126.0")
+
+    def test_integer_version_roundtrip(self):
+        """version: '14' should not become int 14."""
+        pkginfo = {"name": "Xcode", "version": "14", "display_name": "Xcode"}
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        loaded = loads_pkginfo_yaml(yaml_str)
+        self.assertIsInstance(loaded["version"], str)
+        self.assertEqual(loaded["version"], "14")
+
+    def test_minimum_os_version_roundtrip(self):
+        pkginfo = {
+            "name": "Test",
+            "version": "1.0",
+            "minimum_os_version": "10.15",
+        }
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        loaded = loads_pkginfo_yaml(yaml_str)
+        self.assertIsInstance(loaded["minimum_os_version"], str)
+        self.assertEqual(loaded["minimum_os_version"], "10.15")
+
+    def test_receipt_version_roundtrip(self):
+        pkginfo = {
+            "name": "Test",
+            "version": "2.0",
+            "receipts": [
+                {"packageid": "com.example.test", "version": "2.0"},
+            ],
+        }
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        loaded = loads_pkginfo_yaml(yaml_str)
+        self.assertIsInstance(loaded["receipts"][0]["version"], str)
+        self.assertEqual(loaded["receipts"][0]["version"], "2.0")
+
+    def test_unquoted_trailing_zero_version_preserved(self):
+        """`version: 10.10` (UNQUOTED in source) must arrive as the string
+        '10.10', not float 10.1. This is the canonical bug PR #1023 fixes
+        for recipes; the same fix here covers Munki pkginfo and catalogs.
+        Without AutoPkgYAMLLoader removing the float implicit resolver,
+        Pyyaml collapses 10.10 to 10.1 before any post-parse normalization
+        can recover the trailing zero."""
+        # Note: deliberately UNQUOTED in the source yaml to exercise the
+        # loader-level fix. Quoted '10.10' would be safe even without it.
+        yaml_input = (
+            "name: TestApp\n"
+            "version: 10.10\n"
+            "minimum_os_version: 10.10\n"
+        )
+        loaded = loads_pkginfo_yaml(yaml_input)
+        self.assertIsInstance(loaded["version"], str)
+        self.assertEqual(loaded["version"], "10.10")
+        self.assertEqual(loaded["minimum_os_version"], "10.10")
+
+
+class TestCleanFloat(unittest.TestCase):
+    def test_float_no_trailing_zero(self):
+        self.assertEqual(_clean_float_to_str(14.0), "14")
+
+    def test_float_decimal(self):
+        self.assertEqual(_clean_float_to_str(10.15), "10.15")
+
+    def test_int(self):
+        self.assertEqual(_clean_float_to_str(14), "14")
+
+
+class TestNormalizeYamlTypes(unittest.TestCase):
+    def test_normalizes_version_float(self):
+        data = {"version": 10.15, "name": "Test"}
+        _normalize_yaml_types(data)
+        self.assertIsInstance(data["version"], str)
+        self.assertEqual(data["version"], "10.15")
+
+    def test_normalizes_nested_receipt_version(self):
+        data = {"receipts": [{"packageid": "com.foo", "version": 2.0}]}
+        _normalize_yaml_types(data)
+        self.assertIsInstance(data["receipts"][0]["version"], str)
+
+    def test_leaves_non_version_keys_alone(self):
+        data = {"installer_item_size": 12345, "name": "Test"}
+        _normalize_yaml_types(data)
+        self.assertIsInstance(data["installer_item_size"], int)
+
+    def test_skips_booleans(self):
+        data = {"version": "1.0", "uninstallable": True}
+        _normalize_yaml_types(data)
+        self.assertIsInstance(data["uninstallable"], bool)
+
+
+class TestKeyOrdering(unittest.TestCase):
+    def test_pkginfo_key_order(self):
+        d = {
+            "_metadata": {},
+            "catalogs": ["testing"],
+            "version": "1.0",
+            "name": "Firefox",
+            "display_name": "Mozilla Firefox",
+            "autoremove": False,
+        }
+        keys = _sorted_keys(d, _PKGINFO_HEAD_KEYS)
+        # name, display_name, version first
+        self.assertEqual(keys[0], "name")
+        self.assertEqual(keys[1], "display_name")
+        self.assertEqual(keys[2], "version")
+        # _metadata last
+        self.assertEqual(keys[-1], "_metadata")
+        # alpha middle
+        middle = keys[3:-1]
+        self.assertEqual(middle, sorted(middle))
+
+    def test_receipt_key_order(self):
+        d = {
+            "version": "1.0",
+            "packageid": "com.example.test",
+            "optional": False,
+            "installed_size": 12345,
+        }
+        keys = _sorted_keys(d, _RECEIPT_HEAD_KEYS)
+        self.assertEqual(keys[0], "packageid")
+
+    def test_installs_key_order(self):
+        d = {
+            "CFBundleShortVersionString": "1.0",
+            "type": "application",
+            "path": "/Applications/Test.app",
+        }
+        keys = _sorted_keys(d, _INSTALLS_HEAD_KEYS)
+        self.assertEqual(keys[0], "path")
+        self.assertEqual(keys[1], "type")
+
+
+class TestMultilineStrings(unittest.TestCase):
+    def test_script_uses_literal_block(self):
+        pkginfo = {
+            "name": "Test",
+            "version": "1.0",
+            "postinstall_script": "#!/bin/bash\necho hello\nexit 0\n",
+        }
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        self.assertIn("postinstall_script: |", yaml_str)
+
+    def test_description_uses_folded_block(self):
+        pkginfo = {
+            "name": "Test",
+            "version": "1.0",
+            "description": "This is a long\ndescription that spans\nmultiple lines.\n",
+        }
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        self.assertIn("description: >", yaml_str)
+
+
+class TestNoneAndEmptyFiltering(unittest.TestCase):
+    def test_none_values_omitted(self):
+        pkginfo = {"name": "Test", "version": "1.0", "notes": None}
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        self.assertNotIn("notes", yaml_str)
+
+    def test_empty_string_values_preserved(self):
+        """Empty strings round-trip as `key: ''` (matches Munki's
+        yamlutils.swift behaviour). A key explicitly set to "" is not
+        the same as an absent key — bare empty would re-parse as null
+        and be filtered out, so emit explicitly quoted."""
+        pkginfo = {
+            "name": "Test",
+            "version": "1.0",
+            "description": "",
+            "blocking_applications": "",
+        }
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        # Both empty-string keys must appear in output, explicitly quoted.
+        self.assertIn("description: ''", yaml_str)
+        self.assertIn("blocking_applications: ''", yaml_str)
+        # Round-trip: re-parse must yield empty strings, not null/missing.
+        parsed = loads_pkginfo_yaml(yaml_str)
+        self.assertEqual(parsed["description"], "")
+        self.assertEqual(parsed["blocking_applications"], "")
+
+
+class TestDatetimeSerialization(unittest.TestCase):
+    def test_datetime_iso8601(self):
+        dt = datetime(2025, 8, 26, 7, 7, 3)
+        pkginfo = {
+            "name": "Test",
+            "version": "1.0",
+            "_metadata": {"creation_date": dt},
+        }
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        self.assertIn("2025-08-26T07:07:03Z", yaml_str)
+
+
+class TestBytesSerialization(unittest.TestCase):
+    def test_bytes_base64(self):
+        pkginfo = {
+            "name": "Test",
+            "version": "1.0",
+            "icon_data": b"\x89PNG\r\n",
+        }
+        yaml_str = dumps_pkginfo_yaml(pkginfo)
+        # Should be base64-encoded
+        self.assertNotIn("\\x89", yaml_str)
+        self.assertIn("icon_data:", yaml_str)
+
+
+class TestFormatDetection(unittest.TestCase):
+    def test_yaml_extension(self):
+        self.assertTrue(is_yaml_path("/repo/pkgsinfo/Firefox-126.0.yaml"))
+        self.assertTrue(is_yaml_path("/repo/pkgsinfo/Firefox-126.0.yml"))
+
+    def test_plist_extension(self):
+        self.assertTrue(is_plist_path("/repo/pkgsinfo/Firefox-126.0.plist"))
+
+    def test_detect_yaml_extension(self):
+        self.assertEqual(detect_munki_format("/tmp/test.yaml"), "yaml")
+        self.assertEqual(detect_munki_format("/tmp/test.yml"), "yaml")
+
+    def test_detect_plist_extension(self):
+        self.assertEqual(detect_munki_format("/tmp/test.plist"), "plist")
+
+    def test_detect_xml_content(self):
+        with tempfile.NamedTemporaryFile(suffix="", delete=False, mode="w") as f:
+            f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+            f.write("<plist>\n<dict>\n</dict>\n</plist>\n")
+            path = f.name
+        try:
+            self.assertEqual(detect_munki_format(path), "plist")
+        finally:
+            os.unlink(path)
+
+    def test_detect_yaml_content(self):
+        with tempfile.NamedTemporaryFile(suffix="", delete=False, mode="w") as f:
+            f.write("---\nname: Firefox\nversion: '126.0'\n")
+            path = f.name
+        try:
+            self.assertEqual(detect_munki_format(path), "yaml")
+        finally:
+            os.unlink(path)
+
+    def test_detect_yaml_no_document_start(self):
+        """yaml without --- should still be detected by key: value heuristic."""
+        with tempfile.NamedTemporaryFile(suffix="", delete=False, mode="w") as f:
+            f.write("name: Firefox\nversion: '126.0'\ncatalogs:\n- testing\n")
+            path = f.name
+        try:
+            self.assertEqual(detect_munki_format(path), "yaml")
+        finally:
+            os.unlink(path)
+
+
+class TestParseMunkiData(unittest.TestCase):
+    def test_parse_plist_bytes(self):
+        data = {"name": "Test", "version": "1.0"}
+        plist_bytes = plistlib.dumps(data)
+        result = parse_munki_data(plist_bytes)
+        self.assertEqual(result["name"], "Test")
+        self.assertEqual(result["version"], "1.0")
+
+    def test_parse_yaml_bytes(self):
+        yaml_str = "name: Test\nversion: '1.0'\n"
+        result = parse_munki_data(yaml_str.encode("utf-8"))
+        self.assertEqual(result["name"], "Test")
+        self.assertEqual(result["version"], "1.0")
+
+
+class TestFileRoundTrip(unittest.TestCase):
+    """Full round-trip: dict -> file -> dict for both formats."""
+
+    SAMPLE_PKGINFO = {
+        "name": "Firefox",
+        "display_name": "Mozilla Firefox",
+        "version": "126.0",
+        "catalogs": ["testing"],
+        "minimum_os_version": "10.15",
+        "description": "A web browser\nfor everyone.\n",
+        "postinstall_script": "#!/bin/bash\necho done\n",
+        "receipts": [
+            {"packageid": "org.mozilla.firefox", "version": "126.0"},
+        ],
+        "installs": [
+            {
+                "path": "/Applications/Firefox.app",
+                "type": "application",
+                "CFBundleShortVersionString": "126.0",
+            },
+        ],
+        "_metadata": {"created_by": "autopkg"},
+    }
+
+    def test_yaml_roundtrip(self):
+        with tempfile.NamedTemporaryFile(
+            suffix=".yaml", delete=False, mode="w"
+        ) as f:
+            path = f.name
+        try:
+            save_munki_file(self.SAMPLE_PKGINFO, path)
+            loaded = load_munki_file(path)
+            self.assertEqual(loaded["name"], "Firefox")
+            self.assertEqual(loaded["version"], "126.0")
+            self.assertIsInstance(loaded["version"], str)
+            self.assertEqual(loaded["minimum_os_version"], "10.15")
+            self.assertIsInstance(loaded["minimum_os_version"], str)
+            self.assertEqual(loaded["receipts"][0]["version"], "126.0")
+            self.assertIsInstance(loaded["receipts"][0]["version"], str)
+            self.assertEqual(loaded["catalogs"], ["testing"])
+            self.assertIn("_metadata", loaded)
+        finally:
+            os.unlink(path)
+
+    def test_plist_roundtrip(self):
+        with tempfile.NamedTemporaryFile(
+            suffix=".plist", delete=False, mode="wb"
+        ) as f:
+            path = f.name
+        try:
+            save_munki_file(self.SAMPLE_PKGINFO, path)
+            loaded = load_munki_file(path)
+            self.assertEqual(loaded["name"], "Firefox")
+            self.assertEqual(loaded["version"], "126.0")
+        finally:
+            os.unlink(path)
+
+    def test_yaml_key_order_in_output(self):
+        yaml_str = dumps_pkginfo_yaml(self.SAMPLE_PKGINFO)
+        lines = yaml_str.strip().splitlines()
+        # First content key should be name
+        first_keys = []
+        for line in lines:
+            if ":" in line and not line.startswith(" ") and not line.startswith("-"):
+                first_keys.append(line.split(":")[0])
+        self.assertEqual(first_keys[0], "name")
+        self.assertEqual(first_keys[1], "display_name")
+        self.assertEqual(first_keys[2], "version")
+        # _metadata should be last
+        self.assertEqual(first_keys[-1], "_metadata")
+
+
+class TestAutoPkgLibYamlWrite(unittest.TestCase):
+    """Test that AutoPkgLib.copy_pkginfo_to_repo writes yaml when extension is yaml."""
+
+    def test_yaml_extension_writes_yaml(self):
+        from autopkglib.autopkgyaml import detect_munki_format
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = tmpdir
+            pkgsinfo_path = os.path.join(repo_path, "pkgsinfo")
+            os.makedirs(pkgsinfo_path)
+
+            from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
+
+            lib = AutoPkgLib(repo_path, "")
+            pkginfo = {"name": "Test", "version": "1.0", "catalogs": ["testing"]}
+            result_path = lib.copy_pkginfo_to_repo(pkginfo, file_extension="yaml")
+
+            self.assertTrue(result_path.endswith(".yaml"))
+            self.assertTrue(os.path.exists(result_path))
+            self.assertEqual(detect_munki_format(result_path), "yaml")
+            loaded = load_munki_file(result_path)
+            self.assertEqual(loaded["name"], "Test")
+            self.assertEqual(loaded["version"], "1.0")
+
+    def test_plist_extension_writes_plist(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = tmpdir
+            pkgsinfo_path = os.path.join(repo_path, "pkgsinfo")
+            os.makedirs(pkgsinfo_path)
+
+            from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
+
+            lib = AutoPkgLib(repo_path, "")
+            pkginfo = {"name": "Test", "version": "1.0", "catalogs": ["testing"]}
+            result_path = lib.copy_pkginfo_to_repo(pkginfo, file_extension="plist")
+
+            self.assertTrue(result_path.endswith(".plist"))
+            self.assertTrue(os.path.exists(result_path))
+            with open(result_path, "rb") as f:
+                loaded = plistlib.load(f)
+            self.assertEqual(loaded["name"], "Test")
+
+
+class TestAutoPkgLibYamlCatalog(unittest.TestCase):
+    """Test that AutoPkgLib.make_catalog_db reads yaml catalogs."""
+
+    def test_read_yaml_catalog(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = tmpdir
+            catalogs_path = os.path.join(repo_path, "catalogs")
+            os.makedirs(catalogs_path)
+
+            # Write a yaml catalog
+            catalog = [
+                {
+                    "name": "Firefox",
+                    "version": "126.0",
+                    "installer_item_hash": "abc123",
+                    "installer_item_location": "apps/Firefox-126.0.dmg",
+                },
+            ]
+            import yaml
+
+            # Munki writes yaml catalogs at the same extensionless path as
+            # plist catalogs (see munki/munki#1261). Format is detected by
+            # content inspection on read.
+            with open(
+                os.path.join(catalogs_path, "all"), "w", encoding="utf-8"
+            ) as f:
+                yaml.dump(catalog, f)
+
+            from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
+
+            lib = AutoPkgLib(repo_path, "")
+            pkgdb = lib.make_catalog_db()
+            self.assertIn("abc123", pkgdb["hashes"])
+            self.assertEqual(len(pkgdb["items"]), 1)
+            self.assertEqual(pkgdb["items"][0]["name"], "Firefox")
+
+    def test_read_plist_catalog(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = tmpdir
+            catalogs_path = os.path.join(repo_path, "catalogs")
+            os.makedirs(catalogs_path)
+
+            catalog = [
+                {
+                    "name": "Chrome",
+                    "version": "100.0",
+                    "installer_item_hash": "def456",
+                    "installer_item_location": "apps/Chrome-100.0.dmg",
+                },
+            ]
+            with open(os.path.join(catalogs_path, "all"), "wb") as f:
+                plistlib.dump(catalog, f)
+
+            from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
+
+            lib = AutoPkgLib(repo_path, "")
+            pkgdb = lib.make_catalog_db()
+            self.assertIn("def456", pkgdb["hashes"])
+
+    def test_empty_repo(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
+
+            lib = AutoPkgLib(tmpdir, "")
+            pkgdb = lib.make_catalog_db()
+            self.assertEqual(len(pkgdb["items"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Code/tests/test_autopkgyaml.py
+++ b/Code/tests/test_autopkgyaml.py
@@ -432,30 +432,39 @@ class TestAutoPkgLibYamlCatalog(unittest.TestCase):
             catalogs_path = os.path.join(repo_path, "catalogs")
             os.makedirs(catalogs_path)
 
-            # Write a yaml catalog
-            catalog = [
-                {
-                    "name": "Firefox",
-                    "version": "126.0",
-                    "installer_item_hash": "abc123",
-                    "installer_item_location": "apps/Firefox-126.0.dmg",
-                },
-            ]
-            import yaml
+            # Write a yaml catalog. Include an unquoted int-shaped version
+            # (`version: 14`) to exercise STRING_KEYS normalization on a
+            # list-root yaml document.
+            yaml_text = (
+                "- name: Firefox\n"
+                "  version: '126.0'\n"
+                "  installer_item_hash: abc123\n"
+                "  installer_item_location: apps/Firefox-126.0.dmg\n"
+                "- name: Xcode\n"
+                "  version: 14\n"
+                "  installer_item_hash: xyz789\n"
+                "  installer_item_location: apps/Xcode-14.dmg\n"
+            )
 
             # Munki writes yaml catalogs at the same extensionless path as
             # plist catalogs (see munki/munki#1261). Format is detected by
             # content inspection on read.
             with open(os.path.join(catalogs_path, "all"), "w", encoding="utf-8") as f:
-                yaml.dump(catalog, f)
+                f.write(yaml_text)
 
             from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
 
             lib = AutoPkgLib(repo_path, "")
             pkgdb = lib.make_catalog_db()
             self.assertIn("abc123", pkgdb["hashes"])
-            self.assertEqual(len(pkgdb["items"]), 1)
+            self.assertIn("xyz789", pkgdb["hashes"])
+            self.assertEqual(len(pkgdb["items"]), 2)
             self.assertEqual(pkgdb["items"][0]["name"], "Firefox")
+            # Int-shaped versions must be normalized back to str so catalog
+            # keys (name-version, etc.) stay consistent across yaml/plist.
+            xcode_item = next(i for i in pkgdb["items"] if i["name"] == "Xcode")
+            self.assertIsInstance(xcode_item["version"], str)
+            self.assertEqual(xcode_item["version"], "14")
 
     def test_read_plist_catalog(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/Code/tests/test_autopkgyaml.py
+++ b/Code/tests/test_autopkgyaml.py
@@ -25,18 +25,18 @@ from datetime import datetime
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from autopkglib.autopkgyaml import (
+    _INSTALLS_HEAD_KEYS,
+    _PKGINFO_HEAD_KEYS,
+    _RECEIPT_HEAD_KEYS,
     STRING_KEYS,
     _clean_float_to_str,
     _normalize_yaml_types,
     _sorted_keys,
-    _PKGINFO_HEAD_KEYS,
-    _RECEIPT_HEAD_KEYS,
-    _INSTALLS_HEAD_KEYS,
     detect_munki_format,
     dump_pkginfo_yaml,
     dumps_pkginfo_yaml,
-    is_yaml_path,
     is_plist_path,
+    is_yaml_path,
     load_munki_file,
     load_pkginfo_yaml,
     loads_pkginfo_yaml,
@@ -97,11 +97,7 @@ class TestVersionStringQuoting(unittest.TestCase):
         can recover the trailing zero."""
         # Note: deliberately UNQUOTED in the source yaml to exercise the
         # loader-level fix. Quoted '10.10' would be safe even without it.
-        yaml_input = (
-            "name: TestApp\n"
-            "version: 10.10\n"
-            "minimum_os_version: 10.10\n"
-        )
+        yaml_input = "name: TestApp\n" "version: 10.10\n" "minimum_os_version: 10.10\n"
         loaded = loads_pkginfo_yaml(yaml_input)
         self.assertIsInstance(loaded["version"], str)
         self.assertEqual(loaded["version"], "10.10")
@@ -341,9 +337,7 @@ class TestFileRoundTrip(unittest.TestCase):
     }
 
     def test_yaml_roundtrip(self):
-        with tempfile.NamedTemporaryFile(
-            suffix=".yaml", delete=False, mode="w"
-        ) as f:
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False, mode="w") as f:
             path = f.name
         try:
             save_munki_file(self.SAMPLE_PKGINFO, path)
@@ -361,9 +355,7 @@ class TestFileRoundTrip(unittest.TestCase):
             os.unlink(path)
 
     def test_plist_roundtrip(self):
-        with tempfile.NamedTemporaryFile(
-            suffix=".plist", delete=False, mode="wb"
-        ) as f:
+        with tempfile.NamedTemporaryFile(suffix=".plist", delete=False, mode="wb") as f:
             path = f.name
         try:
             save_munki_file(self.SAMPLE_PKGINFO, path)
@@ -454,9 +446,7 @@ class TestAutoPkgLibYamlCatalog(unittest.TestCase):
             # Munki writes yaml catalogs at the same extensionless path as
             # plist catalogs (see munki/munki#1261). Format is detected by
             # content inspection on read.
-            with open(
-                os.path.join(catalogs_path, "all"), "w", encoding="utf-8"
-            ) as f:
+            with open(os.path.join(catalogs_path, "all"), "w", encoding="utf-8") as f:
                 yaml.dump(catalog, f)
 
             from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib

--- a/Code/tests/test_autopkgyaml.py
+++ b/Code/tests/test_autopkgyaml.py
@@ -18,7 +18,6 @@ import plistlib
 import sys
 import tempfile
 import unittest
-from collections import OrderedDict
 from datetime import datetime
 
 # Ensure the Code directory is on the path
@@ -28,17 +27,14 @@ from autopkglib.autopkgyaml import (
     _INSTALLS_HEAD_KEYS,
     _PKGINFO_HEAD_KEYS,
     _RECEIPT_HEAD_KEYS,
-    STRING_KEYS,
     _clean_float_to_str,
     _normalize_yaml_types,
     _sorted_keys,
     detect_munki_format,
-    dump_pkginfo_yaml,
     dumps_pkginfo_yaml,
     is_plist_path,
     is_yaml_path,
     load_munki_file,
-    load_pkginfo_yaml,
     loads_pkginfo_yaml,
     parse_munki_data,
     save_munki_file,

--- a/Code/tests/test_munkiimporter.py
+++ b/Code/tests/test_munkiimporter.py
@@ -530,5 +530,47 @@ class TestMunkiImporter(unittest.TestCase):
         self.assertIn("data", summary)
 
 
+class TestAutoPkgLibCatalogDb(unittest.TestCase):
+    """Tests for AutoPkgLib.make_catalog_db yaml catalog reading."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.munki_repo = os.path.join(self.tmp_dir.name, "munki_repo")
+        os.makedirs(os.path.join(self.munki_repo, "pkgs"))
+        os.makedirs(os.path.join(self.munki_repo, "pkgsinfo"))
+        os.makedirs(os.path.join(self.munki_repo, "catalogs"))
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def _make_pkginfo(self, name="TestApp", version="1.0.0", hash_value="abc123"):
+        return {
+            "name": name,
+            "version": version,
+            "catalogs": ["testing"],
+            "installer_item_hash": hash_value,
+            "installer_item_location": f"apps/{name}-{version}.pkg",
+            "installer_item_size": 1024,
+        }
+
+    def test_yaml_catalog_is_read(self):
+        """catalogs/all written as yaml (extensionless, matching munki/munki#1261)
+        is read via content inspection."""
+        from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
+
+        items = [self._make_pkginfo(name="Audacity", hash_value="yamlCat1")]
+        with open(
+            os.path.join(self.munki_repo, "catalogs", "all"), "w", encoding="utf-8"
+        ) as f:
+            import yaml
+
+            yaml.dump(items, f)
+
+        lib = AutoPkgLib(self.munki_repo, "apps")
+        db = lib.make_catalog_db()
+
+        self.assertIn("yamlCat1", db["hashes"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds opt-in yaml support to AutoPkg's Munki integration — pkginfo, catalogs, and recipe lists can all be read and written as yaml. This is the AutoPkg-side counterpart to [munki PR #1261](https://github.com/munki/munki/pull/1261); together they let admins run an all-yaml Munki repo end-to-end, from AutoPkg output through `makecatalogs` and into the client. Behavior is unchanged for repos that don't opt in: plist remains the default, and yaml code paths fire only when a file's extension is `.yaml`/`.yml`, `MUNKI_PKGINFO_FILE_EXTENSION=yaml` is set, or a catalog is detected as yaml by content inspection.

Three related changes:

1. **Read path** — Munki processors (`MunkiImporter`, `MunkiInfoCreator`, `MunkiInstallsItemsCreator`, `MunkiOptionalReceiptEditor`) accept yaml pkginfo from `makepkginfo` stdout and on disk via a new `parse_munki_data` / `load_munki_file` helper that detects plist vs yaml by content.
2. **Write path** — When `MUNKI_PKGINFO_FILE_EXTENSION=yaml` is set, pkginfo and catalogs are emitted as yaml using a custom dumper that preserves Munki's pkginfo key ordering, force-quotes version-like scalars, and uses block scalars for script fields.
3. **Catalog format detection + yaml recipe lists** — `make_catalog_db` reads `catalogs/all` and detects plist vs yaml by content, and `parse_recipe_list` accepts `.yaml`/`.yml` files containing a top-level `recipes:` list.

### Why — and how this aligns with Munki's YAML PR

This PR is the AutoPkg-side counterpart to `munki/munki#1261`, which adds yaml pkginfo support to Munki.

Parity is verified element-for-element:

- **Same script keys** — identical 9-entry sets (`preinstall_script`, `postinstall_script`, `installcheck_script`, `uninstallcheck_script`, `postuninstall_script`, `uninstall_script`, `preuninstall_script`, `version_script`, `embedded_script`).
- **Same string-typed keys** — identical 11-entry sets covering `version`, `minimum_os_version`, `maximum_os_version`, `minimum_munki_version`, `minimum_update_version`, `installer_item_version`, `installed_version`, `product_version`, `CFBundleShortVersionString`, `CFBundleVersion`, `minosversion`.
- **Same prose keys** — identical 2-entry set (`description`, `notes`).
- **Same catalog convention** — extensionless `catalogs/<name>` filename, format detected by content detection.
- **Same float-resolver** — both sides remove the float implicit resolver at parse time so `version: 10.10` arrives as the string `"10.10"`. Munki via `Yams.Resolver.default.removing(.float)`; AutoPkg via `AutoPkgYAMLLoader`.
- **Same empty-string policy** — both sides emit `key: ''` (explicitly single-quoted, str-tagged) so empty values round-trip rather than being silently dropped or re-parsed as null.

### Relationship to `#1023`

`#1023` (@homebysix) fixes the yaml float-resolver bug at the loader level for recipes by subclassing `yaml.FullLoader` and stripping the float implicit resolver, so `MinimumVersion: 2.3` arrives as string `"2.3"` directly instead of being coerced to a float. This PR uses the same approach for Munki pkginfo and catalogs. It defines a class named `AutoPkgYAMLLoader`.

### Before / after

```sh
defaults write com.github.autopkg MUNKI_PKGINFO_FILE_EXTENSION yaml
autopkg run local.munki.Blender
# Writes Blender-5.1.1.yaml — actual yaml, consumed by Munki tooling from #1261.

# yaml recipe lists work too:
autopkg run --recipe-list=my-recipes.yaml
# where my-recipes.yaml contains:
#   recipes:
#     - local.munki.Blender
#     - local.munki.Chrome

# Catalogs are content-detected at the existing path:
# catalogs/all can be plist or yaml — AutoPkg detects the format.
```

Sample written pkginfo (from a real production run):

```yaml
name: Blender
display_name: Blender
version: 5.1.1
catalogs:
- Testing
- Staging
- Production
description: 2D/3D modeling app.
installer_item_hash: ff6219b3aaab4d9adf548b9a32b3b31764fe740b6c741d16660c5c0f4ffe9841
installer_item_location: apps/modeling/Blender-arm64-5.1.1.dmg
installer_item_size: 327490
installer_type: copy_from_dmg
installs:
- path: /Applications/Blender.app
  type: application
  CFBundleIdentifier: org.blenderfoundation.blender
  CFBundleName: Blender
  CFBundleShortVersionString: 5.1.1
  CFBundleVersion: 5.1.1
  minosversion: '11.2'
  version_comparison_key: CFBundleShortVersionString
items_to_copy:
- destination_path: /Applications
  source_item: Blender.app
minimum_os_version: '11.2'
unattended_install: true
unattended_uninstall: false
uninstall_method: remove_copied_items
uninstallable: true
_metadata:
  created_by: autopkg
  creation_date: '2026-04-14T14:06:17Z'
  munki_version: 2026.03.31.1725
  os_version: 15.7.5
```

### Production evidence

I've been running my fork internally in a AzDevOps CI pipeline for about 30 days. The pipeline pins `rodchristiansen/autopkg pr/add-yaml-support` on a `macos-latest` runner, installs the matching Munki YAML fork from `munki/munki#1261` as the client, and it has been running all my recipes in yaml.

```
# AutoPkg Pipeline - YAML-native Munki repo
# Installs AutoPkg YAML fork, runs recipes, syncs pkgs to Azure Blob Storage
# New pkgsinfo committed to repo triggers munki-push-production.yml

trigger: none
pr: none

parameters:
  - name: recipes
    displayName: "Recipes (comma-separated, leave blank to run all)"
    type: string
    default: 'all'

schedules:
  - cron: "0 14 * * 1-5"
    displayName: Weekday AutoPkg Run (7 AM PT)
    branches:
      include:
        - main
    always: true

pool:
  vmImage: 'macos-latest'

variables:
  - group: munki-repo-secrets
  - name: AUTOPKG_FORK
    value: 'https://github.com/rodchristiansen/autopkg.git'
  - name: AUTOPKG_BRANCH
    value: 'main'
```

Excerpts pulled from the pipeline log, annotated to show each new code path firing:

```text
# 1. Fork installed from this branch.
14:02:18  Installing AutoPkg YAML fork...
14:02:18  Cloning into '/tmp/autopkg-yaml-install'...
14:02:27  AutoPkg version: 2.9.1

# 2. Munki YAML fork (from munki/munki#1261) installed as the downstream consumer.
14:02:42  Munki Tools (YAML fork) version 26.3.31-1725

# 3. MUNKI_PKGINFO_FILE_EXTENSION=yaml is the only config toggle required.
14:02:50  AutoPkg preferences configured for YAML output
14:02:50      "MUNKI_PKGINFO_FILE_EXTENSION" = yaml;

# 4. Recipe list is itself a .yaml file — read by parse_recipe_list().
14:01:47   - deployment/autopkg/recipe_list.yaml [file] -→ 7F3BA0054A3A...

# 5. Catalogs built from a mixed plist+yaml pkgsinfo tree.
#    AutoPkgLib.make_catalog_db() detects each file's format via load_munki_file().
14:02:53  Adding pkgsinfo/MunkiAdmin-2026.03.31.1805.yaml to Development...
  ... 1,127 .yaml + 67 .plist pkginfo files added to 4 catalogs (Development/Testing/Staging/Production) ...
14:02:58  Created catalogs/all...
14:02:58  Catalogs built — MunkiImporter will use catalogs/all for matching

# 6. AutoPkg run kicks off; 43 recipes in parallel.
14:14:03  Running 43 recipes in 6 parallel batches

# 7. MunkiImporter using the yaml-aware AutoPkgLib repo lib.
#    Three fresh yaml pkginfos written by the new dump_pkginfo_yaml() in this run:
14:14:03  [batch 0] MunkiImporter: Using repo lib: AutoPkgLib
14:14:03  [batch 0] MunkiImporter: Copied pkginfo to: .../pkgsinfo/apps/browsers/Chrome-147.0.7727.102.yaml
14:14:03  [batch 0] MunkiImporter: Copied pkginfo to: .../pkgsinfo/apps/communication/Teams-26072.608.4595.8484.yaml
14:14:03  [batch 3] MunkiImporter: Copied pkginfo to: .../pkgsinfo/apps/media/IINA-1.4.2.yaml
```

What this shows:

1. `parse_recipe_list` read the top-level `.yaml` recipe list (line 4).
2. `AutoPkgLib.make_catalog_db` → `load_munki_file` detected the format of our 1,194 yaml pkginfo files and built our catalogs (line 5).
3. `MunkiImporter` + `dump_pkginfo_yaml` wrote three new `.yaml` pkginfos that downstream (line 7).
4. The Munki YAML fork from `#1261` was the actual client reading AutoPkg's output — paired implementations were exercised, not just unit-tested.

Every `version` value in the repo round-trips as `str` — no float-coercion bugs observed in production.

One known artifact: `_metadata.creation_date` datetimes are serialized as ISO-8601 strings; this is intentional, matches Munki's behaviour under Yams, and is not a regression.

### What's NOT in this PR

- **Dependency or tooling bumps** — no `requirements.txt`, `.pre-commit-config.yaml`, or workflow changes. Working from clean `dev-2.x` deps.

### Acknowledging the support burden

The new code paths are gated by file extension (`.yaml`/`.yml`), explicit content detection, or the existing `MUNKI_PKGINFO_FILE_EXTENSION` input variable. Repos that have always been plist remain plist-only with no behavior change. The new code lives in one new module (`autopkglib/autopkgyaml/__init__.py`) and small additions to existing Munki processors — the surface for future maintenance is contained and bounded.

If specific decisions here need to change to fit upstream's preferences — naming, where helpers live, default-output style — happy to iterate.
