### PR TITLE
Backport recipe map from dev-3.x (closes #869, #874, #884, #886, #893, #894, #898, #901, #903, #908, #918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [2.9.1](https://github.com/autopkg/autopkg/compare/v2.9.0...HEAD) (Unreleased)
 
+### Recipe map
+
+Backports the recipe map feature originally developed for the 3.x line. The recipe map is an on-disk JSON cache (`~/Library/AutoPkg/recipe_map.json` by default) of every recipe and override on the system, indexed by identifier and shortname. Recipe resolution becomes O(1) instead of walking every configured `RECIPE_SEARCH_DIRS` entry.
+
+- New `autopkg generate-recipe-map` subcommand explicitly builds and persists the map. Intended for CI/CD pipelines that want to pay the scan cost up front rather than on the first recipe run.
+- The map auto-rebuilds on first use when it is missing or invalid, so fresh installs and ephemeral CI runners "just work" without a manual bootstrap step.
+- `repo-add`, `repo-delete`, `repo-update`, `make-override` and `new-recipe` now keep the map in sync automatically. `repo-update` only rebuilds when `git pull` actually changed `HEAD`.
+- CLI `--search-dir` / `--override-dir` flags still scope resolution to exactly the supplied directories when they differ from the configured preferences, preserving the dev-2.x "recipes in `~/Library/AutoPkg/Recipes` override installed repos" contract (#886, #908, #918).
+- `find_processor_path` uses the map to locate shared-processor recipes, including a one-shot rebuild that pulls in the current working directory when a shared processor can't be resolved from the persisted map (#894).
+- Trust-info verification (`verify-trust-info`, `update-trust-info`) correctly classifies override files passed by path, via the map's `overrides` tables (#903).
+- The map location is configurable: the `AUTOPKG_RECIPE_MAP_PATH` environment variable takes precedence over the `RECIPE_MAP_PATH` preference, which takes precedence over the default (#901).
+- Escape hatch: set `AUTOPKG_DISABLE_RECIPE_MAP=1` (or the `DISABLE_RECIPE_MAP` preference) to bypass the map and fall back to the legacy on-disk scanners.
+- Persisted files carry a `schema_version` field so future format changes can trigger a clean rebuild rather than reading stale data.
+- Writes are atomic (tmpfile + `os.replace`) to tolerate concurrent autopkg invocations.
+
+Fixes #869, #874, #886, #894, #901, #903, #908, #918.
+
+### Other
+
 - Updated virtualenv to 20.36.1
 - Updated filelock to 3.20.3
 - Improved search error in case of bad GitHub credentials (#1021, thanks to @MagerValp)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,27 @@ All notable changes to this project will be documented in this file. This projec
 
 Backports the recipe map feature originally developed for the 3.x line. The recipe map is an on-disk JSON cache (`~/Library/AutoPkg/recipe_map.json` by default) of every recipe and override on the system, indexed by identifier and shortname. Recipe resolution becomes O(1) instead of walking every configured `RECIPE_SEARCH_DIRS` entry.
 
-- New `autopkg generate-recipe-map` subcommand explicitly builds and persists the map. Intended for CI/CD pipelines that want to pay the scan cost up front rather than on the first recipe run.
+**What you'll notice:**
+
+- Recipe runs, `info`, `search` and trust-info verification are faster on systems with many recipe repos. The first run after installing or `repo-add`/`repo-update` may be slightly slower while the map is (re)built.
+- New `autopkg generate-recipe-map` subcommand explicitly builds and persists the map. Intended for CI/CD pipelines that want to pay the scan cost up front.
 - The map auto-rebuilds on first use when it is missing or invalid, so fresh installs and ephemeral CI runners "just work" without a manual bootstrap step.
-- `repo-add`, `repo-delete`, `repo-update`, `make-override` and `new-recipe` now keep the map in sync automatically. `repo-update` only rebuilds when `git pull` actually changed `HEAD`.
-- CLI `--search-dir` / `--override-dir` flags still scope resolution to exactly the supplied directories when they differ from the configured preferences, preserving the dev-2.x "recipes in `~/Library/AutoPkg/Recipes` override installed repos" contract (#886, #908, #918).
-- `find_processor_path` uses the map to locate shared-processor recipes, including a one-shot rebuild that pulls in the current working directory when a shared processor can't be resolved from the persisted map (#894).
-- Trust-info verification (`verify-trust-info`, `update-trust-info`) correctly classifies override files passed by path, via the map's `overrides` tables (#903).
-- The map location is configurable: the `AUTOPKG_RECIPE_MAP_PATH` environment variable takes precedence over the `RECIPE_MAP_PATH` preference, which takes precedence over the default (#901).
-- Escape hatch: set `AUTOPKG_DISABLE_RECIPE_MAP=1` (or the `DISABLE_RECIPE_MAP` preference) to bypass the map and fall back to the legacy on-disk scanners.
-- Persisted files carry a `schema_version` field so future format changes can trigger a clean rebuild rather than reading stale data.
-- Writes are atomic (tmpfile + `os.replace`) to tolerate concurrent autopkg invocations.
+- `repo-add`, `repo-delete`, `repo-update`, `make-override` and `new-recipe` keep the map in sync automatically.
+- CLI `--search-dir` / `--override-dir` flags still scope resolution to exactly the supplied directories when they differ from the configured preferences (preserves the dev-2.x "recipes in `~/Library/AutoPkg/Recipes` override installed repos" contract).
+- Trust-info verification (`verify-trust-info`, `update-trust-info`) correctly classifies override files passed by path.
+
+**If something goes wrong:**
+
+- Run `autopkg generate-recipe-map` to force a clean rebuild.
+- Set `RECIPE_MAP_PATH` preference or `AUTOPKG_RECIPE_MAP_PATH` env var to redirect the cache to a writable location (e.g. CI workspaces that don't use `~/Library/AutoPkg`).
+- Set `DISABLE_RECIPE_MAP` preference or `AUTOPKG_DISABLE_RECIPE_MAP=1` env var to bypass the cache entirely and fall back to the legacy on-disk scanners.
+
+**Implementation notes:**
+
+- Persisted files carry a `schema_version` field so future format changes trigger a clean rebuild rather than reading stale data.
+- Writes use `tempfile.mkstemp` + `os.replace` so concurrent autopkg invocations can't observe a half-written file.
+- When running as root (e.g. via `sudo autopkg`), redirecting the map path via env var or pref now emits a prominent warning. Ops teams should strip `AUTOPKG_*` from their sudoers `env_keep` if they don't want unprivileged callers to influence where autopkg writes.
+- YAML recipes are now parsed with `yaml.safe_load` (previously `yaml.FullLoader`). Recipes only use plain mappings of primitives, so no legitimate recipe is affected.
 
 Fixes #869, #874, #886, #894, #901, #903, #908, #918.
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -466,7 +466,20 @@ def load_recipe(
     if recipe_file:
         # read it
         recipe = recipe_from_file(recipe_file)
+        if recipe is None:
+            # Map entry pointed at a file that exists but isn't a
+            # readable recipe (stale entry, truncated mid-write by a
+            # concurrent generate-recipe-map, or tampered). Fall
+            # through to the make_suggestions / search_github path as
+            # if we never found it.
+            log_err(
+                f"WARNING: {recipe_file} from recipe map is not a "
+                "readable recipe; the map may be stale. Run "
+                "`autopkg generate-recipe-map` to rebuild."
+            )
+            recipe_file = None
 
+    if recipe_file:
         # store parent trust info, but only if this is an override
         if recipe_in_override_dir(recipe_file, override_dirs):
             parent_trust_info = recipe.get("ParentRecipeTrustInfo")

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -159,6 +159,30 @@ def _normalize_dirs(dirs) -> list[str]:
     return [os.path.abspath(os.path.expanduser(d)) for d in dirs]
 
 
+def _path_under_dirs(path: str, dirs) -> bool:
+    """Return True when ``path`` resides under any directory in ``dirs``.
+
+    Uses a path-separator-anchored startswith check so sibling-prefix
+    false positives (``/a/AutoPkg2`` vs ``/a/AutoPkg``) are avoided.
+    An empty or missing ``dirs`` returns True — callers that haven't
+    constrained the scope accept any path.
+
+    This is a security helper for the recipe-map lookups: we use it to
+    refuse a map hit that points outside the caller-declared search
+    scope."""
+    if not dirs:
+        # No scope declared; callers that want scope enforcement must
+        # pass a non-empty list.
+        return True
+    normalized_path = os.path.abspath(os.path.expanduser(path))
+    for directory in _normalize_dirs(dirs):
+        if normalized_path == directory:
+            return True
+        if normalized_path.startswith(directory + os.sep):
+            return True
+    return False
+
+
 def _dirs_match_prefs(
     caller_search_dirs, caller_override_dirs
 ) -> bool:
@@ -1463,9 +1487,23 @@ def find_processor_path(processor_name, recipe, env=None):
             # Map-first, fall back to on-disk scan. This is the hot path for
             # users with many shared-processor recipes — the map was built
             # precisely to make it O(1) (issue #894).
+            #
+            # Security scope check: the map is pref-scoped. If the caller has
+            # narrowed env["RECIPE_SEARCH_DIRS"] to a subset of the prefs
+            # (e.g., `autopkg run --search-dir /sandboxed/repo`), a map
+            # hit could point at a recipe outside that subset, causing
+            # us to load a `<processor_name>.py` from a directory the
+            # caller explicitly excluded. Gate the map lookup on the
+            # resolved path living under env["RECIPE_SEARCH_DIRS"].
             shared_processor_recipe_path = find_recipe_by_id_in_map(
                 processor_recipe_id
             )
+            if shared_processor_recipe_path and not _path_under_dirs(
+                shared_processor_recipe_path, env.get("RECIPE_SEARCH_DIRS", [])
+            ):
+                # Map hit points outside the caller's declared search
+                # scope; do not honour it.
+                shared_processor_recipe_path = None
             if shared_processor_recipe_path is None:
                 shared_processor_recipe_path = find_recipe_by_identifier_on_disk(
                     processor_recipe_id, env["RECIPE_SEARCH_DIRS"]
@@ -1484,6 +1522,11 @@ def find_processor_path(processor_name, recipe, env=None):
                 shared_processor_recipe_path = find_recipe_by_id_in_map(
                     processor_recipe_id
                 )
+                if shared_processor_recipe_path and not _path_under_dirs(
+                    shared_processor_recipe_path,
+                    env.get("RECIPE_SEARCH_DIRS", []),
+                ):
+                    shared_processor_recipe_path = None
             if shared_processor_recipe_path:
                 processor_search_dirs.append(
                     os.path.dirname(shared_processor_recipe_path)
@@ -1615,40 +1658,80 @@ class TrustVerificationError(AutoPackagerError):
 
 
 def recipe_from_external_repo(recipe_path):
-    """Returns True if the recipe_path is in a path in RECIPE_REPOS, which contains
-    recipes added via repo-add"""
+    """Returns True if the recipe_path is in a path in RECIPE_REPOS, which
+    contains recipes added via repo-add.
+
+    Path-separator-anchored prefix match. A naive ``startswith(repo)``
+    would accept ``/repos/autopkg-evil/foo.recipe`` as originating from
+    ``/repos/autopkg``, enabling trust-classification confusion."""
+    normalized_path = os.path.abspath(os.path.expanduser(recipe_path))
     recipe_repos = get_pref("RECIPE_REPOS") or {}
     for repo in list(recipe_repos.keys()):
-        if recipe_path.startswith(repo):
+        normalized_repo = os.path.abspath(os.path.expanduser(repo))
+        if normalized_path == normalized_repo:
+            return True
+        if normalized_path.startswith(normalized_repo + os.sep):
             return True
     return False
 
 
 def recipe_in_override_dir(recipe_path, override_dirs):
     """Returns True if ``recipe_path`` is in one of ``override_dirs`` or
-    is listed in the recipe map's overrides/overrides-identifiers dicts.
+    is listed in the recipe map's overrides tables AND the listed path
+    also resides under a configured override directory.
 
-    The map-based check (issue #903) covers cases where the user passes a
-    relative/absolute path to ``update-trust-info`` or ``verify-trust-info``
-    but the configured ``override_dirs`` doesn't cover the parent of that
-    path. The canonical way to know whether a file is an override is to
-    check what the map has classified it as."""
+    The directory-prefix check is the authoritative answer; the map
+    lookup is an optimisation that lets us short-circuit for paths that
+    have already been classified.
+
+    Security: the recipe map is a user-writable on-disk file.
+    Trusting map entries as the sole source of truth for
+    override classification would let an attacker who can write to
+    ``recipe_map.json`` insert arbitrary paths into ``overrides`` and
+    have them treated as overrides for trust-info purposes. We require
+    the path to still live under a configured override dir to preserve
+    the invariant that override-ness is determined by on-disk location,
+    not by a cache."""
     normalized_recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
-
-    # Fast path: the map already knows whether this path is an override.
-    for key in ("overrides", "overrides-identifiers"):
-        for path in globalRecipeMap.get(key, {}).values():
-            if os.path.abspath(os.path.expanduser(path)) == normalized_recipe_path:
-                return True
-
     normalized_override_dirs = [
         os.path.abspath(os.path.expanduser(directory)) for directory in override_dirs
     ]
-    for override_dir in normalized_override_dirs:
-        if normalized_recipe_path.startswith(override_dir + os.sep):
-            return True
-        if normalized_recipe_path == override_dir:
-            return True
+
+    def _under_configured_override_dir(path: str) -> bool:
+        for override_dir in normalized_override_dirs:
+            if path == override_dir:
+                return True
+            if path.startswith(override_dir + os.sep):
+                return True
+        return False
+
+    # Directory-prefix check against the caller-supplied override_dirs.
+    if _under_configured_override_dir(normalized_recipe_path):
+        return True
+
+    # Map hint: a path listed in the map's overrides tables is still
+    # required to live under one of the configured override dirs. This
+    # lets us honour issue #903 (file paths that aren't directly rooted
+    # in override_dirs but are known to the map) without introducing an
+    # easy trust-bypass via a tampered map.
+    for key in ("overrides", "overrides-identifiers"):
+        for path in globalRecipeMap.get(key, {}).values():
+            resolved = os.path.abspath(os.path.expanduser(path))
+            if resolved != normalized_recipe_path:
+                continue
+            if _under_configured_override_dir(resolved):
+                return True
+            # Path is in the map's overrides tables but does NOT live
+            # under any configured override dir. This is the pattern an
+            # attacker would use to plant a bogus override entry; refuse
+            # to honour it.
+            log_err(
+                f"WARNING: recipe map lists {resolved} as an override "
+                "but the path is not under any configured "
+                "RECIPE_OVERRIDE_DIRS. Ignoring the map entry."
+            )
+            return False
+
     return False
 
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -41,6 +41,7 @@ from autopkglib import (  # noqa: F401  (valid_override_file + valid_recipe_dict
     AutoPackagerError,
     PreferenceError,
     _recipe_map_path,
+    add_recipe_to_map,
     calculate_recipe_map,
     core_processor_names,
     extract_processor_name_with_recipe_identifier,
@@ -87,18 +88,31 @@ RECIPE_FAILED_CODE = 70
 # process so pathological multi-miss runs (e.g. `autopkg run -l typos`
 # against a list of non-existent identifiers) don't trigger N full
 # rebuilds for N misses.
-#
-# Test fixtures reset this in setUp via ``_set_locate_recipe_rebuild_attempted``
-# so each test starts from a clean state.
 _locate_recipe_rebuild_attempted = False
 
 
-def _set_locate_recipe_rebuild_attempted(value: bool) -> None:
-    """Setter used by ``locate_recipe``, ``find_processor_path`` and by
-    tests. Exposed as a function so callers don't need ``global``
-    declarations."""
+def _try_cwd_rebuild_once(reason: str) -> bool:
+    """Perform a one-shot cwd-inclusive recipe-map rebuild, or return
+    False if we've already tried in this process.
+
+    Call sites use this to recover from map misses where the recipe may
+    be in the current working directory (which is excluded from the
+    persisted map by default). Returns True iff a rebuild was actually
+    performed; callers should retry their lookup on True.
+
+    ``reason`` is included in the log line so users can correlate the
+    rebuild with the verb that triggered it (``locate_recipe`` for a
+    recipe miss, ``find_processor_path`` for a shared-processor miss).
+
+    Tests reset the latch by patching ``_locate_recipe_rebuild_attempted``
+    directly; there is no public setter."""
     global _locate_recipe_rebuild_attempted
-    _locate_recipe_rebuild_attempted = value
+    if _locate_recipe_rebuild_attempted:
+        return False
+    _locate_recipe_rebuild_attempted = True
+    log(f"Rebuilding recipe map with current working directories ({reason})...")
+    calculate_recipe_map(skip_cwd=False, persist=False)
+    return True
 
 
 # Override global yaml state with our str representer
@@ -249,11 +263,7 @@ def find_recipe(
     # Caller-supplied dirs that differ from prefs → scope to those dirs
     # only. The map is pref-scoped and would silently include/exclude the
     # wrong set of dirs, so we bypass it entirely in that case.
-    effective_search = search_dirs if search_dirs else get_search_dirs()
-    effective_override = override_dirs if override_dirs else get_override_dirs()
-    use_map = _dirs_match_prefs(search_dirs, override_dirs)
-
-    if use_map:
+    if _dirs_match_prefs(search_dirs, override_dirs):
         result = find_recipe_by_identifier_in_map(
             id_or_name, skip_overrides=skip_overrides
         ) or find_recipe_by_name_in_map(id_or_name, skip_overrides=skip_overrides)
@@ -261,11 +271,12 @@ def find_recipe(
             return result
 
     # Map disabled, map miss, or caller scoped the search. Walk the
-    # effective search set on disk.
+    # effective search set on disk. Compute the dirs lazily so a map
+    # hit above doesn't pay the cost.
     scan_dirs: list[str] = []
     if not skip_overrides:
-        scan_dirs.extend(effective_override or [])
-    scan_dirs.extend(effective_search or [])
+        scan_dirs.extend(override_dirs or get_override_dirs())
+    scan_dirs.extend(search_dirs or get_search_dirs())
     if not scan_dirs:
         return None
     return find_recipe_by_identifier_on_disk(
@@ -356,14 +367,7 @@ def locate_recipe(
             name, search_dirs=recipe_dirs, override_dirs=override_dirs
         )
 
-    if not recipe_file and not _locate_recipe_rebuild_attempted:
-        # Map miss (or scoped scan miss). Force a one-shot full rebuild
-        # including '.' in case the recipe is in a cwd-local directory the
-        # cached map excluded, then retry. We gate this with a module-level
-        # flag so a run with many misses doesn't trigger N full rebuilds.
-        _set_locate_recipe_rebuild_attempted(True)
-        log("Rebuilding recipe map with current working directories...")
-        calculate_recipe_map(skip_cwd=False, persist=False)
+    if not recipe_file and _try_cwd_rebuild_once(f"resolving {name!r}"):
         recipe_file = find_recipe(
             name, search_dirs=recipe_dirs, override_dirs=override_dirs
         )
@@ -1539,20 +1543,11 @@ def find_processor_path(processor_name, recipe, env=None):
                 shared_processor_recipe_path = find_recipe_by_identifier_on_disk(
                     processor_recipe_id, env["RECIPE_SEARCH_DIRS"]
                 )
-            if (
-                shared_processor_recipe_path is None
-                and not _locate_recipe_rebuild_attempted
+            if shared_processor_recipe_path is None and _try_cwd_rebuild_once(
+                f"resolving shared processor {processor_recipe_id!r}"
             ):
-                # Issue #894: when a shared-processor recipe is in the cwd
-                # but was excluded from the persisted map (skip_cwd=True by
-                # default), a recipe run-by-path fails with "Unknown
-                # processor". Rebuild with cwd included and try again.
-                _set_locate_recipe_rebuild_attempted(True)
-                log(
-                    f"Rebuilding recipe map to resolve shared processor "
-                    f"{processor_recipe_id!r} in the working directory..."
-                )
-                calculate_recipe_map(skip_cwd=False, persist=False)
+                # Issue #894: the shared processor may be in the cwd,
+                # which is excluded from the persisted map by default.
                 shared_processor_recipe_path = find_recipe_by_identifier_in_map(
                     processor_recipe_id
                 )
@@ -1692,21 +1687,13 @@ class TrustVerificationError(AutoPackagerError):
 
 
 def recipe_from_external_repo(recipe_path):
-    """Returns True if the recipe_path is in a path in RECIPE_REPOS, which
-    contains recipes added via repo-add.
-
-    Path-separator-anchored prefix match. A naive ``startswith(repo)``
-    would accept ``/repos/autopkg-evil/foo.recipe`` as originating from
-    ``/repos/autopkg``, enabling trust-classification confusion."""
-    normalized_path = os.path.abspath(os.path.expanduser(recipe_path))
+    """Returns True if the recipe_path is in a path in RECIPE_REPOS,
+    which contains recipes added via repo-add. Uses ``_path_under_dirs``
+    for a separator-anchored prefix match so sibling-prefix names (e.g.
+    ``/repos/autopkg`` vs ``/repos/autopkg-evil``) don't confuse trust
+    classification."""
     recipe_repos = get_pref("RECIPE_REPOS") or {}
-    for repo in list(recipe_repos.keys()):
-        normalized_repo = os.path.abspath(os.path.expanduser(repo))
-        if normalized_path == normalized_repo:
-            return True
-        if normalized_path.startswith(normalized_repo + os.sep):
-            return True
-    return False
+    return bool(recipe_repos) and _path_under_dirs(recipe_path, list(recipe_repos))
 
 
 def recipe_in_override_dir(recipe_path, override_dirs):
@@ -2218,9 +2205,9 @@ def make_override(argv):
         with open(override_file, "wb") as f:
             plistlib.dump(plist_serializer(override_dict), f)
     log(f"Override file saved to {override_file}")
-    # Refresh the recipe map so the newly created override is discoverable
-    # immediately without a separate `generate-recipe-map` step.
-    calculate_recipe_map()
+    # Add the new override to the map incrementally instead of a full
+    # rebuild — we already know exactly which file changed.
+    add_recipe_to_map(override_file, is_override=True)
     return 0
 
 
@@ -2996,11 +2983,13 @@ def new_recipe(argv):
         log_err(f"Failed to write recipe: {err}")
         return
 
-    # Refresh the recipe map so the newly created recipe is discoverable.
-    # We include the recipe's directory as an extra search dir in case the
-    # caller wrote to somewhere outside the configured RECIPE_SEARCH_DIRS.
-    recipe_dir = os.path.dirname(os.path.abspath(filename)) or "."
-    calculate_recipe_map(extra_search_dirs=[recipe_dir])
+    # Add the new recipe to the map incrementally instead of a full
+    # rebuild. Note: if the caller wrote the recipe outside any
+    # configured RECIPE_SEARCH_DIRS, the entry will persist until the
+    # next full map rebuild (e.g. via `autopkg repo-update`), which
+    # matches the user's "make it findable right now" expectation
+    # without permanently baking a non-pref path into the cache.
+    add_recipe_to_map(os.path.abspath(filename), is_override=False)
 
 
 def main(argv):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -35,20 +35,17 @@ from urllib.parse import quote, urlparse
 import yaml
 from autopkgcmd import common_parse, gen_common_parser, search_recipes
 from autopkgcmd.searchcmd import get_search_results
-from autopkglib import (
-    DEFAULT_RECIPE_MAP,
+from autopkglib import (  # noqa: F401  (valid_override_file + valid_recipe_dict_with_keys re-exported for tests)
     RECIPE_EXTS,
     AutoPackager,
     AutoPackagerError,
     PreferenceError,
+    _recipe_map_path,
     calculate_recipe_map,
     core_processor_names,
     extract_processor_name_with_recipe_identifier,
     find_binary,
-    find_identifier_from_name,
-    find_name_from_identifier,
-    find_recipe_by_id_in_map,
-    find_recipe_by_identifier,
+    find_recipe_by_identifier_in_map,
     find_recipe_by_identifier_on_disk,
     find_recipe_by_name_in_map,
     find_recipe_by_name_on_disk,
@@ -85,18 +82,24 @@ _ = f"""{sys.version_info.major} It looks like you're running the autopkg tool w
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70
 
-# Module-level latch: have we already paid the cost of rebuilding the map
-# with cwd included during this process? Prevents pathological multi-miss
-# runs from triggering a full rebuild for each missing recipe.
+# Module-level latch: have we already paid the cost of rebuilding the
+# recipe map with cwd included during this process? Gated to once per
+# process so pathological multi-miss runs (e.g. `autopkg run -l typos`
+# against a list of non-existent identifiers) don't trigger N full
+# rebuilds for N misses.
+#
+# Test fixtures reset this in setUp via ``_set_locate_recipe_rebuild_attempted``
+# so each test starts from a clean state.
 _locate_recipe_rebuild_attempted = False
 
 
 def _set_locate_recipe_rebuild_attempted(value: bool) -> None:
-    """Setter used by locate_recipe and by tests. Kept as a function so
-    test code can patch it without worrying about module-global
-    assignment semantics."""
+    """Setter used by ``locate_recipe``, ``find_processor_path`` and by
+    tests. Exposed as a function so callers don't need ``global``
+    declarations."""
     global _locate_recipe_rebuild_attempted
     _locate_recipe_rebuild_attempted = value
+
 
 # Override global yaml state with our str representer
 # See https://github.com/autopkg/autopkg/issues/768
@@ -183,9 +186,7 @@ def _path_under_dirs(path: str, dirs) -> bool:
     return False
 
 
-def _dirs_match_prefs(
-    caller_search_dirs, caller_override_dirs
-) -> bool:
+def _dirs_match_prefs(caller_search_dirs, caller_override_dirs) -> bool:
     """Return True when the caller-supplied dirs are equivalent to the
     currently-configured pref dirs (the dirs the persisted recipe map was
     built from). When this is True it is safe to use the map for
@@ -211,16 +212,22 @@ def find_recipe(
     """Find a recipe based on a string that might be an identifier or a name.
 
     Resolution order:
-    1. If the caller supplied explicit ``search_dirs`` / ``override_dirs``
-       that differ from the configured preferences, scan ONLY those dirs
-       on disk. This preserves the dev-2.x contract that ``autopkg run -d
+    1. If the caller supplied ``search_dirs`` / ``override_dirs`` that
+       differ from the configured preferences, scan ONLY those dirs on
+       disk. This preserves the dev-2.x contract that ``autopkg run -d
        /path/to/repo Foo`` searches exactly ``/path/to/repo`` and not
        whatever happens to be in the persisted recipe map (issues #886,
        #894, #908, #918).
     2. Otherwise, consult the recipe map (O(1)).
     3. On a map miss, fall back to an on-disk scan of ``search_dirs`` (or
        the pref-configured dirs) so recipes that have not been indexed
-       yet are still found."""
+       yet are still found.
+
+    Empty-list and ``None`` semantics: both are treated as "not supplied"
+    — the pref baseline is used. Callers that want to restrict resolution
+    to an empty scope should not call this function; call
+    ``find_recipe_by_identifier_on_disk`` / ``find_recipe_by_name_on_disk``
+    directly instead."""
     # Caller-supplied dirs that differ from prefs → scope to those dirs
     # only. The map is pref-scoped and would silently include/exclude the
     # wrong set of dirs, so we bypass it entirely in that case.
@@ -229,11 +236,9 @@ def find_recipe(
     use_map = _dirs_match_prefs(search_dirs, override_dirs)
 
     if use_map:
-        result = find_recipe_by_id_in_map(
+        result = find_recipe_by_identifier_in_map(
             id_or_name, skip_overrides=skip_overrides
-        ) or find_recipe_by_name_in_map(
-            id_or_name, skip_overrides=skip_overrides
-        )
+        ) or find_recipe_by_name_in_map(id_or_name, skip_overrides=skip_overrides)
         if result:
             return result
 
@@ -423,10 +428,11 @@ def load_recipe(
         override_dirs = []
     if recipe_dirs is None:
         recipe_dirs = []
-    # Populate the recipe map before attempting resolution. With the
-    # auto-create UX, a missing map is a non-fatal condition; read_recipe_map
-    # will rebuild it on the fly if needed.
-    read_recipe_map(rebuild=True)
+    # Populate globalRecipeMap before resolution. read_recipe_map() loads
+    # the persisted cache when valid and auto-rebuilds on first miss;
+    # subsequent calls within the same process are cheap (one file read,
+    # no rebuild) so the recursive load for parent recipes is fine.
+    read_recipe_map()
     recipe = None
     recipe_file = locate_recipe(
         name,
@@ -964,9 +970,9 @@ def repo_update(argv):
         # tree (common in CI pipelines that run on every commit).
         pre_hash: str | None
         try:
-            pre_hash = run_git(
-                ["rev-parse", "HEAD"], git_directory=repo_dir
-            ).strip() or None
+            pre_hash = (
+                run_git(["rev-parse", "HEAD"], git_directory=repo_dir).strip() or None
+            )
         except GitError:
             pre_hash = None
         try:
@@ -975,9 +981,9 @@ def repo_update(argv):
             log_err(err)
             continue
         try:
-            post_hash: str | None = run_git(
-                ["rev-parse", "HEAD"], git_directory=repo_dir
-            ).strip() or None
+            post_hash: str | None = (
+                run_git(["rev-parse", "HEAD"], git_directory=repo_dir).strip() or None
+            )
         except GitError:
             post_hash = None
         if pre_hash is None or post_hash is None or pre_hash != post_hash:
@@ -1225,8 +1231,8 @@ def get_recipe_list(
 
     recipes = []
     for directory in search_dirs:
-        # TODO: Combine with similar code in find_recipe_by_name()
-        # and find_recipe_by_identifier()
+        # TODO: Combine with similar code in find_recipe_by_name_on_disk()
+        # and find_recipe_by_identifier_on_disk().
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         if not os.path.isdir(normalized_dir):
             continue
@@ -1495,7 +1501,7 @@ def find_processor_path(processor_name, recipe, env=None):
             # us to load a `<processor_name>.py` from a directory the
             # caller explicitly excluded. Gate the map lookup on the
             # resolved path living under env["RECIPE_SEARCH_DIRS"].
-            shared_processor_recipe_path = find_recipe_by_id_in_map(
+            shared_processor_recipe_path = find_recipe_by_identifier_in_map(
                 processor_recipe_id
             )
             if shared_processor_recipe_path and not _path_under_dirs(
@@ -1508,7 +1514,10 @@ def find_processor_path(processor_name, recipe, env=None):
                 shared_processor_recipe_path = find_recipe_by_identifier_on_disk(
                     processor_recipe_id, env["RECIPE_SEARCH_DIRS"]
                 )
-            if shared_processor_recipe_path is None and not _locate_recipe_rebuild_attempted:
+            if (
+                shared_processor_recipe_path is None
+                and not _locate_recipe_rebuild_attempted
+            ):
                 # Issue #894: when a shared-processor recipe is in the cwd
                 # but was excluded from the persisted map (skip_cwd=True by
                 # default), a recipe run-by-path fails with "Unknown
@@ -1519,7 +1528,7 @@ def find_processor_path(processor_name, recipe, env=None):
                     f"{processor_recipe_id!r} in the working directory..."
                 )
                 calculate_recipe_map(skip_cwd=False, persist=False)
-                shared_processor_recipe_path = find_recipe_by_id_in_map(
+                shared_processor_recipe_path = find_recipe_by_identifier_in_map(
                     processor_recipe_id
                 )
                 if shared_processor_recipe_path and not _path_under_dirs(
@@ -1728,7 +1737,8 @@ def recipe_in_override_dir(recipe_path, override_dirs):
             log_err(
                 f"WARNING: recipe map lists {resolved} as an override "
                 "but the path is not under any configured "
-                "RECIPE_OVERRIDE_DIRS. Ignoring the map entry."
+                "RECIPE_OVERRIDE_DIRS. Ignoring the map entry. "
+                "Run `autopkg generate-recipe-map` to rebuild the cache."
             )
             return False
 
@@ -2852,9 +2862,9 @@ def generate_recipe_map(argv):
     parser = gen_common_parser()
     parser.set_usage(
         f"Usage: %prog {verb} [options]\n"
-        "Build the recipe map cache now. Useful for fresh installs and\n"
-        "CI/CD environments that want to avoid paying the scan cost on\n"
-        "the first recipe run."
+        "Build or rebuild the recipe map cache now. Use this to prime\n"
+        "the cache in CI or to force a rebuild after suspecting a stale\n"
+        "or corrupted map."
     )
     add_search_and_override_dir_options(parser)
     parser.add_option(
@@ -2883,24 +2893,14 @@ def generate_recipe_map(argv):
     )
 
     counts = {k: len(v) for k, v in globalRecipeMap.items() if isinstance(v, dict)}
-    resolved = _recipe_map_path_resolved()
     log(
-        f"Recipe map written to {resolved}:\n"
+        f"Recipe map written to {_recipe_map_path()}:\n"
         f"  identifiers:           {counts.get('identifiers', 0)}\n"
         f"  shortnames:            {counts.get('shortnames', 0)}\n"
         f"  overrides:             {counts.get('overrides', 0)}\n"
         f"  overrides-identifiers: {counts.get('overrides-identifiers', 0)}"
     )
     return 0
-
-
-def _recipe_map_path_resolved() -> str:
-    """Helper that returns the canonical path the recipe map will be
-    written to, consulting the same pref/env resolution the autopkglib
-    helper uses."""
-    from autopkglib import _recipe_map_path
-
-    return _recipe_map_path()
 
 
 def new_recipe(argv):
@@ -3003,9 +3003,10 @@ def main(argv):
         "generate-recipe-map": {
             "function": generate_recipe_map,
             "help": (
-                "Build the recipe map cache. Useful for fresh installs "
-                "and CI/CD environments that want to pay the scan cost "
-                "up-front."
+                "Build or rebuild the recipe map cache. Most uses "
+                "(repo-add, make-override, first recipe run) refresh "
+                "the map automatically; invoke this explicitly to "
+                "force a rebuild or prime the cache in CI."
             ),
         },
         "make-override": {"function": make_override, "help": "Make a recipe override"},

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -844,10 +844,6 @@ Example: '%prog repo-add recipes'
         log_err("Need at least one recipe repo URL!")
         return -1
 
-    # Read the existing map (if any) before modifying prefs so that the
-    # rebuild below sees a consistent baseline.
-    read_recipe_map(allow_continuing=True)
-
     recipe_search_dirs = get_search_dirs()
     recipe_repos = get_pref("RECIPE_REPOS") or {}
     added_repo_dirs: list[str] = []
@@ -899,10 +895,6 @@ def repo_delete(argv):
     if len(arguments) < 1:
         log_err("Need at least one recipe repo path or URL!")
         return -1
-
-    # Read the existing map (if any) before mutating prefs so we can
-    # rebuild it cleanly below.
-    read_recipe_map(allow_continuing=True)
 
     recipe_repos = get_pref("RECIPE_REPOS") or {}
     recipe_search_dirs = get_search_dirs()
@@ -2911,19 +2903,24 @@ def generate_recipe_map(argv):
     )
     options, _arguments = common_parse(parser, argv)
 
-    extra_search_dirs = list(options.search_dirs or [])
-    extra_override_dirs = list(options.override_dirs or [])
+    # Refuse transient --search-dir / --override-dir flags. Persisting
+    # those paths into recipe_map.json would pollute every subsequent
+    # pref-scoped invocation with paths the user only wanted for this
+    # one build. If the user wants a dir indexed permanently, they
+    # should set it in prefs via `repo-add` or `defaults write`.
+    if options.search_dirs or options.override_dirs:
+        log_err(
+            "ERROR: generate-recipe-map writes to the persistent on-disk "
+            "cache, so transient --search-dir / --override-dir flags are "
+            "not accepted (they would leak into every later run). To "
+            "include a directory permanently, add it to RECIPE_SEARCH_DIRS "
+            "/ RECIPE_OVERRIDE_DIRS via `autopkg repo-add <dir>` or "
+            "`defaults write com.github.autopkg RECIPE_SEARCH_DIRS ...`."
+        )
+        return 1
 
-    # Single rebuild call covering configured prefs + any CLI-supplied
-    # extras. persist=True ensures the result is written to disk even
-    # when extras were supplied, which is the whole point of this verb
-    # (CI/CD bootstrap).
-    calculate_recipe_map(
-        extra_search_dirs=extra_search_dirs or None,
-        extra_override_dirs=extra_override_dirs or None,
-        skip_cwd=not options.include_cwd,
-        persist=True,
-    )
+    # Rebuild and persist the pref-scoped map.
+    calculate_recipe_map(skip_cwd=not options.include_cwd)
 
     counts = {k: len(v) for k, v in globalRecipeMap.items() if isinstance(v, dict)}
     log(

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -44,11 +44,15 @@ from autopkglib import (
     extract_processor_name_with_recipe_identifier,
     find_binary,
     find_recipe_by_identifier,
+    find_recipe_by_identifier_on_disk,
+    find_recipe_by_name_on_disk,
     get_all_prefs,
     get_autopkg_version,
     get_identifier,
+    get_override_dirs,
     get_pref,
     get_processor,
+    get_search_dirs,
     is_mac,
     log,
     log_err,
@@ -57,6 +61,11 @@ from autopkglib import (
     recipe_from_file,
     remove_recipe_extension,
     set_pref,
+    valid_override_dict,
+    valid_override_file,
+    valid_recipe_dict,
+    valid_recipe_dict_with_keys,
+    valid_recipe_file,
     version_equal_or_greater,
 )
 from autopkglib.autopkgyaml import autopkg_str_representer
@@ -113,79 +122,18 @@ def builds_a_package(recipe) -> bool:
     return recipe_has_step_processor(recipe, "PkgCreator")
 
 
-def valid_recipe_dict_with_keys(recipe_dict, keys_to_verify) -> bool:
-    """Attempts to read a dict and ensures the keys in
-    keys_to_verify exist. Returns False on any failure, True otherwise."""
-    if recipe_dict:
-        for key in keys_to_verify:
-            if key not in recipe_dict:
-                return False
-        # if we get here, we found all the keys
-        return True
-    return False
-
-
-def valid_recipe_dict(recipe_dict) -> bool:
-    """Returns True if recipe dict is a valid recipe,
-    otherwise returns False"""
-    return (
-        valid_recipe_dict_with_keys(recipe_dict, ["Input", "Process"])
-        or valid_recipe_dict_with_keys(recipe_dict, ["Input", "Recipe"])
-        or valid_recipe_dict_with_keys(recipe_dict, ["Input", "ParentRecipe"])
-    )
-
-
-def valid_recipe_file(filename) -> bool:
-    """Returns True if filename contains a valid recipe,
-    otherwise returns False"""
-    recipe_dict = recipe_from_file(filename)
-    return valid_recipe_dict(recipe_dict)
-
-
-def valid_override_dict(recipe_dict) -> bool:
-    """Returns True if the recipe is a valid override,
-    otherwise returns False"""
-    return valid_recipe_dict_with_keys(
-        recipe_dict, ["Input", "ParentRecipe"]
-    ) or valid_recipe_dict_with_keys(recipe_dict, ["Input", "Recipe"])
-
-
-def valid_override_file(filename) -> bool:
-    """Returns True if filename contains a valid override,
-    otherwise returns False"""
-    override_dict = recipe_from_file(filename)
-    return valid_override_dict(override_dict)
-
-
 def find_recipe_by_name(name, search_dirs) -> str | None:
-    """Search search_dirs for a recipe by file/directory naming rules"""
-    # drop extension from the end of the name because we're
-    # going to add it back on...
-    name = remove_recipe_extension(name)
-    # search by "Name", using file/directory hierarchy rules
-    for directory in search_dirs:
-        # TODO: Combine with similar code in get_recipe_list()
-        # and find_recipe_by_identifier()
-        normalized_dir = os.path.abspath(os.path.expanduser(directory))
-        patterns = [os.path.join(normalized_dir, f"{name}{ext}") for ext in RECIPE_EXTS]
-        patterns.extend(
-            [os.path.join(normalized_dir, f"*/{name}{ext}") for ext in RECIPE_EXTS]
-        )
-        for pattern in patterns:
-            matches = glob.glob(pattern)
-            for match in matches:
-                if valid_recipe_file(match):
-                    return match
-
-    return None
+    """Legacy helper retained for call-site compatibility. Defers to the
+    canonical on-disk scanner now defined in autopkglib."""
+    return find_recipe_by_name_on_disk(name, search_dirs)
 
 
 def find_recipe(id_or_name, search_dirs) -> str | None:
     """find a recipe based on a string that might be an identifier
     or a name"""
-    return find_recipe_by_identifier(id_or_name, search_dirs) or find_recipe_by_name(
+    return find_recipe_by_identifier_on_disk(
         id_or_name, search_dirs
-    )
+    ) or find_recipe_by_name_on_disk(id_or_name, search_dirs)
 
 
 def get_identifier_from_override(override) -> str:
@@ -635,28 +583,6 @@ def save_pref_or_warn(key, value):
         set_pref(key, value)
     except PreferenceError as err:
         log_err(f"WARNING: {err}")
-
-
-def get_search_dirs() -> list[str]:
-    """Return search dirs from preferences or default list"""
-    default = [".", "~/Library/AutoPkg/Recipes", "/Library/AutoPkg/Recipes"]
-
-    dirs: list[str] = get_pref("RECIPE_SEARCH_DIRS")
-    if isinstance(dirs, str):
-        # convert a string to a list
-        dirs = [dirs]
-    return dirs or default
-
-
-def get_override_dirs() -> list[str]:
-    """Return override dirs from preferences or default list"""
-    default = ["~/Library/AutoPkg/RecipeOverrides"]
-
-    dirs: list[str] = get_pref("RECIPE_OVERRIDE_DIRS")
-    if isinstance(dirs, str):
-        # convert a string to a list
-        dirs = [dirs]
-    return dirs or default
 
 
 def add_search_and_override_dir_options(parser):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -36,15 +36,21 @@ import yaml
 from autopkgcmd import common_parse, gen_common_parser, search_recipes
 from autopkgcmd.searchcmd import get_search_results
 from autopkglib import (
+    DEFAULT_RECIPE_MAP,
     RECIPE_EXTS,
     AutoPackager,
     AutoPackagerError,
     PreferenceError,
+    calculate_recipe_map,
     core_processor_names,
     extract_processor_name_with_recipe_identifier,
     find_binary,
+    find_identifier_from_name,
+    find_name_from_identifier,
+    find_recipe_by_id_in_map,
     find_recipe_by_identifier,
     find_recipe_by_identifier_on_disk,
+    find_recipe_by_name_in_map,
     find_recipe_by_name_on_disk,
     get_all_prefs,
     get_autopkg_version,
@@ -53,11 +59,13 @@ from autopkglib import (
     get_pref,
     get_processor,
     get_search_dirs,
+    globalRecipeMap,
     is_mac,
     log,
     log_err,
     plist_serializer,
     processor_names,
+    read_recipe_map,
     recipe_from_file,
     remove_recipe_extension,
     set_pref,
@@ -128,9 +136,22 @@ def find_recipe_by_name(name, search_dirs) -> str | None:
     return find_recipe_by_name_on_disk(name, search_dirs)
 
 
-def find_recipe(id_or_name, search_dirs) -> str | None:
-    """find a recipe based on a string that might be an identifier
-    or a name"""
+def find_recipe(id_or_name, search_dirs=None, skip_overrides=False) -> str | None:
+    """Find a recipe based on a string that might be an identifier or a name.
+
+    Consults the recipe map first (cheap, O(1)) and then falls back to an
+    on-disk scan of ``search_dirs`` if one was provided. The on-disk scan is
+    retained so callers that pass explicit ``search_dirs`` (e.g. temporary
+    directories during a parent-recipe load) still work without the map
+    needing to be rebuilt."""
+    # Map-first
+    result = find_recipe_by_id_in_map(
+        id_or_name, skip_overrides=skip_overrides
+    ) or find_recipe_by_name_in_map(id_or_name, skip_overrides=skip_overrides)
+    if result:
+        return result
+    if not search_dirs:
+        return None
     return find_recipe_by_identifier_on_disk(
         id_or_name, search_dirs
     ) or find_recipe_by_name_on_disk(id_or_name, search_dirs)
@@ -212,7 +233,17 @@ def locate_recipe(
             recipe_file = name
 
     if not recipe_file:
-        # name wasn't a filename. Let's search our local repos.
+        # name wasn't a filename. Consult the recipe map (with on-disk
+        # fallback) for O(1) resolution.
+        recipe_file = find_recipe(name, override_dirs + recipe_dirs)
+
+    if not recipe_file:
+        # Map miss. Force a full rebuild including '.' in case the recipe
+        # is in a cwd-local directory the cached map excluded, then try
+        # again. calculate_recipe_map is cheap enough that doing this once
+        # per unresolved name is acceptable, and dramatically improves UX
+        # for users who just cloned a new repo.
+        calculate_recipe_map(skip_cwd=False)
         recipe_file = find_recipe(name, override_dirs + recipe_dirs)
 
     if not recipe_file and make_suggestions:
@@ -293,6 +324,10 @@ def load_recipe(
         override_dirs = []
     if recipe_dirs is None:
         recipe_dirs = []
+    # Populate the recipe map before attempting resolution. With the
+    # auto-create UX, a missing map is a non-fatal condition; read_recipe_map
+    # will rebuild it on the fly if needed.
+    read_recipe_map(rebuild=True)
     recipe = None
     recipe_file = locate_recipe(
         name,
@@ -671,8 +706,13 @@ Example: '%prog repo-add recipes'
         log_err("Need at least one recipe repo URL!")
         return -1
 
+    # Read the existing map (if any) before modifying prefs so that the
+    # rebuild below sees a consistent baseline.
+    read_recipe_map(allow_continuing=True)
+
     recipe_search_dirs = get_search_dirs()
     recipe_repos = get_pref("RECIPE_REPOS") or {}
+    added_repo_dirs: list[str] = []
     for repo_url in arguments:
         if "file://" in repo_url:
             log_err(
@@ -688,10 +728,20 @@ Example: '%prog repo-add recipes'
                 recipe_search_dirs.append(new_recipe_repo_dir)
             # add info about this repo to our prefs
             recipe_repos[new_recipe_repo_dir] = {"URL": repo_url}
+            added_repo_dirs.append(new_recipe_repo_dir)
 
     # save our updated RECIPE_REPOS and RECIPE_SEARCH_DIRS
     save_pref_or_warn("RECIPE_REPOS", recipe_repos)
     save_pref_or_warn("RECIPE_SEARCH_DIRS", recipe_search_dirs)
+
+    # Rebuild the recipe map so the newly added repos are immediately
+    # available without requiring a separate `generate-recipe-map` step.
+    if added_repo_dirs:
+        calculate_recipe_map(extra_search_dirs=added_repo_dirs)
+        # calculate_recipe_map does not persist when extra_search_dirs are
+        # supplied (the extras may be temporary). For repo-add they are NOT
+        # temporary, so recalculate without extras to write a clean map.
+        calculate_recipe_map()
 
     log("Updated search path:")
     for search_dir in get_pref("RECIPE_SEARCH_DIRS"):
@@ -714,8 +764,13 @@ def repo_delete(argv):
         log_err("Need at least one recipe repo path or URL!")
         return -1
 
+    # Read the existing map (if any) before mutating prefs so we can
+    # rebuild it cleanly below.
+    read_recipe_map(allow_continuing=True)
+
     recipe_repos = get_pref("RECIPE_REPOS") or {}
     recipe_search_dirs = get_search_dirs()
+    removed_any = False
 
     for path_or_url in arguments:
         path_or_url = expand_repo_url(path_or_url)
@@ -737,10 +792,15 @@ def repo_delete(argv):
         else:
             # last, remove from RECIPE_REPOS
             del recipe_repos[repo_path]
+            removed_any = True
 
     # save our updated RECIPE_REPOS and RECIPE_SEARCH_DIRS
     save_pref_or_warn("RECIPE_REPOS", recipe_repos)
     save_pref_or_warn("RECIPE_SEARCH_DIRS", recipe_search_dirs)
+
+    # Recipes that were in the deleted repo(s) must not linger in the map.
+    if removed_any:
+        calculate_recipe_map()
 
 
 def repo_list(argv):
@@ -797,6 +857,11 @@ def repo_update(argv):
             log(run_git(["pull"], git_directory=repo_dir))
         except GitError as err:
             log_err(err)
+
+    # Repo contents changed on disk; refresh the map so new or renamed
+    # recipes are discoverable without another manual rebuild.
+    if repo_dirs:
+        calculate_recipe_map()
 
 
 def do_gh_repo_contents_fetch(
@@ -1896,6 +1961,9 @@ def make_override(argv):
         with open(override_file, "wb") as f:
             plistlib.dump(plist_serializer(override_dict), f)
     log(f"Override file saved to {override_file}")
+    # Refresh the recipe map so the newly created override is discoverable
+    # immediately without a separate `generate-recipe-map` step.
+    calculate_recipe_map()
     return 0
 
 
@@ -2549,6 +2617,76 @@ def audit(argv):
         log(f"    {recipe_no_issue_count} recipes triggered no audit flags")
 
 
+def generate_recipe_map(argv):
+    """Build and persist the recipe map cache.
+
+    The recipe map is normally rebuilt implicitly by repo-add, repo-delete,
+    repo-update, make-override, new-recipe and (on miss) any recipe-loading
+    verb. This verb exists primarily for fresh installs and CI/CD
+    pipelines that want to pay the scan cost once, up-front, before any
+    recipes are run.
+    """
+    verb = argv[1]
+    parser = gen_common_parser()
+    parser.set_usage(
+        f"Usage: %prog {verb} [options]\n"
+        "Build the recipe map cache now. Useful for fresh installs and\n"
+        "CI/CD environments that want to avoid paying the scan cost on\n"
+        "the first recipe run."
+    )
+    add_search_and_override_dir_options(parser)
+    parser.add_option(
+        "--include-cwd",
+        action="store_true",
+        help=(
+            "Also include the current working directory in the map. By "
+            "default '.' is excluded to avoid surprising behaviour when "
+            "running from arbitrary locations."
+        ),
+    )
+    options, _arguments = common_parse(parser, argv)
+
+    extra_search_dirs = list(options.search_dirs or [])
+    extra_override_dirs = list(options.override_dirs or [])
+
+    calculate_recipe_map(
+        extra_search_dirs=extra_search_dirs or None,
+        extra_override_dirs=extra_override_dirs or None,
+        skip_cwd=not options.include_cwd,
+    )
+
+    # calculate_recipe_map does not persist when extra dirs were provided
+    # (the extras are considered transient). If the user asked to include
+    # extra dirs we still want them in the on-disk cache so CI bootstraps
+    # are self-contained: recalculate once more without the extras and
+    # merge the additions back in.
+    if extra_search_dirs or extra_override_dirs:
+        # Re-run without extras to get a clean persisted baseline, then
+        # layer the extras on top before writing.
+        calculate_recipe_map(skip_cwd=not options.include_cwd)
+        calculate_recipe_map(
+            extra_search_dirs=extra_search_dirs or None,
+            extra_override_dirs=extra_override_dirs or None,
+            skip_cwd=not options.include_cwd,
+        )
+        # Explicitly write because calculate_recipe_map won't when extras
+        # are provided.
+        from autopkglib import write_recipe_map_to_disk as _write
+
+        _write()
+
+    counts = {k: len(v) for k, v in globalRecipeMap.items()}
+    resolved = os.path.abspath(os.path.expanduser(DEFAULT_RECIPE_MAP))
+    log(
+        f"Recipe map written to {resolved}:\n"
+        f"  identifiers:           {counts.get('identifiers', 0)}\n"
+        f"  shortnames:            {counts.get('shortnames', 0)}\n"
+        f"  overrides:             {counts.get('overrides', 0)}\n"
+        f"  overrides-identifiers: {counts.get('overrides-identifiers', 0)}"
+    )
+    return 0
+
+
 def new_recipe(argv):
     """Makes a new recipe template"""
     verb = argv[1]
@@ -2610,6 +2748,13 @@ def new_recipe(argv):
         log(f"Saved new recipe to {filename}")
     except Exception as err:
         log_err(f"Failed to write recipe: {err}")
+        return
+
+    # Refresh the recipe map so the newly created recipe is discoverable.
+    # We include the recipe's directory as an extra search dir in case the
+    # caller wrote to somewhere outside the configured RECIPE_SEARCH_DIRS.
+    recipe_dir = os.path.dirname(os.path.abspath(filename)) or "."
+    calculate_recipe_map(extra_search_dirs=[recipe_dir])
 
 
 def main(argv):
@@ -2638,6 +2783,14 @@ def main(argv):
         "list-processors": {
             "function": list_processors,
             "help": "List available core Processors",
+        },
+        "generate-recipe-map": {
+            "function": generate_recipe_map,
+            "help": (
+                "Build the recipe map cache. Useful for fresh installs "
+                "and CI/CD environments that want to pay the scan cost "
+                "up-front."
+            ),
         },
         "make-override": {"function": make_override, "help": "Make a recipe override"},
         "new-recipe": {"function": new_recipe, "help": "Make a new template recipe"},

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -85,6 +85,19 @@ _ = f"""{sys.version_info.major} It looks like you're running the autopkg tool w
 # If any recipe fails during 'autopkg run', return this exit code
 RECIPE_FAILED_CODE = 70
 
+# Module-level latch: have we already paid the cost of rebuilding the map
+# with cwd included during this process? Prevents pathological multi-miss
+# runs from triggering a full rebuild for each missing recipe.
+_locate_recipe_rebuild_attempted = False
+
+
+def _set_locate_recipe_rebuild_attempted(value: bool) -> None:
+    """Setter used by locate_recipe and by tests. Kept as a function so
+    test code can patch it without worrying about module-global
+    assignment semantics."""
+    global _locate_recipe_rebuild_attempted
+    _locate_recipe_rebuild_attempted = value
+
 # Override global yaml state with our str representer
 # See https://github.com/autopkg/autopkg/issues/768
 yaml.add_representer(str, autopkg_str_representer)
@@ -136,25 +149,81 @@ def find_recipe_by_name(name, search_dirs) -> str | None:
     return find_recipe_by_name_on_disk(name, search_dirs)
 
 
-def find_recipe(id_or_name, search_dirs=None, skip_overrides=False) -> str | None:
+def _normalize_dirs(dirs) -> list[str]:
+    """Return a list of absolute, expanded paths from ``dirs``. ``None`` and
+    empty iterables become an empty list."""
+    if not dirs:
+        return []
+    if isinstance(dirs, str):
+        dirs = [dirs]
+    return [os.path.abspath(os.path.expanduser(d)) for d in dirs]
+
+
+def _dirs_match_prefs(
+    caller_search_dirs, caller_override_dirs
+) -> bool:
+    """Return True when the caller-supplied dirs are equivalent to the
+    currently-configured pref dirs (the dirs the persisted recipe map was
+    built from). When this is True it is safe to use the map for
+    resolution; when False the caller has supplied an explicit scope
+    (e.g. ``autopkg run -d /tmp/test-repo Foo``) and the map would
+    silently ignore that scope.
+
+    This is the guard for GitHub issues #886, #894, #908 and #918."""
+    pref_search = _normalize_dirs(get_search_dirs())
+    pref_override = _normalize_dirs(get_override_dirs())
+    return (
+        _normalize_dirs(caller_search_dirs) == pref_search
+        and _normalize_dirs(caller_override_dirs) == pref_override
+    )
+
+
+def find_recipe(
+    id_or_name,
+    search_dirs=None,
+    override_dirs=None,
+    skip_overrides=False,
+) -> str | None:
     """Find a recipe based on a string that might be an identifier or a name.
 
-    Consults the recipe map first (cheap, O(1)) and then falls back to an
-    on-disk scan of ``search_dirs`` if one was provided. The on-disk scan is
-    retained so callers that pass explicit ``search_dirs`` (e.g. temporary
-    directories during a parent-recipe load) still work without the map
-    needing to be rebuilt."""
-    # Map-first
-    result = find_recipe_by_id_in_map(
-        id_or_name, skip_overrides=skip_overrides
-    ) or find_recipe_by_name_in_map(id_or_name, skip_overrides=skip_overrides)
-    if result:
-        return result
-    if not search_dirs:
+    Resolution order:
+    1. If the caller supplied explicit ``search_dirs`` / ``override_dirs``
+       that differ from the configured preferences, scan ONLY those dirs
+       on disk. This preserves the dev-2.x contract that ``autopkg run -d
+       /path/to/repo Foo`` searches exactly ``/path/to/repo`` and not
+       whatever happens to be in the persisted recipe map (issues #886,
+       #894, #908, #918).
+    2. Otherwise, consult the recipe map (O(1)).
+    3. On a map miss, fall back to an on-disk scan of ``search_dirs`` (or
+       the pref-configured dirs) so recipes that have not been indexed
+       yet are still found."""
+    # Caller-supplied dirs that differ from prefs → scope to those dirs
+    # only. The map is pref-scoped and would silently include/exclude the
+    # wrong set of dirs, so we bypass it entirely in that case.
+    effective_search = search_dirs if search_dirs else get_search_dirs()
+    effective_override = override_dirs if override_dirs else get_override_dirs()
+    use_map = _dirs_match_prefs(search_dirs, override_dirs)
+
+    if use_map:
+        result = find_recipe_by_id_in_map(
+            id_or_name, skip_overrides=skip_overrides
+        ) or find_recipe_by_name_in_map(
+            id_or_name, skip_overrides=skip_overrides
+        )
+        if result:
+            return result
+
+    # Map disabled, map miss, or caller scoped the search. Walk the
+    # effective search set on disk.
+    scan_dirs: list[str] = []
+    if not skip_overrides:
+        scan_dirs.extend(effective_override or [])
+    scan_dirs.extend(effective_search or [])
+    if not scan_dirs:
         return None
     return find_recipe_by_identifier_on_disk(
-        id_or_name, search_dirs
-    ) or find_recipe_by_name_on_disk(id_or_name, search_dirs)
+        id_or_name, scan_dirs
+    ) or find_recipe_by_name_on_disk(id_or_name, scan_dirs)
 
 
 def get_identifier_from_override(override) -> str:
@@ -233,18 +302,24 @@ def locate_recipe(
             recipe_file = name
 
     if not recipe_file:
-        # name wasn't a filename. Consult the recipe map (with on-disk
-        # fallback) for O(1) resolution.
-        recipe_file = find_recipe(name, override_dirs + recipe_dirs)
+        # name wasn't a filename. find_recipe handles map-vs-on-disk
+        # precedence based on whether the caller-supplied dirs match
+        # the prefs (see issues #886, #894, #908, #918).
+        recipe_file = find_recipe(
+            name, search_dirs=recipe_dirs, override_dirs=override_dirs
+        )
 
-    if not recipe_file:
-        # Map miss. Force a full rebuild including '.' in case the recipe
-        # is in a cwd-local directory the cached map excluded, then try
-        # again. calculate_recipe_map is cheap enough that doing this once
-        # per unresolved name is acceptable, and dramatically improves UX
-        # for users who just cloned a new repo.
-        calculate_recipe_map(skip_cwd=False)
-        recipe_file = find_recipe(name, override_dirs + recipe_dirs)
+    if not recipe_file and not _locate_recipe_rebuild_attempted:
+        # Map miss (or scoped scan miss). Force a one-shot full rebuild
+        # including '.' in case the recipe is in a cwd-local directory the
+        # cached map excluded, then retry. We gate this with a module-level
+        # flag so a run with many misses doesn't trigger N full rebuilds.
+        _set_locate_recipe_rebuild_attempted(True)
+        log("Rebuilding recipe map with current working directories...")
+        calculate_recipe_map(skip_cwd=False, persist=False)
+        recipe_file = find_recipe(
+            name, search_dirs=recipe_dirs, override_dirs=override_dirs
+        )
 
     if not recipe_file and make_suggestions:
         print(f"Didn't find a recipe for {name}.")
@@ -735,12 +810,10 @@ Example: '%prog repo-add recipes'
     save_pref_or_warn("RECIPE_SEARCH_DIRS", recipe_search_dirs)
 
     # Rebuild the recipe map so the newly added repos are immediately
-    # available without requiring a separate `generate-recipe-map` step.
+    # available. The RECIPE_SEARCH_DIRS pref was already updated above,
+    # so a single calculate_recipe_map() call picks up the new repos and
+    # persists the result.
     if added_repo_dirs:
-        calculate_recipe_map(extra_search_dirs=added_repo_dirs)
-        # calculate_recipe_map does not persist when extra_search_dirs are
-        # supplied (the extras may be temporary). For repo-add they are NOT
-        # temporary, so recalculate without extras to write a clean map.
         calculate_recipe_map()
 
     log("Updated search path:")
@@ -770,7 +843,7 @@ def repo_delete(argv):
 
     recipe_repos = get_pref("RECIPE_REPOS") or {}
     recipe_search_dirs = get_search_dirs()
-    removed_any = False
+    prefs_changed = False
 
     for path_or_url in arguments:
         path_or_url = expand_repo_url(path_or_url)
@@ -781,25 +854,32 @@ def repo_delete(argv):
         else:
             log(f"Removing repo at {repo_path}...")
 
-        # first, remove from RECIPE_SEARCH_DIRS
+        # Mutate prefs and attempt the filesystem removal together. If
+        # the rmtree fails we still strip the repo from RECIPE_SEARCH_DIRS
+        # and RECIPE_REPOS so the persisted map never references a repo
+        # that isn't in the configured search set.
         if repo_path in recipe_search_dirs:
             recipe_search_dirs.remove(repo_path)
-        # now remove the repo files
+            prefs_changed = True
+        if repo_path in recipe_repos:
+            del recipe_repos[repo_path]
+            prefs_changed = True
         try:
             shutil.rmtree(repo_path)
         except OSError as err:
-            log_err(f"ERROR: Could not remove {repo_path}: {err}")
-        else:
-            # last, remove from RECIPE_REPOS
-            del recipe_repos[repo_path]
-            removed_any = True
+            log_err(
+                f"ERROR: Could not remove {repo_path}: {err}. The repo has "
+                "been deconfigured; remove the directory manually if "
+                "desired."
+            )
 
     # save our updated RECIPE_REPOS and RECIPE_SEARCH_DIRS
     save_pref_or_warn("RECIPE_REPOS", recipe_repos)
     save_pref_or_warn("RECIPE_SEARCH_DIRS", recipe_search_dirs)
 
-    # Recipes that were in the deleted repo(s) must not linger in the map.
-    if removed_any:
+    # Always rebuild when prefs changed so the persisted map matches the
+    # configured state, even if some rmtrees failed.
+    if prefs_changed:
         calculate_recipe_map()
 
 
@@ -849,18 +929,40 @@ def repo_update(argv):
             else:
                 repo_dirs.append(repo_path)
 
+    any_repo_changed = False
     for repo_dir in repo_dirs:
         # resolve ~ and symlinks before passing to git
         repo_dir = os.path.abspath(os.path.expanduser(repo_dir))
         log(f"Attempting git pull for {repo_dir}...")
+        # Capture HEAD before and after so we only rebuild the map when
+        # the on-disk contents actually changed. Avoids paying a full
+        # scan cost for `autopkg repo-update all` on a fully-up-to-date
+        # tree (common in CI pipelines that run on every commit).
+        pre_hash: str | None
+        try:
+            pre_hash = run_git(
+                ["rev-parse", "HEAD"], git_directory=repo_dir
+            ).strip() or None
+        except GitError:
+            pre_hash = None
         try:
             log(run_git(["pull"], git_directory=repo_dir))
         except GitError as err:
             log_err(err)
+            continue
+        try:
+            post_hash: str | None = run_git(
+                ["rev-parse", "HEAD"], git_directory=repo_dir
+            ).strip() or None
+        except GitError:
+            post_hash = None
+        if pre_hash is None or post_hash is None or pre_hash != post_hash:
+            any_repo_changed = True
 
-    # Repo contents changed on disk; refresh the map so new or renamed
-    # recipes are discoverable without another manual rebuild.
-    if repo_dirs:
+    # Refresh the map so new or renamed recipes are discoverable without
+    # another manual rebuild — but only when we actually changed
+    # something on disk.
+    if any_repo_changed:
         calculate_recipe_map()
 
 
@@ -1358,9 +1460,30 @@ def find_processor_path(processor_name, recipe, env=None):
             processor_recipe_id,
         ) = extract_processor_name_with_recipe_identifier(processor_name)
         if processor_recipe_id:
-            shared_processor_recipe_path = find_recipe_by_identifier(
-                processor_recipe_id, env["RECIPE_SEARCH_DIRS"]
+            # Map-first, fall back to on-disk scan. This is the hot path for
+            # users with many shared-processor recipes — the map was built
+            # precisely to make it O(1) (issue #894).
+            shared_processor_recipe_path = find_recipe_by_id_in_map(
+                processor_recipe_id
             )
+            if shared_processor_recipe_path is None:
+                shared_processor_recipe_path = find_recipe_by_identifier_on_disk(
+                    processor_recipe_id, env["RECIPE_SEARCH_DIRS"]
+                )
+            if shared_processor_recipe_path is None and not _locate_recipe_rebuild_attempted:
+                # Issue #894: when a shared-processor recipe is in the cwd
+                # but was excluded from the persisted map (skip_cwd=True by
+                # default), a recipe run-by-path fails with "Unknown
+                # processor". Rebuild with cwd included and try again.
+                _set_locate_recipe_rebuild_attempted(True)
+                log(
+                    f"Rebuilding recipe map to resolve shared processor "
+                    f"{processor_recipe_id!r} in the working directory..."
+                )
+                calculate_recipe_map(skip_cwd=False, persist=False)
+                shared_processor_recipe_path = find_recipe_by_id_in_map(
+                    processor_recipe_id
+                )
             if shared_processor_recipe_path:
                 processor_search_dirs.append(
                     os.path.dirname(shared_processor_recipe_path)
@@ -1502,13 +1625,29 @@ def recipe_from_external_repo(recipe_path):
 
 
 def recipe_in_override_dir(recipe_path, override_dirs):
-    """Returns True if the recipe is in a path in override_dirs"""
+    """Returns True if ``recipe_path`` is in one of ``override_dirs`` or
+    is listed in the recipe map's overrides/overrides-identifiers dicts.
+
+    The map-based check (issue #903) covers cases where the user passes a
+    relative/absolute path to ``update-trust-info`` or ``verify-trust-info``
+    but the configured ``override_dirs`` doesn't cover the parent of that
+    path. The canonical way to know whether a file is an override is to
+    check what the map has classified it as."""
     normalized_recipe_path = os.path.abspath(os.path.expanduser(recipe_path))
+
+    # Fast path: the map already knows whether this path is an override.
+    for key in ("overrides", "overrides-identifiers"):
+        for path in globalRecipeMap.get(key, {}).values():
+            if os.path.abspath(os.path.expanduser(path)) == normalized_recipe_path:
+                return True
+
     normalized_override_dirs = [
         os.path.abspath(os.path.expanduser(directory)) for directory in override_dirs
     ]
     for override_dir in normalized_override_dirs:
-        if normalized_recipe_path.startswith(override_dir):
+        if normalized_recipe_path.startswith(override_dir + os.sep):
+            return True
+        if normalized_recipe_path == override_dir:
             return True
     return False
 
@@ -2649,34 +2788,19 @@ def generate_recipe_map(argv):
     extra_search_dirs = list(options.search_dirs or [])
     extra_override_dirs = list(options.override_dirs or [])
 
+    # Single rebuild call covering configured prefs + any CLI-supplied
+    # extras. persist=True ensures the result is written to disk even
+    # when extras were supplied, which is the whole point of this verb
+    # (CI/CD bootstrap).
     calculate_recipe_map(
         extra_search_dirs=extra_search_dirs or None,
         extra_override_dirs=extra_override_dirs or None,
         skip_cwd=not options.include_cwd,
+        persist=True,
     )
 
-    # calculate_recipe_map does not persist when extra dirs were provided
-    # (the extras are considered transient). If the user asked to include
-    # extra dirs we still want them in the on-disk cache so CI bootstraps
-    # are self-contained: recalculate once more without the extras and
-    # merge the additions back in.
-    if extra_search_dirs or extra_override_dirs:
-        # Re-run without extras to get a clean persisted baseline, then
-        # layer the extras on top before writing.
-        calculate_recipe_map(skip_cwd=not options.include_cwd)
-        calculate_recipe_map(
-            extra_search_dirs=extra_search_dirs or None,
-            extra_override_dirs=extra_override_dirs or None,
-            skip_cwd=not options.include_cwd,
-        )
-        # Explicitly write because calculate_recipe_map won't when extras
-        # are provided.
-        from autopkglib import write_recipe_map_to_disk as _write
-
-        _write()
-
-    counts = {k: len(v) for k, v in globalRecipeMap.items()}
-    resolved = os.path.abspath(os.path.expanduser(DEFAULT_RECIPE_MAP))
+    counts = {k: len(v) for k, v in globalRecipeMap.items() if isinstance(v, dict)}
+    resolved = _recipe_map_path_resolved()
     log(
         f"Recipe map written to {resolved}:\n"
         f"  identifiers:           {counts.get('identifiers', 0)}\n"
@@ -2685,6 +2809,15 @@ def generate_recipe_map(argv):
         f"  overrides-identifiers: {counts.get('overrides-identifiers', 0)}"
     )
     return 0
+
+
+def _recipe_map_path_resolved() -> str:
+    """Helper that returns the canonical path the recipe map will be
+    written to, consulting the same pref/env resolution the autopkglib
+    helper uses."""
+    from autopkglib import _recipe_map_path
+
+    return _recipe_map_path()
 
 
 def new_recipe(argv):

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -187,19 +187,37 @@ def _path_under_dirs(path: str, dirs) -> bool:
 
 
 def _dirs_match_prefs(caller_search_dirs, caller_override_dirs) -> bool:
-    """Return True when the caller-supplied dirs are equivalent to the
-    currently-configured pref dirs (the dirs the persisted recipe map was
-    built from). When this is True it is safe to use the map for
-    resolution; when False the caller has supplied an explicit scope
-    (e.g. ``autopkg run -d /tmp/test-repo Foo``) and the map would
-    silently ignore that scope.
+    """Return True when the caller-supplied dirs fully include the
+    pref-configured baseline the persisted recipe map was built from.
+    When this is True it is safe to use the map: any recipe the map
+    knows about lives in a directory the caller would have scanned
+    anyway.
+
+    When this is False the caller has NARROWED the scope (e.g.,
+    ``autopkg run -d /tmp/test-repo Foo`` without also passing the
+    pref dirs), and the map could point at a recipe the caller
+    explicitly excluded. Fall back to an on-disk scan of the caller's
+    exact scope in that case.
+
+    Superset semantics matter for the recursive ``load_recipe`` call:
+    when resolving a parent recipe, the recursion appends the child's
+    directory to ``recipe_dirs``, making the caller's dirs a strict
+    superset of the prefs. The map is still safe (and vastly faster)
+    in that case.
 
     This is the guard for GitHub issues #886, #894, #908 and #918."""
-    pref_search = _normalize_dirs(get_search_dirs())
-    pref_override = _normalize_dirs(get_override_dirs())
-    return (
-        _normalize_dirs(caller_search_dirs) == pref_search
-        and _normalize_dirs(caller_override_dirs) == pref_override
+    pref_search = set(_normalize_dirs(get_search_dirs()))
+    pref_override = set(_normalize_dirs(get_override_dirs()))
+    caller_search = set(_normalize_dirs(caller_search_dirs))
+    caller_override = set(_normalize_dirs(caller_override_dirs))
+    # If the caller didn't supply anything for a category, they implicitly
+    # accept the pref baseline for that category.
+    if not caller_search_dirs:
+        caller_search = pref_search
+    if not caller_override_dirs:
+        caller_override = pref_override
+    return pref_search.issubset(caller_search) and pref_override.issubset(
+        caller_override
     )
 
 
@@ -428,11 +446,13 @@ def load_recipe(
         override_dirs = []
     if recipe_dirs is None:
         recipe_dirs = []
-    # Populate globalRecipeMap before resolution. read_recipe_map() loads
-    # the persisted cache when valid and auto-rebuilds on first miss;
-    # subsequent calls within the same process are cheap (one file read,
-    # no rebuild) so the recursive load for parent recipes is fine.
-    read_recipe_map()
+    # Populate globalRecipeMap before resolution, but only if it hasn't
+    # already been loaded in this process. Without this guard, every
+    # recursive load_recipe for a parent recipe would re-read the
+    # recipe_map.json from disk and re-validate it, costing 4+ disk
+    # reads on a 3-parent chain for no benefit.
+    if not globalRecipeMap.get("identifiers"):
+        read_recipe_map()
     recipe = None
     recipe_file = locate_recipe(
         name,

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -1736,6 +1736,17 @@ def get_processor(processor_name, verbose=None, recipe=None, env=None):
                 shared_processor_recipe_path = find_recipe_by_identifier_on_disk(
                     processor_recipe_id, env["RECIPE_SEARCH_DIRS"]
                 )
+            # Re-validate the map-returned path is actually a recipe before
+            # adding its directory to the Python import path below. The map
+            # lookup only stat's the file (for speed); this call site feeds
+            # `spec.loader.exec_module`, so we want a structural check here
+            # even when it costs a parse. An attacker who can write to
+            # recipe_map.json cannot point us at an arbitrary directory
+            # just by having a file there — the file must parse as a recipe.
+            if shared_processor_recipe_path and not valid_recipe_file(
+                shared_processor_recipe_path
+            ):
+                shared_processor_recipe_path = None
             if shared_processor_recipe_path:
                 processor_search_dirs.append(
                     os.path.dirname(shared_processor_recipe_path)

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -601,19 +601,20 @@ def find_recipe_by_identifier_in_map(
 ) -> str | None:
     """Resolve an identifier to a recipe path via the global recipe map.
 
-    Returns None if no entry exists or the cached path is no longer a valid
-    recipe file (which typically means the on-disk map is stale)."""
+    Returns None if no entry exists or the cached path has disappeared from
+    disk (stale map). We only stat the file — parsing it to confirm it's a
+    valid recipe would be prohibitively expensive on the hot path (every
+    shared-processor lookup calls this), and the map was built from a valid
+    recipe to begin with."""
     if not skip_overrides and identifier in globalRecipeMap.get(
         "overrides-identifiers", {}
     ):
         override_path = globalRecipeMap["overrides-identifiers"][identifier]
-        if valid_recipe_file(override_path):
-            log(f"Found {identifier} in recipe map overrides")
+        if os.path.isfile(override_path):
             return override_path
     if identifier in globalRecipeMap.get("identifiers", {}):
         recipe_path = globalRecipeMap["identifiers"][identifier]
-        if valid_recipe_file(recipe_path):
-            log(f"Found {identifier} in recipe map")
+        if os.path.isfile(recipe_path):
             return recipe_path
     return None
 
@@ -622,17 +623,16 @@ def find_recipe_by_name_in_map(name: str, skip_overrides: bool = False) -> str |
     """Resolve a recipe shortname to a recipe path via the global recipe map.
 
     Overrides take precedence over stock recipes unless ``skip_overrides`` is
-    True. Returns None if no entry exists or the cached path is no longer a
-    valid recipe file."""
+    True. Returns None if no entry exists or the cached path has disappeared
+    from disk. See ``find_recipe_by_identifier_in_map`` for why we don't
+    re-parse the file here."""
     if not skip_overrides and name in globalRecipeMap.get("overrides", {}):
         override_path = globalRecipeMap["overrides"][name]
-        if valid_recipe_file(override_path):
-            log(f"Found {name} in recipe map overrides")
+        if os.path.isfile(override_path):
             return override_path
     if name in globalRecipeMap.get("shortnames", {}):
         recipe_path = globalRecipeMap["shortnames"][name]
-        if valid_recipe_file(recipe_path):
-            log(f"Found {name} in recipe map")
+        if os.path.isfile(recipe_path):
             return recipe_path
     return None
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -668,29 +668,39 @@ def calculate_recipe_map(
     extra_search_dirs: list[str] | None = None,
     extra_override_dirs: list[str] | None = None,
     skip_cwd: bool = True,
+    persist: bool | None = None,
 ) -> None:
     """Recalculate ``globalRecipeMap`` from scratch by walking every recipe
     search directory and every override directory.
 
-    If ``extra_search_dirs`` or ``extra_override_dirs`` is provided the result
-    is NOT written to disk — callers that pass extra dirs are expected to be
-    building a transient view (e.g. ``repo-add`` immediately before committing
-    the new repo)."""
-    global globalRecipeMap
-    globalRecipeMap = {
-        "identifiers": {},
-        "shortnames": {},
-        "overrides": {},
-        "overrides-identifiers": {},
-    }
-    if extra_search_dirs is None:
-        extra_search_dirs = []
-    if extra_override_dirs is None:
-        extra_override_dirs = []
+    Mutates ``globalRecipeMap`` in place rather than rebinding the name so
+    any module that imported the symbol with ``from autopkglib import
+    globalRecipeMap`` continues to see the fresh contents. (The generate-
+    recipe-map verb in Code/autopkg relies on this.)
+
+    ``persist`` explicitly controls whether the new map is written to disk:
+    * ``None`` (default): persist iff no extra dirs were supplied. This is
+      the legacy behaviour — callers that pass transient extras don't want
+      their view leaking into the on-disk cache.
+    * ``True`` / ``False``: force the corresponding behaviour. Used by the
+      ``generate-recipe-map`` verb, which always wants to persist."""
+    # Mutate in place so every importer sees the refresh.
+    for sub in (
+        "identifiers",
+        "shortnames",
+        "overrides",
+        "overrides-identifiers",
+    ):
+        globalRecipeMap.setdefault(sub, {}).clear()
+
+    extra_search_dirs = list(extra_search_dirs or [])
+    extra_override_dirs = list(extra_override_dirs or [])
+
     search_dirs = get_pref("RECIPE_SEARCH_DIRS") or list(DEFAULT_SEARCH_DIRS)
     if isinstance(search_dirs, str):
         search_dirs = [search_dirs]
-    for search_dir in list(search_dirs) + list(extra_search_dirs):
+
+    for search_dir in list(search_dirs) + extra_search_dirs:
         if search_dir == "." and skip_cwd:
             # Deliberately skip '.' — adding cwd to the persistent map is
             # surprising for users who run autopkg from arbitrary locations.
@@ -703,48 +713,136 @@ def calculate_recipe_map(
             map_key_to_paths("identifiers", search_dir)
         )
         globalRecipeMap["shortnames"].update(map_key_to_paths("shortnames", search_dir))
-    for override in get_override_dirs() + list(extra_override_dirs):
+
+    for override in get_override_dirs() + extra_override_dirs:
+        if override == ".":
+            # Match the search-dir behaviour: '.' is only scanned when the
+            # caller opts in via skip_cwd=False.
+            if skip_cwd:
+                continue
+            override = os.path.abspath(".")
         globalRecipeMap["overrides"].update(map_key_to_paths("overrides", override))
         globalRecipeMap["overrides-identifiers"].update(
             map_key_to_paths("overrides-identifiers", override)
         )
-    if not extra_search_dirs and not extra_override_dirs:
-        # Only persist when the map reflects the real configured state.
+
+    if persist is None:
+        persist = not (extra_search_dirs or extra_override_dirs)
+    if persist:
         write_recipe_map_to_disk()
+
+
+# Schema version baked into the persisted map. Increment when the on-disk
+# format changes in a non-backwards-compatible way so we can force a
+# rebuild rather than reading stale or incompatible content.
+RECIPE_MAP_SCHEMA_VERSION = 1
 
 
 def _recipe_map_path() -> str:
     """Return the absolute, expanded path to the recipe map file on disk.
 
+    Resolution order (issue #901):
+    1. ``AUTOPKG_RECIPE_MAP_PATH`` environment variable (CI/CD friendly).
+    2. ``RECIPE_MAP_PATH`` preference key (per-user override).
+    3. The default location under ``autopkg_user_folder()``.
+
     ``DEFAULT_RECIPE_MAP`` is stored unexpanded (with a leading ``~``) so
     tests can monkey-patch ``os.path.expanduser``; resolve it lazily here."""
-    return os.path.abspath(os.path.expanduser(DEFAULT_RECIPE_MAP))
+    override = os.environ.get("AUTOPKG_RECIPE_MAP_PATH")
+    if not override:
+        override = get_pref("RECIPE_MAP_PATH")
+    target = override or DEFAULT_RECIPE_MAP
+    return os.path.abspath(os.path.expanduser(target))
+
+
+def _recipe_map_disabled() -> bool:
+    """Escape hatch. If either the ``AUTOPKG_DISABLE_RECIPE_MAP`` env var
+    or the ``DISABLE_RECIPE_MAP`` pref is truthy, the recipe map is bypassed
+    entirely: lookups fall back to on-disk scans and writes are skipped.
+
+    Intended as a mitigation for users who hit a bug they can't reproduce
+    locally — they can bypass the map without editing code."""
+    if os.environ.get("AUTOPKG_DISABLE_RECIPE_MAP"):
+        return True
+    pref = get_pref("DISABLE_RECIPE_MAP")
+    return bool(pref)
+
+
+# Module-level latch tracking whether the last write attempt failed. When
+# True we skip further writes for the life of the process to avoid spamming
+# the log with the same OSError on every verb.
+_recipe_map_write_disabled: bool = False
 
 
 def write_recipe_map_to_disk() -> None:
     """Persist ``globalRecipeMap`` to the recipe-map file as sorted JSON.
 
+    The write is atomic: we write to ``<path>.tmp`` in the same directory,
+    fsync, then ``os.replace`` it into position. This protects concurrent
+    autopkg invocations from reading a half-written file.
+
     Failures to write (permission denied, read-only filesystem, etc.) are
     logged but not raised — the in-memory map is still usable for the
-    lifetime of the process."""
-    # Ensure the containing directory exists so the first invocation on a
-    # fresh install doesn't fail. autopkg_user_folder() is itself
-    # permission-tolerant.
+    lifetime of the process. After the first failure subsequent calls in
+    the same process are silent no-ops to avoid log spam."""
+    global _recipe_map_write_disabled
+    if _recipe_map_write_disabled:
+        return
+    if _recipe_map_disabled():
+        # Escape hatch: don't touch disk at all.
+        return
+
+    target = _recipe_map_path()
+    # Ensure the containing directory exists. autopkg_user_folder() handles
+    # the default location; if the user pointed RECIPE_MAP_PATH at a
+    # custom spot we need to ensure its directory is present too.
     autopkg_user_folder()
+    target_dir = os.path.dirname(target)
+    if target_dir:
+        try:
+            os.makedirs(target_dir, exist_ok=True)
+        except OSError:
+            # Fall through; the open below will surface the real error.
+            pass
+
+    # Wrap the persisted dict with a schema version so future versions can
+    # detect and migrate/rebuild incompatible formats.
+    payload = {
+        "schema_version": RECIPE_MAP_SCHEMA_VERSION,
+        **globalRecipeMap,
+    }
+    tmp = f"{target}.tmp"
     try:
-        with open(_recipe_map_path(), "w") as f:
+        with open(tmp, "w") as f:
             json.dump(
-                globalRecipeMap,
+                payload,
                 f,
                 ensure_ascii=True,
                 indent=2,
                 sort_keys=True,
             )
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except (OSError, AttributeError):
+                # fsync can fail on some filesystems (e.g., tmpfs). The
+                # replace below is still atomic enough for our needs.
+                pass
+        os.replace(tmp, target)
     except OSError as err:
-        log_err(f"WARNING: Could not write recipe map to disk: {err}")
+        _recipe_map_write_disabled = True
+        log_err(
+            f"WARNING: Could not write recipe map to {target}: {err}. "
+            "Further write attempts in this process will be skipped."
+        )
+        # Best-effort cleanup of the partial tempfile.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
-def handle_reading_recipe_map_file() -> dict[str, dict[str, str]]:
+def handle_reading_recipe_map_file() -> dict:
     """Read the recipe map from disk. Returns an empty dict on any I/O or
     JSON error — callers are expected to treat that as a signal to rebuild
     the map."""
@@ -760,48 +858,77 @@ def handle_reading_recipe_map_file() -> dict[str, dict[str, str]]:
         return {}
 
 
-def validate_recipe_map(recipe_map: dict[str, dict[str, str]]) -> bool:
+# Required top-level keys in the in-memory / persisted map structure.
+_EXPECTED_MAP_KEYS = frozenset(
+    ("identifiers", "shortnames", "overrides", "overrides-identifiers")
+)
+
+
+def validate_recipe_map(recipe_map: dict) -> bool:
     """Return True if ``recipe_map`` has the full set of expected top-level
-    keys."""
-    expected_keys = {
-        "identifiers",
-        "overrides",
-        "overrides-identifiers",
-        "shortnames",
-    }
-    return expected_keys.issubset(recipe_map.keys())
+    keys AND, if a ``schema_version`` is present, it matches what this
+    version of autopkg knows how to read.
+
+    Missing ``schema_version`` is treated as valid for forward-compat with
+    older persisted files that pre-date the version field; missing required
+    dict keys always invalidate the map."""
+    if not _EXPECTED_MAP_KEYS.issubset(recipe_map.keys()):
+        return False
+    version = recipe_map.get("schema_version")
+    if version is None:
+        # Legacy file from a version before we started writing the
+        # schema_version key — treat as v1.
+        return True
+    return version == RECIPE_MAP_SCHEMA_VERSION
 
 
 def read_recipe_map(rebuild: bool = False, allow_continuing: bool = False) -> None:
     """Load the recipe map from disk into ``globalRecipeMap``.
 
-    If the file is missing or invalid we ALWAYS auto-create it by walking
-    the configured search/override dirs. This is a deliberate divergence
-    from the dev-3.x behaviour which printed an error and exited. The
-    original behaviour was confusing for first-time users and CI jobs that
-    had not yet run a map-building verb.
+    Behaviour:
+    * If ``rebuild`` is True we always rebuild from scratch, regardless of
+      the on-disk state. (Dev-3.x's ``rebuild=True`` originally skipped
+      the rebuild when the file was valid; we treat that as a bug since
+      callers that pass ``rebuild=True`` genuinely want the force.)
+    * Otherwise we read the file and validate it. Valid → load into the
+      global map. Invalid/missing → auto-rebuild silently.
 
-    ``rebuild`` is retained for API compatibility with the dev-3.x callers
-    — callers that pass ``rebuild=True`` get the same on-demand rebuild.
-    ``allow_continuing`` is likewise retained; with the new auto-create
-    behaviour it is effectively a no-op but is accepted so existing callers
-    do not need to be rewritten."""
-    global globalRecipeMap
+    This is a deliberate UX divergence from dev-3.x's "print error and
+    sys.exit(1) when the map is missing" behaviour. Fresh installs and
+    CI/CD pipelines hit that case constantly and the exit was confusing.
+    See GitHub issues #884, #893, #898.
+
+    ``allow_continuing`` is retained for API compatibility with the dev-3.x
+    callers (repo-add / repo-delete pass it to say "the map might not
+    exist yet"). With the new auto-create behaviour it is effectively a
+    no-op but we accept it so existing callers don't need to change."""
     _ = allow_continuing  # retained for API compatibility
+
+    if _recipe_map_disabled():
+        # Escape hatch: callers will still do something; we just don't
+        # populate the map. find_recipe_by_*_in_map will return None and
+        # the on-disk fallbacks will kick in.
+        return
+
+    if rebuild:
+        log("Recipe map: forced rebuild requested.")
+        calculate_recipe_map()
+        return
+
     recipe_map = handle_reading_recipe_map_file()
     if validate_recipe_map(recipe_map):
-        globalRecipeMap.update(recipe_map)
+        # Load into globalRecipeMap in place. Start by clearing the
+        # existing sub-dicts so stale entries don't leak across reads.
+        for sub in _EXPECTED_MAP_KEYS:
+            globalRecipeMap.setdefault(sub, {}).clear()
+            globalRecipeMap[sub].update(recipe_map.get(sub, {}))
         return
-    # Auto-create on miss rather than failing. This is the behavioural fix
-    # called out above.
-    if rebuild:
-        log("Recipe map is missing or invalid; rebuilding now...")
+
+    # Missing/invalid → auto-create.
+    if not recipe_map:
+        log("Recipe map not found; generating it on demand.")
     else:
-        log(
-            "Recipe map is missing or invalid; generating it on demand. "
-            "Run `autopkg generate-recipe-map` explicitly (e.g. in CI) to "
-            "avoid paying this cost on every fresh run."
-        )
+        log("Recipe map is invalid or from an older schema; rebuilding now.")
     calculate_recipe_map()
 
 

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -380,15 +380,23 @@ def remove_recipe_extension(name) -> str:
 
 
 def recipe_from_file(filename) -> VarDict | None:
-    """Create a recipe dictionary from a file. Handle exceptions and log"""
+    """Create a recipe dictionary from a file. Handle exceptions and log.
+
+    YAML recipes are parsed with ``yaml.safe_load`` (not ``FullLoader``).
+    Recipe documents are always plain mappings of primitives, so the safe
+    loader is sufficient for every legitimate recipe in the ecosystem.
+    This is a deliberate defence against arbitrary-code-execution via
+    crafted YAML tags (CVE-2020-14343-class issues) — doubly important
+    now that the recipe map backport causes every ``.recipe.yaml`` in
+    ``RECIPE_SEARCH_DIRS`` to be parsed during every map build and
+    lookup, not just when the user explicitly invokes the recipe."""
     if not os.path.isfile(filename):
         return
 
     if filename.endswith(".yaml"):
         try:
-            # try to read it as yaml
             with open(filename, "rb") as f:
-                recipe_dict = yaml.load(f, Loader=yaml.FullLoader)
+                recipe_dict = yaml.safe_load(f)
             return recipe_dict
         except Exception as err:
             log_err(f"WARNING: yaml error for {filename}: {err}")
@@ -746,13 +754,47 @@ def _recipe_map_path() -> str:
     2. ``RECIPE_MAP_PATH`` preference key (per-user override).
     3. The default location under ``autopkg_user_folder()``.
 
-    ``DEFAULT_RECIPE_MAP`` is stored unexpanded (with a leading ``~``) so
-    tests can monkey-patch ``os.path.expanduser``; resolve it lazily here."""
+    Security notes:
+    * Environment variables are honoured regardless of effective UID,
+      but when running as root we log a prominent warning so operators
+      noticing the deviation in their logs can investigate. Users who
+      run ``sudo autopkg`` in CI pipelines should strip ``AUTOPKG_*``
+      from their ``env_keep`` list to avoid letting an unprivileged
+      caller influence a privileged process's write target.
+    * ``DEFAULT_RECIPE_MAP`` is stored unexpanded (with a leading ``~``)
+      so tests can monkey-patch ``os.path.expanduser``; resolve it
+      lazily here."""
+    override_source: str | None = None
     override = os.environ.get("AUTOPKG_RECIPE_MAP_PATH")
-    if not override:
-        override = get_pref("RECIPE_MAP_PATH")
+    if override:
+        override_source = "AUTOPKG_RECIPE_MAP_PATH environment variable"
+    else:
+        pref = get_pref("RECIPE_MAP_PATH")
+        if pref:
+            override = pref
+            override_source = "RECIPE_MAP_PATH preference"
+
     target = override or DEFAULT_RECIPE_MAP
-    return os.path.abspath(os.path.expanduser(target))
+    resolved = os.path.abspath(os.path.expanduser(target))
+
+    if override and override_source:
+        try:
+            euid = os.geteuid()
+        except AttributeError:
+            # Windows doesn't have geteuid; treat as unprivileged.
+            euid = -1
+        if euid == 0:
+            log_err(
+                "SECURITY WARNING: autopkg is running as root and the "
+                f"recipe map path has been redirected via {override_source} "
+                f"to {resolved}. If this was not set by the system "
+                "administrator it may be a privilege-escalation attempt. "
+                "Consider stripping AUTOPKG_* from your sudoers env_keep "
+                "configuration."
+            )
+        else:
+            log(f"Recipe map path overridden via {override_source}: {resolved}")
+    return resolved
 
 
 def _recipe_map_disabled() -> bool:
@@ -811,9 +853,35 @@ def write_recipe_map_to_disk() -> None:
         "schema_version": RECIPE_MAP_SCHEMA_VERSION,
         **globalRecipeMap,
     }
-    tmp = f"{target}.tmp"
+
+    # Create the tempfile via tempfile.mkstemp so we get O_EXCL semantics
+    # and explicit mode bits. This prevents a classic symlink-TOCTOU
+    # attack (CWE-59/CWE-377): if another principal can pre-create a
+    # symlink at ``<target>.tmp`` pointing at an attacker-chosen file,
+    # a plain ``open(tmp, "w")`` would follow the symlink and truncate
+    # the target. mkstemp refuses to follow existing symlinks.
+    tmp_dir = target_dir or "."
+    tmp_basename = f".{os.path.basename(target)}.tmp"
+    tmp_fd = -1
+    tmp: str | None = None
     try:
-        with open(tmp, "w") as f:
+        import tempfile as _tempfile
+
+        tmp_fd, tmp = _tempfile.mkstemp(
+            prefix=tmp_basename,
+            dir=tmp_dir,
+        )
+        # Tighten permissions so a shared-homedir setup doesn't leak the
+        # map's file listing to other users on the system.
+        try:
+            os.chmod(tmp, 0o600)
+        except OSError:
+            # Chmod not supported on every filesystem; soft-fail.
+            pass
+        with os.fdopen(tmp_fd, "w") as f:
+            # fdopen takes ownership of the fd; null it out so the
+            # finally clause below doesn't double-close.
+            tmp_fd = -1
             json.dump(
                 payload,
                 f,
@@ -829,17 +897,26 @@ def write_recipe_map_to_disk() -> None:
                 # replace below is still atomic enough for our needs.
                 pass
         os.replace(tmp, target)
+        tmp = None  # Successfully renamed; no cleanup needed.
     except OSError as err:
         _recipe_map_write_disabled = True
         log_err(
             f"WARNING: Could not write recipe map to {target}: {err}. "
             "Further write attempts in this process will be skipped."
         )
-        # Best-effort cleanup of the partial tempfile.
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
+    finally:
+        # Best-effort cleanup of the partial tempfile if we didn't rename
+        # it into position.
+        if tmp_fd != -1:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
+        if tmp and os.path.exists(tmp):
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
 
 
 def handle_reading_recipe_map_file() -> dict:

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -124,6 +124,29 @@ RE_KEYREF = re.compile(r"%(?P<key>[a-zA-Z_][a-zA-Z_0-9]*)%")
 # Supported recipe extensions
 RECIPE_EXTS = (".recipe", ".recipe.plist", ".recipe.yaml")
 
+# Default filesystem locations used by autopkg. These mirror the post-3.x
+# layout so that the recipe map backport can find the same paths that the
+# dev-3.x code expects.
+DEFAULT_USER_LIBRARY_DIR = "~/Library/AutoPkg"
+DEFAULT_LIBRARY_DIR = "/Library/AutoPkg"
+DEFAULT_USER_OVERRIDES_DIR = os.path.join(DEFAULT_USER_LIBRARY_DIR, "RecipeOverrides")
+DEFAULT_USER_RECIPES_DIR = os.path.join(DEFAULT_USER_LIBRARY_DIR, "Recipes")
+DEFAULT_USER_CACHE_DIR = os.path.join(DEFAULT_USER_LIBRARY_DIR, "Cache")
+DEFAULT_USER_REPOS_DIR = os.path.join(DEFAULT_USER_LIBRARY_DIR, "RecipeRepos")
+# Canonical on-disk location of the recipe map
+DEFAULT_RECIPE_MAP = os.path.join(DEFAULT_USER_LIBRARY_DIR, "recipe_map.json")
+DEFAULT_GH_TOKEN = os.path.join(DEFAULT_USER_LIBRARY_DIR, "gh_token")
+DEFAULT_SEARCH_DIRS = [".", DEFAULT_USER_LIBRARY_DIR, DEFAULT_LIBRARY_DIR]
+
+
+def autopkg_user_folder() -> str:
+    """Return the absolute path to the user's AutoPkg folder, creating it
+    and its immediate subfolders on demand. This is used as the canonical
+    location for the recipe map and related caches."""
+    folder = os.path.abspath(os.path.expanduser(DEFAULT_USER_LIBRARY_DIR))
+    os.makedirs(folder, exist_ok=True)
+    return folder
+
 
 class PreferenceError(Exception):
     """Preference exception"""
@@ -381,11 +404,76 @@ def get_identifier_from_recipe_file(filename) -> str | None:
     return get_identifier(recipe_dict)
 
 
-def find_recipe_by_identifier(identifier, search_dirs) -> str | None:
-    """Search search_dirs for a recipe with the given
-    identifier"""
+def valid_recipe_dict_with_keys(recipe_dict, keys_to_verify) -> bool:
+    """Attempts to read a dict and ensures the keys in
+    keys_to_verify exist. Returns False on any failure, True otherwise."""
+    if recipe_dict:
+        for key in keys_to_verify:
+            if key not in recipe_dict:
+                return False
+        # if we get here, we found all the keys
+        return True
+    return False
+
+
+def valid_recipe_dict(recipe_dict) -> bool:
+    """Returns True if recipe dict is a valid recipe,
+    otherwise returns False"""
+    return (
+        valid_recipe_dict_with_keys(recipe_dict, ["Input", "Process"])
+        or valid_recipe_dict_with_keys(recipe_dict, ["Input", "Recipe"])
+        or valid_recipe_dict_with_keys(recipe_dict, ["Input", "ParentRecipe"])
+    )
+
+
+def valid_recipe_file(filename) -> bool:
+    """Returns True if filename contains a valid recipe,
+    otherwise returns False"""
+    recipe_dict = recipe_from_file(filename)
+    return valid_recipe_dict(recipe_dict)
+
+
+def valid_override_dict(recipe_dict) -> bool:
+    """Returns True if the recipe is a valid override,
+    otherwise returns False"""
+    return valid_recipe_dict_with_keys(
+        recipe_dict, ["Input", "ParentRecipe"]
+    ) or valid_recipe_dict_with_keys(recipe_dict, ["Input", "Recipe"])
+
+
+def valid_override_file(filename) -> bool:
+    """Returns True if filename contains a valid override,
+    otherwise returns False"""
+    override_dict = recipe_from_file(filename)
+    return valid_override_dict(override_dict)
+
+
+def get_search_dirs() -> list[str]:
+    """Return search dirs from preferences or default list"""
+    dirs: list[str] = get_pref("RECIPE_SEARCH_DIRS")
+    if isinstance(dirs, str):
+        # convert a string to a list
+        dirs = [dirs]
+    return dirs or list(DEFAULT_SEARCH_DIRS)
+
+
+def get_override_dirs() -> list[str]:
+    """Return override dirs from preferences or default list"""
+    default = [DEFAULT_USER_OVERRIDES_DIR]
+
+    dirs: list[str] = get_pref("RECIPE_OVERRIDE_DIRS")
+    if isinstance(dirs, str):
+        # convert a string to a list
+        dirs = [dirs]
+    return dirs or default
+
+
+def find_recipe_by_identifier_on_disk(identifier, search_dirs) -> str | None:
+    """Search search_dirs on disk for a recipe with the given identifier.
+
+    This is the legacy on-disk scan used as a fallback when the recipe map
+    cannot resolve a recipe."""
     for directory in search_dirs:
-        # TODO: Combine with similar code in get_recipe_list() and find_recipe_by_name()
         normalized_dir = os.path.abspath(os.path.expanduser(directory))
         patterns = [os.path.join(normalized_dir, f"*{ext}") for ext in RECIPE_EXTS]
         patterns.extend(
@@ -398,6 +486,36 @@ def find_recipe_by_identifier(identifier, search_dirs) -> str | None:
                     return match
 
     return None
+
+
+def find_recipe_by_name_on_disk(name, search_dirs) -> str | None:
+    """Search search_dirs on disk for a recipe by file/directory naming rules.
+
+    This is the legacy on-disk scan used as a fallback when the recipe map
+    cannot resolve a recipe."""
+    # drop extension from the end of the name because we're
+    # going to add it back on...
+    name = remove_recipe_extension(name)
+    # search by "Name", using file/directory hierarchy rules
+    for directory in search_dirs:
+        normalized_dir = os.path.abspath(os.path.expanduser(directory))
+        patterns = [os.path.join(normalized_dir, f"{name}{ext}") for ext in RECIPE_EXTS]
+        patterns.extend(
+            [os.path.join(normalized_dir, f"*/{name}{ext}") for ext in RECIPE_EXTS]
+        )
+        for pattern in patterns:
+            matches = glob.glob(pattern)
+            for match in matches:
+                if valid_recipe_file(match):
+                    return match
+
+    return None
+
+
+# Backwards-compatible alias. The dev-3.x port will replace this with a
+# recipe-map-based implementation; for now point callers at the on-disk
+# scanner so existing behaviour is preserved.
+find_recipe_by_identifier = find_recipe_by_identifier_on_disk
 
 
 def get_autopkg_version() -> str:

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -330,6 +330,18 @@ class Preferences:
 # Set the global preferences object
 globalPreferences = Preferences()
 
+# Set the global recipe map. The four top-level dicts map:
+#   identifiers           -> identifier string -> absolute recipe path
+#   shortnames            -> recipe shortname  -> absolute recipe path
+#   overrides             -> override shortname -> absolute override path
+#   overrides-identifiers -> override identifier -> absolute override path
+globalRecipeMap: dict[str, dict[str, str]] = {
+    "identifiers": {},
+    "shortnames": {},
+    "overrides": {},
+    "overrides-identifiers": {},
+}
+
 
 def get_pref(key) -> Any | None:
     """Return a single pref value (or None) for a domain."""
@@ -512,10 +524,262 @@ def find_recipe_by_name_on_disk(name, search_dirs) -> str | None:
     return None
 
 
-# Backwards-compatible alias. The dev-3.x port will replace this with a
-# recipe-map-based implementation; for now point callers at the on-disk
-# scanner so existing behaviour is preserved.
+# Backwards-compatible alias. The recipe-map port below keeps this name
+# pointing at the on-disk scanner so existing tests that mock
+# ``find_recipe_by_identifier`` keep working. Callers that want the new
+# map-based behaviour should use ``find_recipe_by_id_in_map`` explicitly.
 find_recipe_by_identifier = find_recipe_by_identifier_on_disk
+
+
+# ---------------------------------------------------------------------------
+# Recipe map: backport from dev-3.x
+# ---------------------------------------------------------------------------
+#
+# The recipe map is an on-disk JSON cache of every recipe and override
+# discovered on the system. It lets autopkg resolve a recipe by identifier
+# or shortname without walking every recipe directory on each invocation,
+# which is the dominant cost for users with many recipe repos.
+#
+# The cache lives at DEFAULT_RECIPE_MAP (``~/Library/AutoPkg/recipe_map.json``)
+# and has four top-level keys: ``identifiers``, ``shortnames``, ``overrides``
+# and ``overrides-identifiers``. Each maps the corresponding string to an
+# absolute path.
+#
+# UX note (dev-2.x backport): the original dev-3.x behaviour exited with an
+# error when the map was missing. We auto-create it on demand instead, and
+# expose an explicit ``autopkg generate-recipe-map`` verb for environments
+# (e.g. CI/CD) that want to build the cache up-front.
+
+
+def find_recipe_by_id_in_map(
+    identifier: str, skip_overrides: bool = False
+) -> str | None:
+    """Resolve an identifier to a recipe path via the global recipe map.
+
+    Returns None if no entry exists or the cached path is no longer a valid
+    recipe file (which typically means the on-disk map is stale)."""
+    if not skip_overrides and identifier in globalRecipeMap.get(
+        "overrides-identifiers", {}
+    ):
+        override_path = globalRecipeMap["overrides-identifiers"][identifier]
+        if valid_recipe_file(override_path):
+            log(f"Found {identifier} in recipe map overrides")
+            return override_path
+    if identifier in globalRecipeMap.get("identifiers", {}):
+        recipe_path = globalRecipeMap["identifiers"][identifier]
+        if valid_recipe_file(recipe_path):
+            log(f"Found {identifier} in recipe map")
+            return recipe_path
+    return None
+
+
+def find_recipe_by_name_in_map(name: str, skip_overrides: bool = False) -> str | None:
+    """Resolve a recipe shortname to a recipe path via the global recipe map.
+
+    Overrides take precedence over stock recipes unless ``skip_overrides`` is
+    True. Returns None if no entry exists or the cached path is no longer a
+    valid recipe file."""
+    if not skip_overrides and name in globalRecipeMap.get("overrides", {}):
+        override_path = globalRecipeMap["overrides"][name]
+        if valid_recipe_file(override_path):
+            log(f"Found {name} in recipe map overrides")
+            return override_path
+    if name in globalRecipeMap.get("shortnames", {}):
+        recipe_path = globalRecipeMap["shortnames"][name]
+        if valid_recipe_file(recipe_path):
+            log(f"Found {name} in recipe map")
+            return recipe_path
+    return None
+
+
+def find_name_from_identifier(identifier: str) -> str | None:
+    """Reverse lookup: return a shortname for the given identifier, or None."""
+    recipe_path = globalRecipeMap.get("identifiers", {}).get(identifier)
+    if recipe_path is None:
+        log_err(f"Could not find shortname from {identifier}!")
+        return None
+    for shortname, path in globalRecipeMap.get("shortnames", {}).items():
+        if recipe_path == path:
+            return shortname
+    log_err(f"Could not find shortname from {identifier}!")
+    return None
+
+
+def find_identifier_from_name(name: str) -> str | None:
+    """Reverse lookup: return an identifier for the given shortname, or None."""
+    recipe_path = globalRecipeMap.get("shortnames", {}).get(name)
+    if recipe_path is None:
+        log_err(f"Could not find identifier from {name}!")
+        return None
+    for recipe_id, path in globalRecipeMap.get("identifiers", {}).items():
+        if recipe_path == path:
+            return recipe_id
+    log_err(f"Could not find identifier from {name}!")
+    return None
+
+
+def map_key_to_paths(keyname: str, repo_dir: str) -> dict[str, str]:
+    """Walk ``repo_dir`` one level deep and emit {key: absolute_path} entries
+    suitable for inclusion in ``globalRecipeMap[keyname]``.
+
+    When ``keyname`` contains ``"identifiers"`` the key is read from the
+    recipe file's Identifier field; otherwise the key is the filename minus
+    the recipe extension.
+
+    First-wins: if a key is already present in the return dict or in
+    ``globalRecipeMap[keyname]`` the new path is ignored."""
+    recipe_map: dict[str, str] = {}
+    normalized_dir = os.path.abspath(os.path.expanduser(repo_dir))
+    patterns = [os.path.join(normalized_dir, f"*{ext}") for ext in RECIPE_EXTS]
+    patterns.extend([os.path.join(normalized_dir, f"*/*{ext}") for ext in RECIPE_EXTS])
+    for pattern in patterns:
+        matches = glob.glob(pattern)
+        for match in matches:
+            if "identifiers" in keyname:
+                key = get_identifier_from_recipe_file(match)
+            else:
+                key = remove_recipe_extension(os.path.basename(match))
+            # In case the file was invalid, or missing a key
+            if not key:
+                log_err(
+                    f"WARNING: {match} is potentially an invalid file, not "
+                    "adding it to the recipe map! Please file a GitHub Issue "
+                    "for this repo."
+                )
+                continue
+            if key in recipe_map or key in globalRecipeMap.get(keyname, {}):
+                # first-wins; do not overwrite an existing entry
+                continue
+            recipe_map[key] = match
+    return recipe_map
+
+
+def calculate_recipe_map(
+    extra_search_dirs: list[str] | None = None,
+    extra_override_dirs: list[str] | None = None,
+    skip_cwd: bool = True,
+) -> None:
+    """Recalculate ``globalRecipeMap`` from scratch by walking every recipe
+    search directory and every override directory.
+
+    If ``extra_search_dirs`` or ``extra_override_dirs`` is provided the result
+    is NOT written to disk — callers that pass extra dirs are expected to be
+    building a transient view (e.g. ``repo-add`` immediately before committing
+    the new repo)."""
+    global globalRecipeMap
+    globalRecipeMap = {
+        "identifiers": {},
+        "shortnames": {},
+        "overrides": {},
+        "overrides-identifiers": {},
+    }
+    if extra_search_dirs is None:
+        extra_search_dirs = []
+    if extra_override_dirs is None:
+        extra_override_dirs = []
+    search_dirs = get_pref("RECIPE_SEARCH_DIRS") or list(DEFAULT_SEARCH_DIRS)
+    if isinstance(search_dirs, str):
+        search_dirs = [search_dirs]
+    for search_dir in list(search_dirs) + list(extra_search_dirs):
+        if search_dir == "." and skip_cwd:
+            # Deliberately skip '.' — adding cwd to the persistent map is
+            # surprising for users who run autopkg from arbitrary locations.
+            continue
+        elif search_dir == ".":
+            # If the caller opted back in to scanning '.', resolve it so the
+            # absolute path ends up in the map.
+            search_dir = os.path.abspath(".")
+        globalRecipeMap["identifiers"].update(
+            map_key_to_paths("identifiers", search_dir)
+        )
+        globalRecipeMap["shortnames"].update(map_key_to_paths("shortnames", search_dir))
+    for override in get_override_dirs() + list(extra_override_dirs):
+        globalRecipeMap["overrides"].update(map_key_to_paths("overrides", override))
+        globalRecipeMap["overrides-identifiers"].update(
+            map_key_to_paths("overrides-identifiers", override)
+        )
+    if not extra_search_dirs and not extra_override_dirs:
+        # Only persist when the map reflects the real configured state.
+        write_recipe_map_to_disk()
+
+
+def write_recipe_map_to_disk() -> None:
+    """Persist ``globalRecipeMap`` to ``DEFAULT_RECIPE_MAP`` as sorted JSON."""
+    # Ensure the containing directory exists so the first invocation on a
+    # fresh install doesn't fail.
+    autopkg_user_folder()
+    try:
+        with open(DEFAULT_RECIPE_MAP, "w") as f:
+            json.dump(
+                globalRecipeMap,
+                f,
+                ensure_ascii=True,
+                indent=2,
+                sort_keys=True,
+            )
+    except OSError as err:
+        log_err(f"WARNING: Could not write recipe map to disk: {err}")
+
+
+def handle_reading_recipe_map_file() -> dict[str, dict[str, str]]:
+    """Read ``DEFAULT_RECIPE_MAP`` from disk. Returns an empty dict on any
+    I/O or JSON error — callers are expected to treat that as a signal to
+    rebuild the map."""
+    try:
+        with open(DEFAULT_RECIPE_MAP) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        # Silent: this is the normal case on a fresh install and the caller
+        # will trigger a rebuild.
+        return {}
+    except (OSError, json.JSONDecodeError) as err:
+        log_err(f"WARNING: Cannot read the recipe map file: {err}")
+        return {}
+
+
+def validate_recipe_map(recipe_map: dict[str, dict[str, str]]) -> bool:
+    """Return True if ``recipe_map`` has the full set of expected top-level
+    keys."""
+    expected_keys = {
+        "identifiers",
+        "overrides",
+        "overrides-identifiers",
+        "shortnames",
+    }
+    return expected_keys.issubset(recipe_map.keys())
+
+
+def read_recipe_map(rebuild: bool = False, allow_continuing: bool = False) -> None:
+    """Load the recipe map from disk into ``globalRecipeMap``.
+
+    If the file is missing or invalid we ALWAYS auto-create it by walking
+    the configured search/override dirs. This is a deliberate divergence
+    from the dev-3.x behaviour which printed an error and exited. The
+    original behaviour was confusing for first-time users and CI jobs that
+    had not yet run a map-building verb.
+
+    ``rebuild`` is retained for API compatibility with the dev-3.x callers
+    — callers that pass ``rebuild=True`` get the same on-demand rebuild.
+    ``allow_continuing`` is likewise retained; with the new auto-create
+    behaviour it is effectively a no-op but is accepted so existing callers
+    do not need to be rewritten."""
+    global globalRecipeMap
+    _ = allow_continuing  # retained for API compatibility
+    recipe_map = handle_reading_recipe_map_file()
+    if validate_recipe_map(recipe_map):
+        globalRecipeMap.update(recipe_map)
+        return
+    # Auto-create on miss rather than failing. This is the behavioural fix
+    # called out above.
+    if rebuild:
+        log("Recipe map is missing or invalid; rebuilding now...")
+    else:
+        log(
+            "Recipe map is missing or invalid; generating it on demand. "
+            "Run `autopkg generate-recipe-map` explicitly (e.g. in CI) to "
+            "avoid paying this cost on every fresh run."
+        )
+    calculate_recipe_map()
 
 
 def get_autopkg_version() -> str:
@@ -1203,9 +1467,13 @@ def get_processor(processor_name, verbose=None, recipe=None, env=None):
             processor_recipe_id,
         ) = extract_processor_name_with_recipe_identifier(processor_name)
         if processor_recipe_id:
-            shared_processor_recipe_path = find_recipe_by_identifier(
-                processor_recipe_id, env["RECIPE_SEARCH_DIRS"]
-            )
+            # Prefer the recipe map (cheap, O(1) lookup); fall back to an
+            # on-disk scan when the map doesn't know about this identifier.
+            shared_processor_recipe_path = find_recipe_by_id_in_map(processor_recipe_id)
+            if shared_processor_recipe_path is None:
+                shared_processor_recipe_path = find_recipe_by_identifier_on_disk(
+                    processor_recipe_id, env["RECIPE_SEARCH_DIRS"]
+                )
             if shared_processor_recipe_path:
                 processor_search_dirs.append(
                     os.path.dirname(shared_processor_recipe_path)

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -136,7 +136,11 @@ DEFAULT_USER_REPOS_DIR = os.path.join(DEFAULT_USER_LIBRARY_DIR, "RecipeRepos")
 # Canonical on-disk location of the recipe map
 DEFAULT_RECIPE_MAP = os.path.join(DEFAULT_USER_LIBRARY_DIR, "recipe_map.json")
 DEFAULT_GH_TOKEN = os.path.join(DEFAULT_USER_LIBRARY_DIR, "gh_token")
-DEFAULT_SEARCH_DIRS = [".", DEFAULT_USER_LIBRARY_DIR, DEFAULT_LIBRARY_DIR]
+DEFAULT_SEARCH_DIRS = [
+    ".",
+    DEFAULT_USER_RECIPES_DIR,
+    os.path.join(DEFAULT_LIBRARY_DIR, "Recipes"),
+]
 
 
 def autopkg_user_folder() -> str:
@@ -730,6 +734,12 @@ def calculate_recipe_map(
                      rebuild, which is only expanding the in-memory view
                      for the current process.
     ===============  ====================================================="""
+    # Honour the disable escape hatch here too — otherwise users who've
+    # set AUTOPKG_DISABLE_RECIPE_MAP still pay the full scan cost on
+    # repo-add / repo-update / make-override etc.
+    if _recipe_map_disabled():
+        return
+
     # Mutate in place so every importer sees the refresh.
     for sub in (
         "identifiers",
@@ -742,11 +752,9 @@ def calculate_recipe_map(
     extra_search_dirs = list(extra_search_dirs or [])
     extra_override_dirs = list(extra_override_dirs or [])
 
-    search_dirs = get_pref("RECIPE_SEARCH_DIRS") or list(DEFAULT_SEARCH_DIRS)
-    if isinstance(search_dirs, str):
-        search_dirs = [search_dirs]
-
-    for search_dir in list(search_dirs) + extra_search_dirs:
+    # Defer to get_search_dirs() so the pref-or-default resolution lives
+    # in exactly one place.
+    for search_dir in get_search_dirs() + extra_search_dirs:
         if search_dir == "." and skip_cwd:
             # Deliberately skip '.' — adding cwd to the persistent map is
             # surprising for users who run autopkg from arbitrary locations.

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -708,6 +708,46 @@ def map_key_to_paths(keyname: str, repo_dir: str) -> dict[str, str]:
     return recipe_map
 
 
+def add_recipe_to_map(recipe_path: str, is_override: bool) -> None:
+    """Insert a single recipe/override into ``globalRecipeMap`` and
+    re-persist. Avoids a full RECIPE_SEARCH_DIRS tree walk when we
+    already know exactly which file changed (e.g. ``make-override``
+    and ``new-recipe`` have just written the file).
+
+    Honours first-wins semantics: existing entries are preserved, so
+    a new recipe with an identifier that clashes with a pre-existing
+    one is NOT added (matching ``map_key_to_paths``). On the rare
+    clash the caller gets a warning log and the persisted map is
+    left unchanged.
+
+    Silently no-ops when the recipe map is disabled."""
+    if _recipe_map_disabled():
+        return
+    recipe_dict = recipe_from_file(recipe_path)
+    if recipe_dict is None:
+        log_err(
+            f"WARNING: {recipe_path} is not a readable recipe; not "
+            "adding it to the recipe map."
+        )
+        return
+    identifier = get_identifier(recipe_dict)
+    shortname = remove_recipe_extension(os.path.basename(recipe_path))
+    id_key = "overrides-identifiers" if is_override else "identifiers"
+    name_key = "overrides" if is_override else "shortnames"
+    id_table = globalRecipeMap.setdefault(id_key, {})
+    name_table = globalRecipeMap.setdefault(name_key, {})
+
+    changed = False
+    if identifier and identifier not in id_table:
+        id_table[identifier] = recipe_path
+        changed = True
+    if shortname and shortname not in name_table:
+        name_table[shortname] = recipe_path
+        changed = True
+    if changed:
+        write_recipe_map_to_disk()
+
+
 def calculate_recipe_map(
     extra_search_dirs: list[str] | None = None,
     extra_override_dirs: list[str] | None = None,

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -146,14 +146,15 @@ def autopkg_user_folder() -> str:
     permission or read-only errors so callers running in sandboxed or
     mocked environments (notably the test suite, which routinely patches
     ``os.path.expanduser`` to point at ``/``) are not crashed by a
-    housekeeping operation."""
+    housekeeping operation.
+
+    Note: any ``OSError`` raised during directory creation is swallowed
+    here and surfaces later at the actual write site — see
+    ``write_recipe_map_to_disk`` which handles real write failures."""
     folder = os.path.abspath(os.path.expanduser(DEFAULT_USER_LIBRARY_DIR))
     try:
         os.makedirs(folder, exist_ok=True)
     except OSError:
-        # Soft-fail: callers that need the directory will surface the
-        # error themselves when they try to write. Tests mock expanduser
-        # and we don't want that to blow up unrelated behaviour.
         pass
     return folder
 
@@ -545,7 +546,7 @@ def find_recipe_by_name_on_disk(name, search_dirs) -> str | None:
 # Backwards-compatible alias. The recipe-map port below keeps this name
 # pointing at the on-disk scanner so existing tests that mock
 # ``find_recipe_by_identifier`` keep working. Callers that want the new
-# map-based behaviour should use ``find_recipe_by_id_in_map`` explicitly.
+# map-based behaviour should use ``find_recipe_by_identifier_in_map`` explicitly.
 find_recipe_by_identifier = find_recipe_by_identifier_on_disk
 
 
@@ -558,18 +559,44 @@ find_recipe_by_identifier = find_recipe_by_identifier_on_disk
 # or shortname without walking every recipe directory on each invocation,
 # which is the dominant cost for users with many recipe repos.
 #
-# The cache lives at DEFAULT_RECIPE_MAP (``~/Library/AutoPkg/recipe_map.json``)
-# and has four top-level keys: ``identifiers``, ``shortnames``, ``overrides``
-# and ``overrides-identifiers``. Each maps the corresponding string to an
-# absolute path.
+# Glossary:
+#   identifier      A recipe's globally-unique reverse-DNS ID, read from
+#                   its ``Identifier`` field (e.g. ``com.github.autopkg.X``).
+#   shortname       The recipe's filename minus the ``.recipe`` /
+#                   ``.recipe.plist`` / ``.recipe.yaml`` extension.
+#   override        A recipe in RECIPE_OVERRIDE_DIRS. Has precedence over a
+#                   stock recipe of the same name during resolution.
+#   search dir      An entry in RECIPE_SEARCH_DIRS.
+#   pref-scoped     The persisted map reflects the prefs at build time.
+#                   CLI ``--search-dir`` / ``--override-dir`` flags that
+#                   differ from the pref baseline bypass the map and
+#                   scan only the requested dirs on disk.
 #
-# UX note (dev-2.x backport): the original dev-3.x behaviour exited with an
-# error when the map was missing. We auto-create it on demand instead, and
+# On-disk layout:
+#   Path:  ``~/Library/AutoPkg/recipe_map.json``
+#          (overridable via AUTOPKG_RECIPE_MAP_PATH env var or
+#          RECIPE_MAP_PATH pref — issue #901)
+#   Keys:  ``identifiers``, ``shortnames``, ``overrides``,
+#          ``overrides-identifiers``, plus ``schema_version`` for
+#          forward-compat.
+#
+# UX divergence from dev-3.x: the original behaviour exited with an error
+# when the map was missing. We auto-create it on demand instead, and
 # expose an explicit ``autopkg generate-recipe-map`` verb for environments
-# (e.g. CI/CD) that want to build the cache up-front.
+# (e.g. CI/CD) that want to build the cache up-front. See issues #884,
+# #893, #898.
+#
+# Resolution flow (used by ``find_recipe`` in Code/autopkg):
+#   1. Did the caller supply CLI dirs that differ from prefs?
+#        yes → on-disk scan of ONLY the supplied dirs
+#        no  → consult globalRecipeMap (O(1))
+#   2. Miss?
+#        yes → on-disk fallback of the effective dirs
+#   3. Still miss? ``locate_recipe`` triggers one cwd-inclusive rebuild
+#      (once per process) and retries.
 
 
-def find_recipe_by_id_in_map(
+def find_recipe_by_identifier_in_map(
     identifier: str, skip_overrides: bool = False
 ) -> str | None:
     """Resolve an identifier to a recipe path via the global recipe map.
@@ -636,13 +663,19 @@ def find_identifier_from_name(name: str) -> str | None:
     return None
 
 
+# Keys in globalRecipeMap that index by recipe Identifier (read from the
+# plist/yaml). All other keys index by shortname (filename minus extension).
+_IDENTIFIER_KEYS = frozenset({"identifiers", "overrides-identifiers"})
+
+
 def map_key_to_paths(keyname: str, repo_dir: str) -> dict[str, str]:
     """Walk ``repo_dir`` one level deep and emit {key: absolute_path} entries
     suitable for inclusion in ``globalRecipeMap[keyname]``.
 
-    When ``keyname`` contains ``"identifiers"`` the key is read from the
-    recipe file's Identifier field; otherwise the key is the filename minus
-    the recipe extension.
+    For identifier-keyed dicts (``identifiers``, ``overrides-identifiers``)
+    the key is read from the recipe file's Identifier field; for the
+    shortname-keyed dicts (``shortnames``, ``overrides``) the key is the
+    filename minus the recipe extension.
 
     First-wins: if a key is already present in the return dict or in
     ``globalRecipeMap[keyname]`` the new path is ignored."""
@@ -650,14 +683,13 @@ def map_key_to_paths(keyname: str, repo_dir: str) -> dict[str, str]:
     normalized_dir = os.path.abspath(os.path.expanduser(repo_dir))
     patterns = [os.path.join(normalized_dir, f"*{ext}") for ext in RECIPE_EXTS]
     patterns.extend([os.path.join(normalized_dir, f"*/*{ext}") for ext in RECIPE_EXTS])
+    use_identifier = keyname in _IDENTIFIER_KEYS
     for pattern in patterns:
-        matches = glob.glob(pattern)
-        for match in matches:
-            if "identifiers" in keyname:
+        for match in glob.glob(pattern):
+            if use_identifier:
                 key = get_identifier_from_recipe_file(match)
             else:
                 key = remove_recipe_extension(os.path.basename(match))
-            # In case the file was invalid, or missing a key
             if not key:
                 log_err(
                     f"WARNING: {match} is potentially an invalid file, not "
@@ -683,15 +715,21 @@ def calculate_recipe_map(
 
     Mutates ``globalRecipeMap`` in place rather than rebinding the name so
     any module that imported the symbol with ``from autopkglib import
-    globalRecipeMap`` continues to see the fresh contents. (The generate-
-    recipe-map verb in Code/autopkg relies on this.)
+    globalRecipeMap`` continues to see the fresh contents.
 
-    ``persist`` explicitly controls whether the new map is written to disk:
-    * ``None`` (default): persist iff no extra dirs were supplied. This is
-      the legacy behaviour — callers that pass transient extras don't want
-      their view leaking into the on-disk cache.
-    * ``True`` / ``False``: force the corresponding behaviour. Used by the
-      ``generate-recipe-map`` verb, which always wants to persist."""
+    ``persist`` controls whether the new map is written to disk:
+
+    ===============  =======================================================
+    Value            Behaviour
+    ===============  =======================================================
+    ``None``         Default. Persist **iff** no ``extra_*`` dirs were
+                     supplied. Callers that pass transient extras don't
+                     want their view leaking into the on-disk cache.
+    ``True``         Always persist. Used by ``generate-recipe-map``.
+    ``False``        Never persist. Used by ``locate_recipe``'s on-miss
+                     rebuild, which is only expanding the in-memory view
+                     for the current process.
+    ===============  ====================================================="""
     # Mutate in place so every importer sees the refresh.
     for sub in (
         "identifiers",
@@ -812,7 +850,8 @@ def _recipe_map_disabled() -> bool:
 
 # Module-level latch tracking whether the last write attempt failed. When
 # True we skip further writes for the life of the process to avoid spamming
-# the log with the same OSError on every verb.
+# the log with the same OSError on every verb. Test fixtures reset this
+# in setUp by assigning directly.
 _recipe_map_write_disabled: bool = False
 
 
@@ -902,7 +941,11 @@ def write_recipe_map_to_disk() -> None:
         _recipe_map_write_disabled = True
         log_err(
             f"WARNING: Could not write recipe map to {target}: {err}. "
-            "Further write attempts in this process will be skipped."
+            "Further write attempts in this process will be skipped. "
+            "To resolve: check write permissions on the target, set "
+            "RECIPE_MAP_PATH (or AUTOPKG_RECIPE_MAP_PATH) to a writable "
+            "location, or set AUTOPKG_DISABLE_RECIPE_MAP=1 to bypass "
+            "the cache entirely."
         )
     finally:
         # Best-effort cleanup of the partial tempfile if we didn't rename
@@ -962,48 +1005,38 @@ def validate_recipe_map(recipe_map: dict) -> bool:
 def read_recipe_map(rebuild: bool = False, allow_continuing: bool = False) -> None:
     """Load the recipe map from disk into ``globalRecipeMap``.
 
-    Behaviour:
-    * If ``rebuild`` is True we always rebuild from scratch, regardless of
-      the on-disk state. (Dev-3.x's ``rebuild=True`` originally skipped
-      the rebuild when the file was valid; we treat that as a bug since
-      callers that pass ``rebuild=True`` genuinely want the force.)
-    * Otherwise we read the file and validate it. Valid → load into the
-      global map. Invalid/missing → auto-rebuild silently.
+    * ``rebuild=True`` forces a full rebuild regardless of on-disk state.
+    * Otherwise: valid file → load; missing/invalid → auto-rebuild once.
 
-    This is a deliberate UX divergence from dev-3.x's "print error and
-    sys.exit(1) when the map is missing" behaviour. Fresh installs and
-    CI/CD pipelines hit that case constantly and the exit was confusing.
-    See GitHub issues #884, #893, #898.
+    Dev-3.x printed an error and called ``sys.exit(1)`` when the map was
+    missing. We auto-rebuild silently instead — fresh installs and CI
+    pipelines hit that case constantly. See issues #884, #893, #898.
 
-    ``allow_continuing`` is retained for API compatibility with the dev-3.x
-    callers (repo-add / repo-delete pass it to say "the map might not
-    exist yet"). With the new auto-create behaviour it is effectively a
-    no-op but we accept it so existing callers don't need to change."""
+    ``allow_continuing`` is retained for API compatibility with dev-3.x
+    callers that used it to signal "the map may not exist yet". The new
+    auto-create behaviour makes it a no-op."""
     _ = allow_continuing  # retained for API compatibility
 
     if _recipe_map_disabled():
-        # Escape hatch: callers will still do something; we just don't
-        # populate the map. find_recipe_by_*_in_map will return None and
-        # the on-disk fallbacks will kick in.
         return
 
     if rebuild:
-        log("Recipe map: forced rebuild requested.")
         calculate_recipe_map()
         return
 
     recipe_map = handle_reading_recipe_map_file()
     if validate_recipe_map(recipe_map):
-        # Load into globalRecipeMap in place. Start by clearing the
-        # existing sub-dicts so stale entries don't leak across reads.
         for sub in _EXPECTED_MAP_KEYS:
             globalRecipeMap.setdefault(sub, {}).clear()
             globalRecipeMap[sub].update(recipe_map.get(sub, {}))
         return
 
-    # Missing/invalid → auto-create.
     if not recipe_map:
-        log("Recipe map not found; generating it on demand.")
+        log(
+            "Recipe map not found; generating it on demand. Run "
+            "`autopkg generate-recipe-map` explicitly (e.g. in CI) to "
+            "avoid paying this cost on every fresh run."
+        )
     else:
         log("Recipe map is invalid or from an older schema; rebuilding now.")
     calculate_recipe_map()
@@ -1696,7 +1729,9 @@ def get_processor(processor_name, verbose=None, recipe=None, env=None):
         if processor_recipe_id:
             # Prefer the recipe map (cheap, O(1) lookup); fall back to an
             # on-disk scan when the map doesn't know about this identifier.
-            shared_processor_recipe_path = find_recipe_by_id_in_map(processor_recipe_id)
+            shared_processor_recipe_path = find_recipe_by_identifier_in_map(
+                processor_recipe_id
+            )
             if shared_processor_recipe_path is None:
                 shared_processor_recipe_path = find_recipe_by_identifier_on_disk(
                     processor_recipe_id, env["RECIPE_SEARCH_DIRS"]

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -140,11 +140,21 @@ DEFAULT_SEARCH_DIRS = [".", DEFAULT_USER_LIBRARY_DIR, DEFAULT_LIBRARY_DIR]
 
 
 def autopkg_user_folder() -> str:
-    """Return the absolute path to the user's AutoPkg folder, creating it
-    and its immediate subfolders on demand. This is used as the canonical
-    location for the recipe map and related caches."""
+    """Return the absolute path to the user's AutoPkg folder.
+
+    The folder is created on demand when possible, but we fail soft on
+    permission or read-only errors so callers running in sandboxed or
+    mocked environments (notably the test suite, which routinely patches
+    ``os.path.expanduser`` to point at ``/``) are not crashed by a
+    housekeeping operation."""
     folder = os.path.abspath(os.path.expanduser(DEFAULT_USER_LIBRARY_DIR))
-    os.makedirs(folder, exist_ok=True)
+    try:
+        os.makedirs(folder, exist_ok=True)
+    except OSError:
+        # Soft-fail: callers that need the directory will surface the
+        # error themselves when they try to write. Tests mock expanduser
+        # and we don't want that to blow up unrelated behaviour.
+        pass
     return folder
 
 
@@ -703,13 +713,26 @@ def calculate_recipe_map(
         write_recipe_map_to_disk()
 
 
+def _recipe_map_path() -> str:
+    """Return the absolute, expanded path to the recipe map file on disk.
+
+    ``DEFAULT_RECIPE_MAP`` is stored unexpanded (with a leading ``~``) so
+    tests can monkey-patch ``os.path.expanduser``; resolve it lazily here."""
+    return os.path.abspath(os.path.expanduser(DEFAULT_RECIPE_MAP))
+
+
 def write_recipe_map_to_disk() -> None:
-    """Persist ``globalRecipeMap`` to ``DEFAULT_RECIPE_MAP`` as sorted JSON."""
+    """Persist ``globalRecipeMap`` to the recipe-map file as sorted JSON.
+
+    Failures to write (permission denied, read-only filesystem, etc.) are
+    logged but not raised — the in-memory map is still usable for the
+    lifetime of the process."""
     # Ensure the containing directory exists so the first invocation on a
-    # fresh install doesn't fail.
+    # fresh install doesn't fail. autopkg_user_folder() is itself
+    # permission-tolerant.
     autopkg_user_folder()
     try:
-        with open(DEFAULT_RECIPE_MAP, "w") as f:
+        with open(_recipe_map_path(), "w") as f:
             json.dump(
                 globalRecipeMap,
                 f,
@@ -722,11 +745,11 @@ def write_recipe_map_to_disk() -> None:
 
 
 def handle_reading_recipe_map_file() -> dict[str, dict[str, str]]:
-    """Read ``DEFAULT_RECIPE_MAP`` from disk. Returns an empty dict on any
-    I/O or JSON error — callers are expected to treat that as a signal to
-    rebuild the map."""
+    """Read the recipe map from disk. Returns an empty dict on any I/O or
+    JSON error — callers are expected to treat that as a signal to rebuild
+    the map."""
     try:
-        with open(DEFAULT_RECIPE_MAP) as f:
+        with open(_recipe_map_path()) as f:
             return json.load(f)
     except FileNotFoundError:
         # Silent: this is the normal case on a fresh install and the caller

--- a/Code/autopkglib/__init__.py
+++ b/Code/autopkglib/__init__.py
@@ -606,16 +606,26 @@ def find_recipe_by_identifier_in_map(
     """Resolve an identifier to a recipe path via the global recipe map.
 
     Returns None if no entry exists or the cached path has disappeared from
-    disk (stale map). We only stat the file — parsing it to confirm it's a
-    valid recipe would be prohibitively expensive on the hot path (every
-    shared-processor lookup calls this), and the map was built from a valid
-    recipe to begin with."""
+    disk (stale map). For stock recipes (``identifiers`` bucket) we only stat
+    the file — parsing to confirm it's still valid would be prohibitively
+    expensive on the hot path (every shared-processor lookup calls this). For
+    overrides we do a cheap identifier cross-check: users routinely edit
+    override files (e.g. when copying for multi-arch setups), and a stale
+    entry would cause a split-identifier run (map resolves via old id, recipe
+    loads with new id, RECIPE_CACHE_DIR disagrees) rather than a clean miss."""
     if not skip_overrides and identifier in globalRecipeMap.get(
         "overrides-identifiers", {}
     ):
         override_path = globalRecipeMap["overrides-identifiers"][identifier]
         if os.path.isfile(override_path):
-            return override_path
+            if get_identifier_from_recipe_file(override_path) == identifier:
+                return override_path
+            log_err(
+                f"WARNING: Recipe map entry for '{identifier}' points to "
+                f"'{override_path}', but that file's identifier no longer "
+                "matches. The map is stale — run "
+                "`autopkg generate-recipe-map` to rebuild."
+            )
     if identifier in globalRecipeMap.get("identifiers", {}):
         recipe_path = globalRecipeMap["identifiers"][identifier]
         if os.path.isfile(recipe_path):

--- a/Code/tests/test_autopkg_other.py
+++ b/Code/tests/test_autopkg_other.py
@@ -1354,7 +1354,7 @@ class TestAutoPkgOther(unittest.TestCase):
         recipe = {"RECIPE_PATH": "/sandboxed/x.recipe"}
         env = {"RECIPE_SEARCH_DIRS": ["/sandboxed"]}
 
-        autopkg._set_locate_recipe_rebuild_attempted(True)  # skip rebuild
+        autopkg._locate_recipe_rebuild_attempted = True  # skip rebuild
         with (
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
@@ -1500,7 +1500,7 @@ class TestAutoPkgOther(unittest.TestCase):
         # find_processor_path consults the map first then the on-disk
         # scanner. Stub both to "not found" so we exercise the
         # cwd-rebuild fallback path.
-        autopkg._set_locate_recipe_rebuild_attempted(True)  # skip rebuild
+        autopkg._locate_recipe_rebuild_attempted = True  # skip rebuild
         with (
             patch("os.path.dirname") as mock_dirname,
             patch(

--- a/Code/tests/test_autopkg_other.py
+++ b/Code/tests/test_autopkg_other.py
@@ -1319,21 +1319,29 @@ class TestAutoPkgOther(unittest.TestCase):
             ) as mock_extract,
             patch("autopkg.find_recipe_by_identifier_in_map") as mock_find_in_map,
             patch("autopkg.find_recipe_by_identifier_on_disk") as mock_find_on_disk,
+            patch("autopkg._path_under_dirs", return_value=True),
+            patch("os.path.dirname") as mock_dirname,
             patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
         ):
+            mock_dirname.side_effect = lambda path: {
+                "/recipes/TestApp.recipe": "/recipes",
+                "/shared/SharedRecipe.recipe": "/shared",
+            }.get(path, "/default")
             mock_extract.return_value = (
                 "CustomProcessor",
                 "com.example.recipes.shared",
             )
-            # Map hit points INSIDE the configured search scope.
-            mock_find_in_map.return_value = "/search/dir1/SharedRecipe.recipe"
-            mock_exists.side_effect = lambda path: (
-                path == "/search/dir1/CustomProcessor.py"
-            )
+            # Map hit; the _path_under_dirs check is mocked to True so we
+            # don't depend on the host OS's path separator for the scope
+            # check.
+            mock_find_in_map.return_value = "/shared/SharedRecipe.recipe"
+            mock_exists.side_effect = lambda path: path == "/shared/CustomProcessor.py"
+            mock_join.side_effect = lambda *args: "/".join(args)
 
             result = autopkg.find_processor_path(processor_name, recipe, env)
 
-            self.assertEqual(result, "/search/dir1/CustomProcessor.py")
+            self.assertEqual(result, "/shared/CustomProcessor.py")
             mock_find_in_map.assert_called_once_with("com.example.recipes.shared")
             mock_find_on_disk.assert_not_called()
 
@@ -1553,30 +1561,36 @@ class TestAutoPkgOther(unittest.TestCase):
         }
         env = {"RECIPE_SEARCH_DIRS": ["/search1", "/search2"]}
 
-        # The map hit must reside under env["RECIPE_SEARCH_DIRS"] to be
-        # trusted (security fix F-5). Use /search1 as the parent.
-        env = {"RECIPE_SEARCH_DIRS": ["/search1", "/search2"]}
-
         with (
+            patch("os.path.dirname") as mock_dirname,
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
             ) as mock_extract,
             patch("autopkg.find_recipe_by_identifier_in_map") as mock_find_in_map,
             patch("autopkg.find_recipe_by_identifier_on_disk"),
+            patch("autopkg._path_under_dirs", return_value=True),
             patch("os.path.exists") as mock_exists,
+            patch("os.path.join") as mock_join,
         ):
+
+            def dirname_side_effect(path):
+                dirname_map = {
+                    "/main/TestApp.recipe": "/main",
+                    "/parent1/Parent1.recipe": "/parent1",
+                    "/parent2/Parent2.recipe": "/parent2",
+                    "/shared/SharedRecipe.recipe": "/shared",
+                }
+                return dirname_map.get(path, "/default")
+
+            mock_dirname.side_effect = dirname_side_effect
             mock_extract.return_value = ("CustomProcessor", "com.shared.recipes")
-            mock_find_in_map.return_value = "/search1/SharedRecipe.recipe"
-
-            # Make processor exist next to the shared recipe.
-            def exists_side_effect(path):
-                return path == "/search1/CustomProcessor.py"
-
-            mock_exists.side_effect = exists_side_effect
+            mock_find_in_map.return_value = "/shared/SharedRecipe.recipe"
+            mock_exists.side_effect = lambda path: path == "/shared/CustomProcessor.py"
+            mock_join.side_effect = lambda *args: "/".join(args)
 
             result = autopkg.find_processor_path(processor_name, recipe, env)
 
-            self.assertEqual(result, "/search1/CustomProcessor.py")
+            self.assertEqual(result, "/shared/CustomProcessor.py")
 
     def test_find_processor_path_get_pref_returns_none(self):
         """Test find_processor_path when get_pref returns None for search dirs."""

--- a/Code/tests/test_autopkg_other.py
+++ b/Code/tests/test_autopkg_other.py
@@ -1309,41 +1309,67 @@ class TestAutoPkgOther(unittest.TestCase):
         """Test find_processor_path with processor name that includes recipe identifier."""
         processor_name = "com.example.recipes.shared/CustomProcessor"
         recipe = {"RECIPE_PATH": "/recipes/TestApp.recipe"}
+        # Map hit must reside under env["RECIPE_SEARCH_DIRS"] to be
+        # trusted (security fix F-5). Use /search/dir1 as the parent.
         env = {"RECIPE_SEARCH_DIRS": ["/search/dir1", "/search/dir2"]}
 
         with (
-            patch("os.path.dirname") as mock_dirname,
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
             ) as mock_extract,
-            # find_processor_path consults the map first; simulate a hit
-            # there so the on-disk fallback is never exercised.
             patch("autopkg.find_recipe_by_id_in_map") as mock_find_in_map,
             patch("autopkg.find_recipe_by_identifier_on_disk") as mock_find_on_disk,
             patch("os.path.exists") as mock_exists,
-            patch("os.path.join") as mock_join,
         ):
-            mock_dirname.side_effect = lambda path: {
-                "/recipes/TestApp.recipe": "/recipes",
-                "/shared/SharedRecipe.recipe": "/shared",
-            }.get(path, "/default")
-
             mock_extract.return_value = (
                 "CustomProcessor",
                 "com.example.recipes.shared",
             )
-            mock_find_in_map.return_value = "/shared/SharedRecipe.recipe"
-            mock_exists.side_effect = lambda path: path == "/shared/CustomProcessor.py"
-            mock_join.side_effect = lambda *args: "/".join(args)
+            # Map hit points INSIDE the configured search scope.
+            mock_find_in_map.return_value = "/search/dir1/SharedRecipe.recipe"
+            mock_exists.side_effect = lambda path: (
+                path == "/search/dir1/CustomProcessor.py"
+            )
 
             result = autopkg.find_processor_path(processor_name, recipe, env)
 
-            self.assertEqual(result, "/shared/CustomProcessor.py")
-
-            # Verify it consulted the map first.
+            self.assertEqual(result, "/search/dir1/CustomProcessor.py")
             mock_find_in_map.assert_called_once_with("com.example.recipes.shared")
-            # On-disk fallback should not have been needed.
             mock_find_on_disk.assert_not_called()
+
+    def test_find_processor_path_map_hit_outside_scope_is_rejected(self):
+        """Security F-5: a map hit that points OUTSIDE the caller's
+        declared RECIPE_SEARCH_DIRS must NOT be honoured. Otherwise a
+        pre-existing map could leak processor-resolution to directories
+        the caller explicitly excluded via --search-dir."""
+        processor_name = "com.example.shared/Proc"
+        recipe = {"RECIPE_PATH": "/sandboxed/x.recipe"}
+        env = {"RECIPE_SEARCH_DIRS": ["/sandboxed"]}
+
+        autopkg._set_locate_recipe_rebuild_attempted(True)  # skip rebuild
+        with (
+            patch(
+                "autopkg.extract_processor_name_with_recipe_identifier"
+            ) as mock_extract,
+            patch("autopkg.find_recipe_by_id_in_map") as mock_find_in_map,
+            patch(
+                "autopkg.find_recipe_by_identifier_on_disk",
+                return_value=None,
+            ) as mock_find_on_disk,
+            patch("autopkg.calculate_recipe_map"),
+            patch("os.path.exists", return_value=False),
+        ):
+            mock_extract.return_value = ("Proc", "com.example.shared")
+            # Map says the shared recipe is OUTSIDE /sandboxed.
+            mock_find_in_map.return_value = "/outside/Leaky.recipe"
+
+            result = autopkg.find_processor_path(processor_name, recipe, env)
+
+            # Map hit was rejected; fallback was tried and returned None.
+            self.assertIsNone(result)
+            mock_find_on_disk.assert_called_once_with(
+                "com.example.shared", ["/sandboxed"]
+            )
 
     def test_find_processor_path_with_parent_recipes(self):
         """Test find_processor_path with recipe that has parent recipes."""
@@ -1523,49 +1549,30 @@ class TestAutoPkgOther(unittest.TestCase):
         }
         env = {"RECIPE_SEARCH_DIRS": ["/search1", "/search2"]}
 
+        # The map hit must reside under env["RECIPE_SEARCH_DIRS"] to be
+        # trusted (security fix F-5). Use /search1 as the parent.
+        env = {"RECIPE_SEARCH_DIRS": ["/search1", "/search2"]}
+
         with (
-            patch("os.path.dirname") as mock_dirname,
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
             ) as mock_extract,
             patch("autopkg.find_recipe_by_id_in_map") as mock_find_in_map,
             patch("autopkg.find_recipe_by_identifier_on_disk"),
             patch("os.path.exists") as mock_exists,
-            patch("os.path.join") as mock_join,
         ):
-
-            def dirname_side_effect(path):
-                dirname_map = {
-                    "/main/TestApp.recipe": "/main",
-                    "/parent1/Parent1.recipe": "/parent1",
-                    "/parent2/Parent2.recipe": "/parent2",
-                    "/shared/SharedRecipe.recipe": "/shared",
-                }
-                return dirname_map.get(path, "/default")
-
-            mock_dirname.side_effect = dirname_side_effect
             mock_extract.return_value = ("CustomProcessor", "com.shared.recipes")
-            mock_find_in_map.return_value = "/shared/SharedRecipe.recipe"
+            mock_find_in_map.return_value = "/search1/SharedRecipe.recipe"
 
-            # Make processor exist in shared directory
+            # Make processor exist next to the shared recipe.
             def exists_side_effect(path):
-                return path == "/shared/CustomProcessor.py"
+                return path == "/search1/CustomProcessor.py"
 
             mock_exists.side_effect = exists_side_effect
-            mock_join.side_effect = lambda *args: "/".join(args)
 
             result = autopkg.find_processor_path(processor_name, recipe, env)
 
-            self.assertEqual(result, "/shared/CustomProcessor.py")
-
-            # Verify the search order: recipe dir, shared dir, parent dirs
-            expected_calls = [
-                unittest.mock.call("/main/CustomProcessor.py"),
-                unittest.mock.call(
-                    "/shared/CustomProcessor.py"
-                ),  # Found here, so stops
-            ]
-            mock_exists.assert_has_calls(expected_calls[:2])
+            self.assertEqual(result, "/search1/CustomProcessor.py")
 
     def test_find_processor_path_get_pref_returns_none(self):
         """Test find_processor_path when get_pref returns None for search dirs."""

--- a/Code/tests/test_autopkg_other.py
+++ b/Code/tests/test_autopkg_other.py
@@ -1316,7 +1316,10 @@ class TestAutoPkgOther(unittest.TestCase):
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
             ) as mock_extract,
-            patch("autopkg.find_recipe_by_identifier") as mock_find_recipe,
+            # find_processor_path consults the map first; simulate a hit
+            # there so the on-disk fallback is never exercised.
+            patch("autopkg.find_recipe_by_id_in_map") as mock_find_in_map,
+            patch("autopkg.find_recipe_by_identifier_on_disk") as mock_find_on_disk,
             patch("os.path.exists") as mock_exists,
             patch("os.path.join") as mock_join,
         ):
@@ -1329,7 +1332,7 @@ class TestAutoPkgOther(unittest.TestCase):
                 "CustomProcessor",
                 "com.example.recipes.shared",
             )
-            mock_find_recipe.return_value = "/shared/SharedRecipe.recipe"
+            mock_find_in_map.return_value = "/shared/SharedRecipe.recipe"
             mock_exists.side_effect = lambda path: path == "/shared/CustomProcessor.py"
             mock_join.side_effect = lambda *args: "/".join(args)
 
@@ -1337,10 +1340,10 @@ class TestAutoPkgOther(unittest.TestCase):
 
             self.assertEqual(result, "/shared/CustomProcessor.py")
 
-            # Verify it searched for the shared recipe
-            mock_find_recipe.assert_called_once_with(
-                "com.example.recipes.shared", ["/search/dir1", "/search/dir2"]
-            )
+            # Verify it consulted the map first.
+            mock_find_in_map.assert_called_once_with("com.example.recipes.shared")
+            # On-disk fallback should not have been needed.
+            mock_find_on_disk.assert_not_called()
 
     def test_find_processor_path_with_parent_recipes(self):
         """Test find_processor_path with recipe that has parent recipes."""
@@ -1525,7 +1528,8 @@ class TestAutoPkgOther(unittest.TestCase):
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
             ) as mock_extract,
-            patch("autopkg.find_recipe_by_identifier") as mock_find_recipe,
+            patch("autopkg.find_recipe_by_id_in_map") as mock_find_in_map,
+            patch("autopkg.find_recipe_by_identifier_on_disk"),
             patch("os.path.exists") as mock_exists,
             patch("os.path.join") as mock_join,
         ):
@@ -1541,7 +1545,7 @@ class TestAutoPkgOther(unittest.TestCase):
 
             mock_dirname.side_effect = dirname_side_effect
             mock_extract.return_value = ("CustomProcessor", "com.shared.recipes")
-            mock_find_recipe.return_value = "/shared/SharedRecipe.recipe"
+            mock_find_in_map.return_value = "/shared/SharedRecipe.recipe"
 
             # Make processor exist in shared directory
             def exists_side_effect(path):

--- a/Code/tests/test_autopkg_other.py
+++ b/Code/tests/test_autopkg_other.py
@@ -1317,7 +1317,7 @@ class TestAutoPkgOther(unittest.TestCase):
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
             ) as mock_extract,
-            patch("autopkg.find_recipe_by_id_in_map") as mock_find_in_map,
+            patch("autopkg.find_recipe_by_identifier_in_map") as mock_find_in_map,
             patch("autopkg.find_recipe_by_identifier_on_disk") as mock_find_on_disk,
             patch("os.path.exists") as mock_exists,
         ):
@@ -1351,7 +1351,7 @@ class TestAutoPkgOther(unittest.TestCase):
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
             ) as mock_extract,
-            patch("autopkg.find_recipe_by_id_in_map") as mock_find_in_map,
+            patch("autopkg.find_recipe_by_identifier_in_map") as mock_find_in_map,
             patch(
                 "autopkg.find_recipe_by_identifier_on_disk",
                 return_value=None,
@@ -1489,18 +1489,22 @@ class TestAutoPkgOther(unittest.TestCase):
         recipe = {"RECIPE_PATH": "/recipes/TestApp.recipe"}
         env = {"RECIPE_SEARCH_DIRS": ["/search/dir1"]}
 
+        # find_processor_path consults the map first then the on-disk
+        # scanner. Stub both to "not found" so we exercise the
+        # cwd-rebuild fallback path.
+        autopkg._set_locate_recipe_rebuild_attempted(True)  # skip rebuild
         with (
             patch("os.path.dirname") as mock_dirname,
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
             ) as mock_extract,
-            patch("autopkg.find_recipe_by_identifier") as mock_find_recipe,
+            patch("autopkg.find_recipe_by_identifier_in_map", return_value=None),
+            patch("autopkg.find_recipe_by_identifier_on_disk", return_value=None),
             patch("os.path.exists") as mock_exists,
             patch("os.path.join") as mock_join,
         ):
             mock_dirname.return_value = "/recipes"
             mock_extract.return_value = ("TestProcessor", "com.missing.recipe")
-            mock_find_recipe.return_value = None  # Shared recipe not found
             mock_exists.return_value = False
             mock_join.side_effect = lambda *args: "/".join(args)
 
@@ -1557,7 +1561,7 @@ class TestAutoPkgOther(unittest.TestCase):
             patch(
                 "autopkg.extract_processor_name_with_recipe_identifier"
             ) as mock_extract,
-            patch("autopkg.find_recipe_by_id_in_map") as mock_find_in_map,
+            patch("autopkg.find_recipe_by_identifier_in_map") as mock_find_in_map,
             patch("autopkg.find_recipe_by_identifier_on_disk"),
             patch("os.path.exists") as mock_exists,
         ):

--- a/Code/tests/test_autopkg_other.py
+++ b/Code/tests/test_autopkg_other.py
@@ -33,6 +33,20 @@ sys.modules["autopkg"] = autopkg
 class TestAutoPkgOther(unittest.TestCase):
     """Test cases for miscellaneous core functions of AutoPkg."""
 
+    def setUp(self):
+        """Silence recipe-map side effects (see test_autopkg_recipes for
+        rationale)."""
+        self._recipe_map_patches = [
+            patch("autopkg.calculate_recipe_map"),
+            patch("autopkg.read_recipe_map"),
+        ]
+        for patcher in self._recipe_map_patches:
+            patcher.start()
+
+    def tearDown(self):
+        for patcher in self._recipe_map_patches:
+            patcher.stop()
+
     def test_display_help_basic_functionality(self):
         """Test display_help with basic subcommands."""
         argv = ["autopkg"]

--- a/Code/tests/test_autopkg_overrides.py
+++ b/Code/tests/test_autopkg_overrides.py
@@ -35,10 +35,20 @@ class TestAutoPkgOverrides(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures with a temporary directory."""
         self.tmp_dir = TemporaryDirectory()
+        # Silence recipe-map side effects (see test_autopkg_recipes for
+        # rationale).
+        self._recipe_map_patches = [
+            patch("autopkg.calculate_recipe_map"),
+            patch("autopkg.read_recipe_map"),
+        ]
+        for patcher in self._recipe_map_patches:
+            patcher.start()
 
     def tearDown(self):
         """Clean up test fixtures."""
         self.tmp_dir.cleanup()
+        for patcher in self._recipe_map_patches:
+            patcher.stop()
 
     def test_get_trust_info_basic_recipe(self):
         """Test get_trust_info with a basic recipe."""

--- a/Code/tests/test_autopkg_recipe_map.py
+++ b/Code/tests/test_autopkg_recipe_map.py
@@ -76,18 +76,29 @@ class _RecipeMapIsolationMixin:
         self.tmpdir = tempfile.mkdtemp(prefix="autopkg_recipe_map_test_")
         self.addCleanup(self._cleanup_tmp)
 
-        self._saved_map = dict(autopkglib.globalRecipeMap)
-        self._saved_default = autopkglib.DEFAULT_RECIPE_MAP
-        autopkglib.globalRecipeMap = {
-            "identifiers": {},
-            "shortnames": {},
-            "overrides": {},
-            "overrides-identifiers": {},
+        # Mutate globalRecipeMap IN PLACE rather than rebinding the
+        # module attribute — the invariant established in commit f6b4f2e
+        # requires object-identity stability so `from autopkglib import
+        # globalRecipeMap` importers always see the live dict.
+        self._saved_map = {
+            key: dict(value) if isinstance(value, dict) else value
+            for key, value in autopkglib.globalRecipeMap.items()
         }
+        self._saved_default = autopkglib.DEFAULT_RECIPE_MAP
+        autopkglib.globalRecipeMap.clear()
+        autopkglib.globalRecipeMap.update(
+            {
+                "identifiers": {},
+                "shortnames": {},
+                "overrides": {},
+                "overrides-identifiers": {},
+            }
+        )
         autopkglib.DEFAULT_RECIPE_MAP = os.path.join(self.tmpdir, "recipe_map.json")
 
     def tearDown(self):
-        autopkglib.globalRecipeMap = self._saved_map
+        autopkglib.globalRecipeMap.clear()
+        autopkglib.globalRecipeMap.update(self._saved_map)
         autopkglib.DEFAULT_RECIPE_MAP = self._saved_default
 
     def _cleanup_tmp(self):
@@ -108,14 +119,16 @@ class TestRecipeMapLookups(_RecipeMapIsolationMixin, unittest.TestCase):
         self.override_path = os.path.join(self.tmpdir, "Override.recipe")
         _write_plist_recipe(self.override_path, SAMPLE_OVERRIDE)
 
-        autopkglib.globalRecipeMap = {
-            "identifiers": {SAMPLE_RECIPE["Identifier"]: self.recipe_path},
-            "shortnames": {"Sample": self.recipe_path},
-            "overrides": {"Override": self.override_path},
-            "overrides-identifiers": {
-                SAMPLE_OVERRIDE["Identifier"]: self.override_path
-            },
-        }
+        # Populate in place (see _RecipeMapIsolationMixin setUp for
+        # why identity matters).
+        autopkglib.globalRecipeMap["identifiers"].update(
+            {SAMPLE_RECIPE["Identifier"]: self.recipe_path}
+        )
+        autopkglib.globalRecipeMap["shortnames"].update({"Sample": self.recipe_path})
+        autopkglib.globalRecipeMap["overrides"].update({"Override": self.override_path})
+        autopkglib.globalRecipeMap["overrides-identifiers"].update(
+            {SAMPLE_OVERRIDE["Identifier"]: self.override_path}
+        )
 
     def test_find_by_id_prefers_override(self):
         """An override identifier beats a stock recipe identifier."""
@@ -146,7 +159,7 @@ class TestRecipeMapLookups(_RecipeMapIsolationMixin, unittest.TestCase):
             SAMPLE_RECIPE["Identifier"]
         ] = "/nonexistent/path.recipe"
         # Override identifier still resolves though...
-        autopkglib.globalRecipeMap["overrides-identifiers"] = {}
+        autopkglib.globalRecipeMap["overrides-identifiers"].clear()
         self.assertIsNone(
             autopkglib.find_recipe_by_identifier_in_map(SAMPLE_RECIPE["Identifier"])
         )
@@ -219,12 +232,12 @@ class TestRecipeMapPersistence(_RecipeMapIsolationMixin, unittest.TestCase):
     def test_write_is_sorted_for_stable_diffs(self):
         """The file should use sort_keys=True so repeated regenerations
         produce byte-identical output."""
-        autopkglib.globalRecipeMap = {
-            "identifiers": {"com.example.b": "/b.recipe", "com.example.a": "/a.recipe"},
-            "shortnames": {"B": "/b.recipe", "A": "/a.recipe"},
-            "overrides": {},
-            "overrides-identifiers": {},
-        }
+        autopkglib.globalRecipeMap["identifiers"].update(
+            {"com.example.b": "/b.recipe", "com.example.a": "/a.recipe"}
+        )
+        autopkglib.globalRecipeMap["shortnames"].update(
+            {"B": "/b.recipe", "A": "/a.recipe"}
+        )
         autopkglib.write_recipe_map_to_disk()
         with open(autopkglib.DEFAULT_RECIPE_MAP) as f:
             text = f.read()
@@ -598,17 +611,34 @@ class TestGenerateRecipeMapVerb(_RecipeMapIsolationMixin, unittest.TestCase):
             autopkg.generate_recipe_map,
         )
 
-    def test_generates_and_persists_map(self):
-        """Invoking the verb with explicit search/override dirs must
-        produce a persisted recipe map covering those dirs."""
+    def test_refuses_transient_cli_dirs(self):
+        """Transient --search-dir / --override-dir flags are refused
+        because persisting them into recipe_map.json would pollute
+        every later pref-scoped run. The verb must return a non-zero
+        exit code and NOT write the map."""
         rc = self._run(
             [],
             options_kwargs={
                 "search_dirs": [self.recipes_dir],
                 "override_dirs": [self.overrides_dir],
             },
-            # No background prefs — test only the CLI-supplied dirs.
             prefs={"RECIPE_SEARCH_DIRS": [], "RECIPE_OVERRIDE_DIRS": []},
+        )
+        self.assertEqual(rc, 1, "Verb must refuse transient CLI dirs.")
+        self.assertFalse(
+            os.path.exists(autopkglib.DEFAULT_RECIPE_MAP),
+            "Verb must NOT persist when refusing.",
+        )
+
+    def test_persists_pref_scoped_map_with_schema_version(self):
+        """Happy path: no CLI dirs, prefs configured. Verb builds the
+        pref-scoped map and writes it to disk with a schema_version."""
+        rc = self._run(
+            [],
+            prefs={
+                "RECIPE_SEARCH_DIRS": [self.recipes_dir],
+                "RECIPE_OVERRIDE_DIRS": [self.overrides_dir],
+            },
         )
         self.assertEqual(rc, 0)
         self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))

--- a/Code/tests/test_autopkg_recipe_map.py
+++ b/Code/tests/test_autopkg_recipe_map.py
@@ -15,7 +15,7 @@
 """Tests for the recipe map backported from dev-3.x.
 
 Covers:
-* Lookup helpers (find_recipe_by_id_in_map, find_recipe_by_name_in_map,
+* Lookup helpers (find_recipe_by_identifier_in_map, find_recipe_by_name_in_map,
   find_identifier_from_name, find_name_from_identifier).
 * Persistence (write_recipe_map_to_disk, handle_reading_recipe_map_file,
   validate_recipe_map).
@@ -28,7 +28,6 @@ these tests are hermetic and safe to run in parallel with others."""
 
 import importlib
 import importlib.machinery
-import io
 import json
 import os
 import plistlib
@@ -86,15 +85,10 @@ class _RecipeMapIsolationMixin:
             "overrides-identifiers": {},
         }
         autopkglib.DEFAULT_RECIPE_MAP = os.path.join(self.tmpdir, "recipe_map.json")
-        # Mirror the constant into the autopkg module so verb code that
-        # references it (e.g. generate-recipe-map's log line) picks up
-        # the test-local path too.
-        autopkg.DEFAULT_RECIPE_MAP = autopkglib.DEFAULT_RECIPE_MAP
 
     def tearDown(self):
         autopkglib.globalRecipeMap = self._saved_map
         autopkglib.DEFAULT_RECIPE_MAP = self._saved_default
-        autopkg.DEFAULT_RECIPE_MAP = self._saved_default
 
     def _cleanup_tmp(self):
         import shutil
@@ -103,7 +97,7 @@ class _RecipeMapIsolationMixin:
 
 
 class TestRecipeMapLookups(_RecipeMapIsolationMixin, unittest.TestCase):
-    """Covers find_recipe_by_id_in_map / find_recipe_by_name_in_map and
+    """Covers find_recipe_by_identifier_in_map / find_recipe_by_name_in_map and
     the reverse lookup helpers."""
 
     def setUp(self):
@@ -125,7 +119,9 @@ class TestRecipeMapLookups(_RecipeMapIsolationMixin, unittest.TestCase):
 
     def test_find_by_id_prefers_override(self):
         """An override identifier beats a stock recipe identifier."""
-        result = autopkglib.find_recipe_by_id_in_map(SAMPLE_OVERRIDE["Identifier"])
+        result = autopkglib.find_recipe_by_identifier_in_map(
+            SAMPLE_OVERRIDE["Identifier"]
+        )
         self.assertEqual(result, self.override_path)
 
     def test_find_by_id_skip_overrides(self):
@@ -134,25 +130,25 @@ class TestRecipeMapLookups(_RecipeMapIsolationMixin, unittest.TestCase):
         autopkglib.globalRecipeMap["overrides-identifiers"][
             SAMPLE_RECIPE["Identifier"]
         ] = self.override_path
-        result = autopkglib.find_recipe_by_id_in_map(
+        result = autopkglib.find_recipe_by_identifier_in_map(
             SAMPLE_RECIPE["Identifier"], skip_overrides=True
         )
         self.assertEqual(result, self.recipe_path)
 
     def test_find_by_id_returns_none_for_missing(self):
         self.assertIsNone(
-            autopkglib.find_recipe_by_id_in_map("com.example.does.not.exist")
+            autopkglib.find_recipe_by_identifier_in_map("com.example.does.not.exist")
         )
 
     def test_find_by_id_returns_none_for_stale_path(self):
         """If the cached path is missing on disk the lookup returns None."""
-        autopkglib.globalRecipeMap["identifiers"][SAMPLE_RECIPE["Identifier"]] = (
-            "/nonexistent/path.recipe"
-        )
+        autopkglib.globalRecipeMap["identifiers"][
+            SAMPLE_RECIPE["Identifier"]
+        ] = "/nonexistent/path.recipe"
         # Override identifier still resolves though...
         autopkglib.globalRecipeMap["overrides-identifiers"] = {}
         self.assertIsNone(
-            autopkglib.find_recipe_by_id_in_map(SAMPLE_RECIPE["Identifier"])
+            autopkglib.find_recipe_by_identifier_in_map(SAMPLE_RECIPE["Identifier"])
         )
 
     def test_find_by_name_prefers_override(self):

--- a/Code/tests/test_autopkg_recipe_map.py
+++ b/Code/tests/test_autopkg_recipe_map.py
@@ -1,0 +1,677 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the recipe map backported from dev-3.x.
+
+Covers:
+* Lookup helpers (find_recipe_by_id_in_map, find_recipe_by_name_in_map,
+  find_identifier_from_name, find_name_from_identifier).
+* Persistence (write_recipe_map_to_disk, handle_reading_recipe_map_file,
+  validate_recipe_map).
+* Rebuild behaviour (map_key_to_paths, calculate_recipe_map).
+* read_recipe_map auto-create UX divergence from dev-3.x.
+* The `autopkg generate-recipe-map` verb.
+
+All filesystem I/O is done against per-test temporary directories so
+these tests are hermetic and safe to run in parallel with others."""
+
+import importlib
+import importlib.machinery
+import io
+import json
+import os
+import plistlib
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import autopkglib
+
+autopkg_path = os.path.join(os.path.dirname(__file__), "..", "autopkg")
+loader = importlib.machinery.SourceFileLoader("autopkg", autopkg_path)
+autopkg = loader.load_module()
+sys.modules["autopkg"] = autopkg
+
+
+# Sample on-disk recipe used to populate temp repos.
+SAMPLE_RECIPE = {
+    "Description": "Sample test recipe.",
+    "Identifier": "com.example.test.sample",
+    "Input": {"NAME": "Sample"},
+    "MinimumVersion": "2.3",
+    "Process": [{"Processor": "URLDownloader"}],
+}
+
+SAMPLE_OVERRIDE = {
+    "Identifier": "local.sample.override",
+    "Input": {"NAME": "Sample"},
+    "ParentRecipe": "com.example.test.sample",
+}
+
+
+def _write_plist_recipe(path, recipe_dict):
+    """Write a plist-format recipe to ``path``."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        plistlib.dump(recipe_dict, f)
+
+
+class _RecipeMapIsolationMixin:
+    """Mixin that resets ``autopkglib.globalRecipeMap`` between tests and
+    redirects ``DEFAULT_RECIPE_MAP`` to a temp location so tests never
+    touch the developer's real ``~/Library/AutoPkg`` directory."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="autopkg_recipe_map_test_")
+        self.addCleanup(self._cleanup_tmp)
+
+        self._saved_map = dict(autopkglib.globalRecipeMap)
+        self._saved_default = autopkglib.DEFAULT_RECIPE_MAP
+        autopkglib.globalRecipeMap = {
+            "identifiers": {},
+            "shortnames": {},
+            "overrides": {},
+            "overrides-identifiers": {},
+        }
+        autopkglib.DEFAULT_RECIPE_MAP = os.path.join(self.tmpdir, "recipe_map.json")
+        # Mirror the constant into the autopkg module so verb code that
+        # references it (e.g. generate-recipe-map's log line) picks up
+        # the test-local path too.
+        autopkg.DEFAULT_RECIPE_MAP = autopkglib.DEFAULT_RECIPE_MAP
+
+    def tearDown(self):
+        autopkglib.globalRecipeMap = self._saved_map
+        autopkglib.DEFAULT_RECIPE_MAP = self._saved_default
+        autopkg.DEFAULT_RECIPE_MAP = self._saved_default
+
+    def _cleanup_tmp(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+
+class TestRecipeMapLookups(_RecipeMapIsolationMixin, unittest.TestCase):
+    """Covers find_recipe_by_id_in_map / find_recipe_by_name_in_map and
+    the reverse lookup helpers."""
+
+    def setUp(self):
+        super().setUp()
+        # Write a real recipe on disk so valid_recipe_file returns True.
+        self.recipe_path = os.path.join(self.tmpdir, "Sample.recipe")
+        _write_plist_recipe(self.recipe_path, SAMPLE_RECIPE)
+        self.override_path = os.path.join(self.tmpdir, "Override.recipe")
+        _write_plist_recipe(self.override_path, SAMPLE_OVERRIDE)
+
+        autopkglib.globalRecipeMap = {
+            "identifiers": {SAMPLE_RECIPE["Identifier"]: self.recipe_path},
+            "shortnames": {"Sample": self.recipe_path},
+            "overrides": {"Override": self.override_path},
+            "overrides-identifiers": {
+                SAMPLE_OVERRIDE["Identifier"]: self.override_path
+            },
+        }
+
+    def test_find_by_id_prefers_override(self):
+        """An override identifier beats a stock recipe identifier."""
+        result = autopkglib.find_recipe_by_id_in_map(SAMPLE_OVERRIDE["Identifier"])
+        self.assertEqual(result, self.override_path)
+
+    def test_find_by_id_skip_overrides(self):
+        """skip_overrides=True ignores the overrides-identifiers dict."""
+        # Seed an override with the same identifier as a stock recipe.
+        autopkglib.globalRecipeMap["overrides-identifiers"][
+            SAMPLE_RECIPE["Identifier"]
+        ] = self.override_path
+        result = autopkglib.find_recipe_by_id_in_map(
+            SAMPLE_RECIPE["Identifier"], skip_overrides=True
+        )
+        self.assertEqual(result, self.recipe_path)
+
+    def test_find_by_id_returns_none_for_missing(self):
+        self.assertIsNone(
+            autopkglib.find_recipe_by_id_in_map("com.example.does.not.exist")
+        )
+
+    def test_find_by_id_returns_none_for_stale_path(self):
+        """If the cached path is missing on disk the lookup returns None."""
+        autopkglib.globalRecipeMap["identifiers"][SAMPLE_RECIPE["Identifier"]] = (
+            "/nonexistent/path.recipe"
+        )
+        # Override identifier still resolves though...
+        autopkglib.globalRecipeMap["overrides-identifiers"] = {}
+        self.assertIsNone(
+            autopkglib.find_recipe_by_id_in_map(SAMPLE_RECIPE["Identifier"])
+        )
+
+    def test_find_by_name_prefers_override(self):
+        """Shortname lookup prefers an override by name."""
+        # Add an override with the same shortname as the stock recipe.
+        autopkglib.globalRecipeMap["overrides"]["Sample"] = self.override_path
+        result = autopkglib.find_recipe_by_name_in_map("Sample")
+        self.assertEqual(result, self.override_path)
+
+    def test_find_by_name_skip_overrides(self):
+        autopkglib.globalRecipeMap["overrides"]["Sample"] = self.override_path
+        result = autopkglib.find_recipe_by_name_in_map("Sample", skip_overrides=True)
+        self.assertEqual(result, self.recipe_path)
+
+    def test_find_by_name_returns_none_for_missing(self):
+        self.assertIsNone(autopkglib.find_recipe_by_name_in_map("NopeRecipe"))
+
+    def test_find_name_from_identifier(self):
+        self.assertEqual(
+            autopkglib.find_name_from_identifier(SAMPLE_RECIPE["Identifier"]),
+            "Sample",
+        )
+
+    def test_find_name_from_identifier_missing_logs_and_returns_none(self):
+        with patch.object(autopkglib, "log_err") as mock_log_err:
+            self.assertIsNone(
+                autopkglib.find_name_from_identifier("com.example.missing")
+            )
+            mock_log_err.assert_called()
+
+    def test_find_identifier_from_name(self):
+        self.assertEqual(
+            autopkglib.find_identifier_from_name("Sample"),
+            SAMPLE_RECIPE["Identifier"],
+        )
+
+    def test_find_identifier_from_name_missing_logs_and_returns_none(self):
+        with patch.object(autopkglib, "log_err") as mock_log_err:
+            self.assertIsNone(autopkglib.find_identifier_from_name("Nope"))
+            mock_log_err.assert_called()
+
+
+class TestRecipeMapPersistence(_RecipeMapIsolationMixin, unittest.TestCase):
+    """write_recipe_map_to_disk / handle_reading_recipe_map_file /
+    validate_recipe_map."""
+
+    def test_write_then_read_roundtrip(self):
+        autopkglib.globalRecipeMap = {
+            "identifiers": {"com.example.a": "/tmp/a.recipe"},
+            "shortnames": {"A": "/tmp/a.recipe"},
+            "overrides": {},
+            "overrides-identifiers": {},
+        }
+        autopkglib.write_recipe_map_to_disk()
+        self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
+        result = autopkglib.handle_reading_recipe_map_file()
+        self.assertEqual(result, autopkglib.globalRecipeMap)
+
+    def test_write_is_sorted_for_stable_diffs(self):
+        """The file should use sort_keys=True so repeated regenerations
+        produce byte-identical output."""
+        autopkglib.globalRecipeMap = {
+            "identifiers": {"com.example.b": "/b.recipe", "com.example.a": "/a.recipe"},
+            "shortnames": {"B": "/b.recipe", "A": "/a.recipe"},
+            "overrides": {},
+            "overrides-identifiers": {},
+        }
+        autopkglib.write_recipe_map_to_disk()
+        with open(autopkglib.DEFAULT_RECIPE_MAP) as f:
+            text = f.read()
+        # Keys should appear in alphabetical order.
+        self.assertLess(text.find('"com.example.a"'), text.find('"com.example.b"'))
+        self.assertLess(text.find('"identifiers"'), text.find('"shortnames"'))
+
+    def test_read_missing_file_returns_empty_dict_silently(self):
+        """A brand-new install has no map file; that must be a non-fatal
+        condition (not a log_err)."""
+        # File does not exist in the temp dir.
+        with patch.object(autopkglib, "log_err") as mock_log_err:
+            result = autopkglib.handle_reading_recipe_map_file()
+            self.assertEqual(result, {})
+            mock_log_err.assert_not_called()
+
+    def test_read_corrupt_file_logs_and_returns_empty(self):
+        with open(autopkglib.DEFAULT_RECIPE_MAP, "w") as f:
+            f.write("not valid json {{{")
+        with patch.object(autopkglib, "log_err") as mock_log_err:
+            result = autopkglib.handle_reading_recipe_map_file()
+            self.assertEqual(result, {})
+            mock_log_err.assert_called()
+
+    def test_write_tolerates_osError(self):
+        """A permission error during write should log a warning, not raise."""
+        with (
+            patch("builtins.open", side_effect=OSError("nope")),
+            patch.object(autopkglib, "log_err") as mock_log_err,
+        ):
+            # Must not raise.
+            autopkglib.write_recipe_map_to_disk()
+            mock_log_err.assert_called()
+
+    def test_validate_recipe_map_happy_path(self):
+        self.assertTrue(
+            autopkglib.validate_recipe_map(
+                {
+                    "identifiers": {},
+                    "shortnames": {},
+                    "overrides": {},
+                    "overrides-identifiers": {},
+                }
+            )
+        )
+
+    def test_validate_recipe_map_missing_key(self):
+        self.assertFalse(
+            autopkglib.validate_recipe_map(
+                {"identifiers": {}, "shortnames": {}, "overrides": {}}
+            )
+        )
+
+    def test_validate_recipe_map_extra_keys_are_fine(self):
+        """Forward-compat: future keys shouldn't cause validation failure."""
+        self.assertTrue(
+            autopkglib.validate_recipe_map(
+                {
+                    "identifiers": {},
+                    "shortnames": {},
+                    "overrides": {},
+                    "overrides-identifiers": {},
+                    "future_key": {},
+                }
+            )
+        )
+
+
+class TestMapKeyToPaths(_RecipeMapIsolationMixin, unittest.TestCase):
+    """map_key_to_paths should walk a directory one level deep and emit
+    first-wins entries keyed correctly for both identifiers and shortnames."""
+
+    def setUp(self):
+        super().setUp()
+        self.recipe_a = os.path.join(self.tmpdir, "RecipeA.recipe")
+        self.recipe_b = os.path.join(self.tmpdir, "sub", "RecipeB.recipe")
+        self.recipe_c = os.path.join(self.tmpdir, "sub", "deeper", "RecipeC.recipe")
+        _write_plist_recipe(
+            self.recipe_a, {**SAMPLE_RECIPE, "Identifier": "com.example.a"}
+        )
+        _write_plist_recipe(
+            self.recipe_b, {**SAMPLE_RECIPE, "Identifier": "com.example.b"}
+        )
+        _write_plist_recipe(
+            self.recipe_c, {**SAMPLE_RECIPE, "Identifier": "com.example.c"}
+        )
+
+    def test_shortnames_key(self):
+        result = autopkglib.map_key_to_paths("shortnames", self.tmpdir)
+        # Top-level and one-level-deep are found; deeper ones are not.
+        self.assertIn("RecipeA", result)
+        self.assertIn("RecipeB", result)
+        self.assertNotIn("RecipeC", result)
+        self.assertEqual(result["RecipeA"], self.recipe_a)
+
+    def test_identifiers_key_reads_from_file(self):
+        result = autopkglib.map_key_to_paths("identifiers", self.tmpdir)
+        self.assertIn("com.example.a", result)
+        self.assertIn("com.example.b", result)
+        self.assertEqual(result["com.example.a"], self.recipe_a)
+
+    def test_overrides_identifiers_key_reads_identifier_field(self):
+        """The 'overrides-identifiers' keyname should also read the
+        Identifier field (the helper tests for the substring
+        'identifiers')."""
+        # Place an override-shaped file in its own dir.
+        override_dir = os.path.join(self.tmpdir, "ovr")
+        override_path = os.path.join(override_dir, "ov.recipe")
+        _write_plist_recipe(override_path, SAMPLE_OVERRIDE)
+        result = autopkglib.map_key_to_paths("overrides-identifiers", override_dir)
+        self.assertEqual(result, {SAMPLE_OVERRIDE["Identifier"]: override_path})
+
+    def test_first_wins_for_duplicates(self):
+        """Duplicate shortnames should preserve the first discovery."""
+        # Two recipes with the same shortname in different subdirs.
+        dup_a = os.path.join(self.tmpdir, "dir1", "DuplicateName.recipe")
+        dup_b = os.path.join(self.tmpdir, "dir2", "DuplicateName.recipe")
+        _write_plist_recipe(dup_a, {**SAMPLE_RECIPE, "Identifier": "com.example.dup1"})
+        _write_plist_recipe(dup_b, {**SAMPLE_RECIPE, "Identifier": "com.example.dup2"})
+        result = autopkglib.map_key_to_paths("shortnames", self.tmpdir)
+        # Only one entry; first-wins semantics.
+        self.assertIn("DuplicateName", result)
+        self.assertIn(result["DuplicateName"], {dup_a, dup_b})
+
+
+class TestCalculateRecipeMap(_RecipeMapIsolationMixin, unittest.TestCase):
+    """End-to-end tests for calculate_recipe_map: honours prefs, writes to
+    disk only when appropriate, and skips '.' by default."""
+
+    def setUp(self):
+        super().setUp()
+        # Two "repos": one recipes dir, one overrides dir.
+        self.recipes_dir = os.path.join(self.tmpdir, "repo")
+        self.overrides_dir = os.path.join(self.tmpdir, "ovrs")
+        os.makedirs(self.recipes_dir)
+        os.makedirs(self.overrides_dir)
+        _write_plist_recipe(
+            os.path.join(self.recipes_dir, "Sample.recipe"), SAMPLE_RECIPE
+        )
+        _write_plist_recipe(
+            os.path.join(self.overrides_dir, "Override.recipe"), SAMPLE_OVERRIDE
+        )
+
+    def _run_with_prefs(self, **overrides):
+        def _fake_get_pref(key):
+            return overrides.get(key)
+
+        return patch.object(autopkglib, "get_pref", side_effect=_fake_get_pref)
+
+    def test_populates_all_four_dicts(self):
+        with self._run_with_prefs(
+            RECIPE_SEARCH_DIRS=[self.recipes_dir],
+            RECIPE_OVERRIDE_DIRS=[self.overrides_dir],
+        ):
+            autopkglib.calculate_recipe_map()
+
+        rm = autopkglib.globalRecipeMap
+        self.assertEqual(
+            rm["identifiers"],
+            {
+                SAMPLE_RECIPE["Identifier"]: os.path.join(
+                    self.recipes_dir, "Sample.recipe"
+                )
+            },
+        )
+        self.assertEqual(
+            rm["shortnames"],
+            {"Sample": os.path.join(self.recipes_dir, "Sample.recipe")},
+        )
+        self.assertEqual(
+            rm["overrides"],
+            {"Override": os.path.join(self.overrides_dir, "Override.recipe")},
+        )
+        self.assertEqual(
+            rm["overrides-identifiers"],
+            {
+                SAMPLE_OVERRIDE["Identifier"]: os.path.join(
+                    self.overrides_dir, "Override.recipe"
+                )
+            },
+        )
+
+    def test_persists_when_no_extras(self):
+        with self._run_with_prefs(
+            RECIPE_SEARCH_DIRS=[self.recipes_dir],
+            RECIPE_OVERRIDE_DIRS=[self.overrides_dir],
+        ):
+            autopkglib.calculate_recipe_map()
+        self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
+
+    def test_does_not_persist_when_extras_supplied(self):
+        """Passing extra_search_dirs / extra_override_dirs keeps the
+        result in-memory only so callers can build transient views."""
+        with self._run_with_prefs(
+            RECIPE_SEARCH_DIRS=[],
+            RECIPE_OVERRIDE_DIRS=[],
+        ):
+            autopkglib.calculate_recipe_map(
+                extra_search_dirs=[self.recipes_dir],
+                extra_override_dirs=[self.overrides_dir],
+            )
+        self.assertFalse(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
+        # Map is still populated in-memory.
+        self.assertEqual(len(autopkglib.globalRecipeMap["identifiers"]), 1)
+
+    def test_skips_cwd_by_default(self):
+        """'.' should not be walked unless explicitly requested."""
+        with self._run_with_prefs(
+            RECIPE_SEARCH_DIRS=[".", self.recipes_dir],
+            RECIPE_OVERRIDE_DIRS=[self.overrides_dir],
+        ):
+            # We mock glob.glob to detect if '.' was walked.
+            seen_dirs = []
+            real_glob = autopkglib.glob.glob
+
+            def tracking_glob(pattern, *args, **kwargs):
+                seen_dirs.append(pattern)
+                return real_glob(pattern, *args, **kwargs)
+
+            with patch.object(autopkglib.glob, "glob", side_effect=tracking_glob):
+                autopkglib.calculate_recipe_map()
+
+        # No pattern should be anchored at the current working directory.
+        cwd = os.path.abspath(".")
+        self.assertFalse(
+            any(p.startswith(cwd + os.sep) for p in seen_dirs),
+            f"'.' should have been skipped but was scanned: {seen_dirs}",
+        )
+
+    def test_skip_cwd_false_includes_cwd(self):
+        """When skip_cwd=False '.' is walked and resolved to an absolute
+        path."""
+        with self._run_with_prefs(
+            RECIPE_SEARCH_DIRS=["."],
+            RECIPE_OVERRIDE_DIRS=[self.overrides_dir],
+        ):
+            with patch.object(
+                autopkglib, "map_key_to_paths", return_value={}
+            ) as mk_mock:
+                autopkglib.calculate_recipe_map(skip_cwd=False)
+
+        # Every call's repo_dir arg should be absolute (no bare '.').
+        called_dirs = [call_args.args[1] for call_args in mk_mock.call_args_list]
+        self.assertFalse(
+            any(d == "." for d in called_dirs),
+            f"'.' should have been resolved to abspath: {called_dirs}",
+        )
+
+
+class TestReadRecipeMapAutoCreate(_RecipeMapIsolationMixin, unittest.TestCase):
+    """The dev-2.x port diverges from dev-3.x here: a missing/invalid map
+    MUST auto-rebuild rather than exit the process."""
+
+    def test_auto_creates_when_file_missing(self):
+        """Normal call with no map on disk should trigger a rebuild, not
+        exit the interpreter."""
+        self.assertFalse(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
+        with (
+            patch.object(autopkglib, "calculate_recipe_map") as mock_calc,
+            patch.object(autopkglib, "sys") as mock_sys,
+        ):
+            autopkglib.read_recipe_map()
+            mock_calc.assert_called_once()
+            # Must NOT have exited.
+            mock_sys.exit.assert_not_called()
+
+    def test_auto_creates_when_file_is_invalid(self):
+        """A map file missing required keys is treated the same as missing."""
+        with open(autopkglib.DEFAULT_RECIPE_MAP, "w") as f:
+            json.dump({"identifiers": {}}, f)  # missing required keys
+        with (
+            patch.object(autopkglib, "calculate_recipe_map") as mock_calc,
+            patch.object(autopkglib, "sys") as mock_sys,
+        ):
+            autopkglib.read_recipe_map()
+            mock_calc.assert_called_once()
+            mock_sys.exit.assert_not_called()
+
+    def test_loads_valid_map_without_rebuild(self):
+        valid = {
+            "identifiers": {"com.example.a": "/a.recipe"},
+            "shortnames": {"A": "/a.recipe"},
+            "overrides": {},
+            "overrides-identifiers": {},
+        }
+        with open(autopkglib.DEFAULT_RECIPE_MAP, "w") as f:
+            json.dump(valid, f)
+        with patch.object(autopkglib, "calculate_recipe_map") as mock_calc:
+            autopkglib.read_recipe_map()
+            mock_calc.assert_not_called()
+        self.assertEqual(
+            autopkglib.globalRecipeMap["identifiers"], valid["identifiers"]
+        )
+
+    def test_rebuild_true_is_still_accepted(self):
+        """The dev-3.x flag must remain supported for API compatibility."""
+        with patch.object(autopkglib, "calculate_recipe_map") as mock_calc:
+            autopkglib.read_recipe_map(rebuild=True)
+            mock_calc.assert_called_once()
+
+    def test_allow_continuing_is_still_accepted(self):
+        """Likewise for allow_continuing — retained as a no-op."""
+        with patch.object(autopkglib, "calculate_recipe_map") as mock_calc:
+            autopkglib.read_recipe_map(allow_continuing=True)
+            mock_calc.assert_called_once()
+
+
+class TestGenerateRecipeMapVerb(_RecipeMapIsolationMixin, unittest.TestCase):
+    """The new ``autopkg generate-recipe-map`` subcommand."""
+
+    def setUp(self):
+        super().setUp()
+        self.recipes_dir = os.path.join(self.tmpdir, "repo")
+        self.overrides_dir = os.path.join(self.tmpdir, "ovrs")
+        os.makedirs(self.recipes_dir)
+        os.makedirs(self.overrides_dir)
+        _write_plist_recipe(
+            os.path.join(self.recipes_dir, "Sample.recipe"), SAMPLE_RECIPE
+        )
+        _write_plist_recipe(
+            os.path.join(self.overrides_dir, "Override.recipe"), SAMPLE_OVERRIDE
+        )
+
+    def _run(self, argv_tail, options_kwargs=None, prefs=None):
+        """Helper that drives the verb through its argparse-mocked harness.
+
+        Fully controls ``get_pref`` AND ``get_override_dirs`` because the
+        latter falls back to DEFAULT_USER_OVERRIDES_DIR (the real user's
+        ~/Library/AutoPkg/RecipeOverrides) when the pref is empty."""
+        from unittest.mock import Mock
+
+        options = Mock()
+        options.search_dirs = (options_kwargs or {}).get("search_dirs")
+        options.override_dirs = (options_kwargs or {}).get("override_dirs")
+        options.include_cwd = (options_kwargs or {}).get("include_cwd", False)
+
+        argv = [None, "generate-recipe-map", *argv_tail]
+        prefs = prefs or {}
+        overrides_fallback = prefs.get("RECIPE_OVERRIDE_DIRS") or []
+
+        with (
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.common_parse", return_value=(options, [])),
+            patch("autopkg.add_search_and_override_dir_options"),
+            patch.object(autopkglib, "get_pref", side_effect=lambda k: prefs.get(k)),
+            patch.object(
+                autopkglib, "get_override_dirs", return_value=overrides_fallback
+            ),
+        ):
+            mock_parser.return_value = Mock()
+            return autopkg.generate_recipe_map(argv)
+
+    def test_registered_in_subcommands(self):
+        """The verb should show up in the main() dispatch dict."""
+        # We call main with an unknown-but-fallthrough-to-help path to
+        # collect the subcommand table via the display_help function.
+        captured = []
+
+        def fake_display_help(argv, subcommands):
+            captured.append(subcommands)
+            return 1
+
+        with patch("autopkg.display_help", side_effect=fake_display_help):
+            autopkg.main([None, "help"])
+
+        self.assertTrue(captured, "main() did not call display_help")
+        self.assertIn("generate-recipe-map", captured[0])
+        self.assertIn("function", captured[0]["generate-recipe-map"])
+        self.assertIs(
+            captured[0]["generate-recipe-map"]["function"],
+            autopkg.generate_recipe_map,
+        )
+
+    def test_generates_and_persists_map(self):
+        """Invoking the verb with explicit search/override dirs must
+        produce a persisted recipe map covering those dirs."""
+        rc = self._run(
+            [],
+            options_kwargs={
+                "search_dirs": [self.recipes_dir],
+                "override_dirs": [self.overrides_dir],
+            },
+            # No background prefs — test only the CLI-supplied dirs.
+            prefs={"RECIPE_SEARCH_DIRS": [], "RECIPE_OVERRIDE_DIRS": []},
+        )
+        self.assertEqual(rc, 0)
+        self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
+
+        with open(autopkglib.DEFAULT_RECIPE_MAP) as f:
+            on_disk = json.load(f)
+        self.assertEqual(
+            set(on_disk.keys()),
+            {"identifiers", "shortnames", "overrides", "overrides-identifiers"},
+        )
+        self.assertIn(SAMPLE_RECIPE["Identifier"], on_disk["identifiers"])
+        self.assertIn(SAMPLE_OVERRIDE["Identifier"], on_disk["overrides-identifiers"])
+
+    def test_generates_without_extras_uses_prefs(self):
+        """No CLI dirs => use the configured prefs. Should still persist."""
+        rc = self._run(
+            [],
+            prefs={
+                "RECIPE_SEARCH_DIRS": [self.recipes_dir],
+                "RECIPE_OVERRIDE_DIRS": [self.overrides_dir],
+            },
+        )
+        self.assertEqual(rc, 0)
+        self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
+        with open(autopkglib.DEFAULT_RECIPE_MAP) as f:
+            on_disk = json.load(f)
+        self.assertIn(SAMPLE_RECIPE["Identifier"], on_disk["identifiers"])
+
+        with open(autopkglib.DEFAULT_RECIPE_MAP) as f:
+            on_disk = json.load(f)
+        self.assertEqual(
+            set(on_disk.keys()),
+            {"identifiers", "shortnames", "overrides", "overrides-identifiers"},
+        )
+        self.assertIn(SAMPLE_RECIPE["Identifier"], on_disk["identifiers"])
+        self.assertIn(SAMPLE_OVERRIDE["Identifier"], on_disk["overrides-identifiers"])
+
+    def test_generates_without_extras_uses_prefs(self):
+        """No CLI dirs => use the configured prefs. Should still persist."""
+        with patch.object(
+            autopkglib,
+            "get_pref",
+            side_effect=lambda k: {
+                "RECIPE_SEARCH_DIRS": [self.recipes_dir],
+                "RECIPE_OVERRIDE_DIRS": [self.overrides_dir],
+            }.get(k),
+        ):
+            rc = self._run([])
+        self.assertEqual(rc, 0)
+        self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
+
+
+class TestAutopkgUserFolder(unittest.TestCase):
+    """autopkg_user_folder must be defensive against permission errors so
+    it doesn't break tests that mock os.path.expanduser."""
+
+    def test_returns_expanded_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            with patch("os.path.expanduser", return_value=td):
+                result = autopkglib.autopkg_user_folder()
+            self.assertEqual(os.path.abspath(result), os.path.abspath(td))
+
+    def test_tolerates_read_only_filesystem(self):
+        with patch("os.makedirs", side_effect=OSError("read-only")):
+            # Must not raise.
+            result = autopkglib.autopkg_user_folder()
+            self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Code/tests/test_autopkg_recipe_map.py
+++ b/Code/tests/test_autopkg_recipe_map.py
@@ -256,7 +256,7 @@ class TestRecipeMapPersistence(_RecipeMapIsolationMixin, unittest.TestCase):
     def test_write_tolerates_osError(self):
         """A permission error during write should log a warning, not raise."""
         with (
-            patch("builtins.open", side_effect=OSError("nope")),
+            patch("tempfile.mkstemp", side_effect=OSError("nope")),
             patch.object(autopkglib, "log_err") as mock_log_err,
         ):
             # Must not raise.

--- a/Code/tests/test_autopkg_recipe_map.py
+++ b/Code/tests/test_autopkg_recipe_map.py
@@ -200,16 +200,25 @@ class TestRecipeMapPersistence(_RecipeMapIsolationMixin, unittest.TestCase):
     validate_recipe_map."""
 
     def test_write_then_read_roundtrip(self):
-        autopkglib.globalRecipeMap = {
-            "identifiers": {"com.example.a": "/tmp/a.recipe"},
-            "shortnames": {"A": "/tmp/a.recipe"},
-            "overrides": {},
-            "overrides-identifiers": {},
-        }
+        autopkglib.globalRecipeMap.clear()
+        autopkglib.globalRecipeMap.update(
+            {
+                "identifiers": {"com.example.a": "/tmp/a.recipe"},
+                "shortnames": {"A": "/tmp/a.recipe"},
+                "overrides": {},
+                "overrides-identifiers": {},
+            }
+        )
         autopkglib.write_recipe_map_to_disk()
         self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
         result = autopkglib.handle_reading_recipe_map_file()
-        self.assertEqual(result, autopkglib.globalRecipeMap)
+        # Persisted file additionally carries a schema_version key; the
+        # four sub-dicts must match.
+        self.assertEqual(
+            result.get("schema_version"), autopkglib.RECIPE_MAP_SCHEMA_VERSION
+        )
+        for key in ("identifiers", "shortnames", "overrides", "overrides-identifiers"):
+            self.assertEqual(result[key], autopkglib.globalRecipeMap[key])
 
     def test_write_is_sorted_for_stable_diffs(self):
         """The file should use sort_keys=True so repeated regenerations
@@ -612,7 +621,17 @@ class TestGenerateRecipeMapVerb(_RecipeMapIsolationMixin, unittest.TestCase):
             on_disk = json.load(f)
         self.assertEqual(
             set(on_disk.keys()),
-            {"identifiers", "shortnames", "overrides", "overrides-identifiers"},
+            {
+                "identifiers",
+                "shortnames",
+                "overrides",
+                "overrides-identifiers",
+                "schema_version",
+            },
+        )
+        self.assertEqual(
+            on_disk["schema_version"],
+            autopkglib.RECIPE_MAP_SCHEMA_VERSION,
         )
         self.assertIn(SAMPLE_RECIPE["Identifier"], on_disk["identifiers"])
         self.assertIn(SAMPLE_OVERRIDE["Identifier"], on_disk["overrides-identifiers"])
@@ -631,29 +650,6 @@ class TestGenerateRecipeMapVerb(_RecipeMapIsolationMixin, unittest.TestCase):
         with open(autopkglib.DEFAULT_RECIPE_MAP) as f:
             on_disk = json.load(f)
         self.assertIn(SAMPLE_RECIPE["Identifier"], on_disk["identifiers"])
-
-        with open(autopkglib.DEFAULT_RECIPE_MAP) as f:
-            on_disk = json.load(f)
-        self.assertEqual(
-            set(on_disk.keys()),
-            {"identifiers", "shortnames", "overrides", "overrides-identifiers"},
-        )
-        self.assertIn(SAMPLE_RECIPE["Identifier"], on_disk["identifiers"])
-        self.assertIn(SAMPLE_OVERRIDE["Identifier"], on_disk["overrides-identifiers"])
-
-    def test_generates_without_extras_uses_prefs(self):
-        """No CLI dirs => use the configured prefs. Should still persist."""
-        with patch.object(
-            autopkglib,
-            "get_pref",
-            side_effect=lambda k: {
-                "RECIPE_SEARCH_DIRS": [self.recipes_dir],
-                "RECIPE_OVERRIDE_DIRS": [self.overrides_dir],
-            }.get(k),
-        ):
-            rc = self._run([])
-        self.assertEqual(rc, 0)
-        self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
 
 
 class TestAutopkgUserFolder(unittest.TestCase):

--- a/Code/tests/test_autopkg_recipe_map_regressions.py
+++ b/Code/tests/test_autopkg_recipe_map_regressions.py
@@ -1008,7 +1008,7 @@ class TestMapEntryMustParseAsRecipe(_RecipeMapIsolation, unittest.TestCase):
         )
 
 
-class TestLoadRecipeTolerartesStaleMapEntry(_RecipeMapIsolation, unittest.TestCase):
+class TestLoadRecipeToleratesStaleMapEntry(_RecipeMapIsolation, unittest.TestCase):
     """Review finding: ``load_recipe`` must not crash with
     ``AttributeError`` when the recipe map returns a path to a file
     that exists but isn't parseable (stale entry, truncated mid-write

--- a/Code/tests/test_autopkg_recipe_map_regressions.py
+++ b/Code/tests/test_autopkg_recipe_map_regressions.py
@@ -71,7 +71,6 @@ class _RecipeMapIsolation:
         self._saved_write_disabled = autopkglib._recipe_map_write_disabled
         autopkglib._recipe_map_write_disabled = False
         autopkglib.DEFAULT_RECIPE_MAP = os.path.join(self.tmpdir, "recipe_map.json")
-        autopkg.DEFAULT_RECIPE_MAP = autopkglib.DEFAULT_RECIPE_MAP
 
         for sub in (
             "identifiers",
@@ -89,7 +88,6 @@ class _RecipeMapIsolation:
         autopkglib.globalRecipeMap.clear()
         autopkglib.globalRecipeMap.update(self._saved_map)
         autopkglib.DEFAULT_RECIPE_MAP = self._saved_default
-        autopkg.DEFAULT_RECIPE_MAP = self._saved_default
         autopkglib._recipe_map_write_disabled = self._saved_write_disabled
 
 
@@ -215,7 +213,7 @@ class TestIssue894ProcessorLookup(_RecipeMapIsolation, unittest.TestCase):
     def test_find_processor_path_map_hit(self):
         """A shared-processor identifier present in the map is resolved
         without any on-disk scan."""
-        # Write a real recipe on disk so find_recipe_by_id_in_map's
+        # Write a real recipe on disk so find_recipe_by_identifier_in_map's
         # valid_recipe_file check succeeds.
         shared_dir = os.path.join(self.tmpdir, "shared")
         os.makedirs(shared_dir)
@@ -280,9 +278,9 @@ class TestIssue894ProcessorLookup(_RecipeMapIsolation, unittest.TestCase):
         )
 
         def fake_calc(*args, **kwargs):
-            autopkglib.globalRecipeMap["identifiers"]["com.example.cwd.shared"] = (
-                shared_recipe
-            )
+            autopkglib.globalRecipeMap["identifiers"][
+                "com.example.cwd.shared"
+            ] = shared_recipe
 
         with (
             patch("autopkg.calculate_recipe_map", side_effect=fake_calc) as mock_calc,
@@ -345,9 +343,9 @@ class TestIssue903TrustInfoByPath(_RecipeMapIsolation, unittest.TestCase):
         override_dir = os.path.join(self.tmpdir, "o")
         os.makedirs(override_dir)
         override_path = os.path.join(override_dir, "by-id.recipe")
-        autopkglib.globalRecipeMap["overrides-identifiers"]["local.byid"] = (
-            override_path
-        )
+        autopkglib.globalRecipeMap["overrides-identifiers"][
+            "local.byid"
+        ] = override_path
         self.assertTrue(autopkg.recipe_in_override_dir(override_path, [override_dir]))
 
     def test_recipe_in_override_dir_via_map_but_not_under_configured_dir(
@@ -367,29 +365,6 @@ class TestIssue903TrustInfoByPath(_RecipeMapIsolation, unittest.TestCase):
             )
             # Should have logged a warning about the bogus map entry.
             mock_log_err.assert_called()
-
-    def test_recipe_in_override_dir_via_configured_dir(self):
-        """The existing path-prefix check still works for files that the
-        map hasn't indexed yet."""
-        override_dir = os.path.join(self.tmpdir, "configured_overrides")
-        override_path = os.path.join(override_dir, "Unindexed.recipe")
-        self.assertTrue(autopkg.recipe_in_override_dir(override_path, [override_dir]))
-
-    def test_recipe_in_override_dir_negative(self):
-        """A file neither in the map nor under any configured override
-        dir is NOT classified as an override."""
-        self.assertFalse(
-            autopkg.recipe_in_override_dir("/some/random/Recipe.recipe", [self.tmpdir])
-        )
-
-    def test_recipe_in_override_dir_sibling_prefix_not_matched(self):
-        """Regression: prior to the fix, `/Users/a/Library/AutoPkg2`
-        could accidentally match `/Users/a/Library/AutoPkg`. Make sure
-        the normalised match requires a path separator."""
-        self.assertFalse(
-            autopkg.recipe_in_override_dir("/a/AutoPkg2/file.recipe", ["/a/AutoPkg"])
-        )
-        self.assertTrue(autopkg.recipe_in_override_dir(override_path, override_dirs=[]))
 
     def test_recipe_in_override_dir_via_configured_dir(self):
         """The existing path-prefix check still works for files that the
@@ -445,11 +420,11 @@ class TestIssue874MissingOverridesIdentifiers(_RecipeMapIsolation, unittest.Test
         autopkglib.globalRecipeMap.pop("overrides-identifiers", None)
         try:
             self.assertIsNone(
-                autopkglib.find_recipe_by_id_in_map("com.example.anything")
+                autopkglib.find_recipe_by_identifier_in_map("com.example.anything")
             )
         except KeyError:
             self.fail(
-                "find_recipe_by_id_in_map raised KeyError when the "
+                "find_recipe_by_identifier_in_map raised KeyError when the "
                 "'overrides-identifiers' key was missing."
             )
 

--- a/Code/tests/test_autopkg_recipe_map_regressions.py
+++ b/Code/tests/test_autopkg_recipe_map_regressions.py
@@ -203,6 +203,40 @@ class TestIssue918And908And886CliPrecedence(_RecipeMapIsolation, unittest.TestCa
             os.path.join(self.primary_dir, "Primary.recipe"),
         )
 
+    def test_superset_cli_dirs_still_uses_map(self):
+        """Caller supplies prefs + an extra dir (the recursive
+        load_recipe pattern, where a parent-recipe lookup appends the
+        child's dir). _dirs_match_prefs should accept the superset and
+        use the map, not fall back to the full-tree on-disk scan.
+
+        This is the fix that prevented the parent-chain recursion from
+        silently bypassing the map and paying the full O(N) scan cost
+        on every parent resolution."""
+        extra_dir = os.path.join(self.tmpdir, "extra")
+        superset = [self.primary_dir, extra_dir]
+        # On-disk scanner should NOT be called because the map has the
+        # answer and the caller's dirs include the full pref baseline.
+        with patch("autopkg.find_recipe_by_identifier_on_disk") as mock_on_disk:
+            result = autopkg.find_recipe("com.example.primary", search_dirs=superset)
+        self.assertEqual(result, os.path.join(self.primary_dir, "Primary.recipe"))
+        mock_on_disk.assert_not_called()
+
+    def test_narrowed_cli_dirs_still_bypasses_map(self):
+        """Caller supplies dirs that EXCLUDE at least one pref dir.
+        The map could point at a recipe the caller explicitly excluded,
+        so the map must still be bypassed (the #886/#894/#908/#918
+        contract). Negative complement to the superset test above."""
+        # `self.scoped_dir` is NOT in the configured prefs. Caller passes
+        # only the scoped dir, which is a narrowed scope. The map's entry
+        # for `com.example.primary` (in self.primary_dir) must not be
+        # returned because self.primary_dir isn't in the caller's set.
+        result = autopkg.find_recipe(
+            "com.example.primary", search_dirs=[self.scoped_dir]
+        )
+        # No recipe with that identifier exists in self.scoped_dir, so
+        # the result is None — the map entry was correctly ignored.
+        self.assertIsNone(result)
+
 
 class TestIssue894ProcessorLookup(_RecipeMapIsolation, unittest.TestCase):
     """Regression tests for issue #894: shared-processor recipes in the

--- a/Code/tests/test_autopkg_recipe_map_regressions.py
+++ b/Code/tests/test_autopkg_recipe_map_regressions.py
@@ -947,5 +947,117 @@ class TestGlobalRecipeMapInPlaceMutation(_RecipeMapIsolation, unittest.TestCase)
         )
 
 
+class TestMapEntryMustParseAsRecipe(_RecipeMapIsolation, unittest.TestCase):
+    """Defence-in-depth: the shared-processor code-import path in
+    ``get_processor`` must reject a map entry that isn't structurally a
+    recipe. Otherwise a user with write access to ``recipe_map.json``
+    could point an entry at any stat-able file and have autopkg append
+    its directory to the Python import path.
+
+    The map lookup itself is deliberately fast (``os.path.isfile`` only)
+    so every verb doesn't re-parse every entry. The structural check
+    lives at the one call site that feeds ``spec.loader.exec_module``."""
+
+    def test_get_processor_rejects_non_recipe_map_entry(self):
+        """A map entry pointing at a file that exists but isn't a
+        recipe must not cause its directory to be appended to the
+        processor search path."""
+        # Non-recipe file (plain text, wrong shape).
+        bad_dir = os.path.join(self.tmpdir, "notarecipe")
+        os.makedirs(bad_dir)
+        bad_path = os.path.join(bad_dir, "X.recipe")
+        with open(bad_path, "w") as f:
+            f.write("this is not a recipe")
+
+        autopkglib.globalRecipeMap["identifiers"]["com.example.evil"] = bad_path
+
+        # A separate directory where the attacker would have placed a
+        # matching <processor_name>.py; we assert THIS directory does
+        # not get added to the import search path.
+        recipe = {"RECIPE_PATH": os.path.join(self.tmpdir, "r.recipe")}
+        env = {"RECIPE_SEARCH_DIRS": []}
+
+        def tracking_exists(path):
+            return False  # Ensure we don't actually import anything.
+
+        with (
+            patch(
+                "autopkglib.extract_processor_name_with_recipe_identifier",
+                return_value=("P", "com.example.evil"),
+            ),
+            patch("os.path.exists", side_effect=tracking_exists),
+            patch("autopkglib.add_processor"),  # Never reached but mocked for safety.
+        ):
+            try:
+                autopkglib.get_processor("com.example.evil/P", recipe=recipe, env=env)
+            except (KeyError, AttributeError):
+                # Expected — processor not found is fine; we only care
+                # that the evil dir wasn't added to the search path.
+                pass
+
+        # The bad_dir must NOT appear in any os.path.exists call. We
+        # confirm via a second pass that traces processor_search_dirs.
+        # Simpler assertion: the bad_path must not be treated as a valid
+        # recipe, which is what find_recipe_by_identifier_in_map +
+        # valid_recipe_file guard together prevent.
+        from autopkglib import valid_recipe_file
+
+        self.assertFalse(
+            valid_recipe_file(bad_path),
+            "Setup invariant: the bad file must not parse as a recipe.",
+        )
+
+
+class TestLoadRecipeTolerartesStaleMapEntry(_RecipeMapIsolation, unittest.TestCase):
+    """Review finding: ``load_recipe`` must not crash with
+    ``AttributeError`` when the recipe map returns a path to a file
+    that exists but isn't parseable (stale entry, truncated mid-write
+    by a concurrent ``generate-recipe-map``, or tampered)."""
+
+    def test_load_recipe_handles_unparseable_map_entry(self):
+        """A map entry pointing at a corrupt file must log a warning
+        and return None, not raise AttributeError."""
+        corrupt_dir = os.path.join(self.tmpdir, "corrupt")
+        os.makedirs(corrupt_dir)
+        corrupt_path = os.path.join(corrupt_dir, "X.recipe.yaml")
+        with open(corrupt_path, "w") as f:
+            f.write("not: valid: recipe: :invalid yaml")
+
+        autopkglib.globalRecipeMap["shortnames"]["X"] = corrupt_path
+
+        # Stub out search_github/make_suggestions so we don't hit the
+        # network when the recipe isn't resolved.
+        with (
+            patch("autopkg.make_suggestions_for"),
+            patch(
+                "autopkglib.get_pref",
+                side_effect=lambda k: {
+                    "RECIPE_SEARCH_DIRS": [corrupt_dir],
+                }.get(k),
+            ),
+            patch.object(autopkglib, "get_override_dirs", return_value=[]),
+            patch.object(autopkg, "log_err") as mock_log_err,
+        ):
+            result = autopkg.load_recipe(
+                "X",
+                override_dirs=[],
+                recipe_dirs=[corrupt_dir],
+                make_suggestions=False,
+                search_github=False,
+            )
+
+        self.assertIsNone(
+            result, "load_recipe must return None for unparseable map entries."
+        )
+        # And it must have logged the stale-map warning.
+        warning_logged = any(
+            "not a readable recipe" in str(call) for call in mock_log_err.call_args_list
+        )
+        self.assertTrue(
+            warning_logged,
+            "Expected a 'not a readable recipe' warning to be logged.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Code/tests/test_autopkg_recipe_map_regressions.py
+++ b/Code/tests/test_autopkg_recipe_map_regressions.py
@@ -82,7 +82,7 @@ class _RecipeMapIsolation:
 
         # Reset the cross-test latch so one test's miss-rebuild doesn't
         # prevent another test from exercising the same code path.
-        autopkg._set_locate_recipe_rebuild_attempted(False)
+        autopkg._locate_recipe_rebuild_attempted = False
 
     def tearDown(self):
         autopkglib.globalRecipeMap.clear()
@@ -299,7 +299,7 @@ class TestIssue894ProcessorLookup(_RecipeMapIsolation, unittest.TestCase):
         rebuild. Subsequent misses in the same process must NOT trigger
         a second rebuild (review recommendation: avoid pathological
         multi-miss rebuilds)."""
-        autopkg._set_locate_recipe_rebuild_attempted(False)
+        autopkg._locate_recipe_rebuild_attempted = False
 
         # Write a real recipe for the first lookup so the rebuild has
         # something to find.
@@ -764,6 +764,66 @@ class TestRepoAddSingleRebuild(_RecipeMapIsolation, unittest.TestCase):
             1,
             "repo-add should call calculate_recipe_map exactly once.",
         )
+
+
+class TestIncrementalMapUpdateForSingleFile(_RecipeMapIsolation, unittest.TestCase):
+    """Review finding: `make-override` and `new-recipe` used to trigger
+    a full RECIPE_SEARCH_DIRS tree walk to index one newly-written file.
+    They now use `add_recipe_to_map` for an O(1) incremental update."""
+
+    def test_add_recipe_to_map_inserts_identifier_and_shortname(self):
+        recipes_dir = os.path.join(self.tmpdir, "repo")
+        os.makedirs(recipes_dir)
+        recipe_path = os.path.join(recipes_dir, "Sample.recipe")
+        _write_plist_recipe(recipe_path, SAMPLE_RECIPE)
+
+        autopkglib.add_recipe_to_map(recipe_path, is_override=False)
+
+        self.assertEqual(
+            autopkglib.globalRecipeMap["identifiers"][SAMPLE_RECIPE["Identifier"]],
+            recipe_path,
+        )
+        self.assertEqual(
+            autopkglib.globalRecipeMap["shortnames"]["Sample"], recipe_path
+        )
+        # Persisted to disk with the new entry.
+        self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
+
+    def test_add_recipe_to_map_respects_first_wins(self):
+        """Adding a second recipe with the same identifier must NOT
+        overwrite the existing entry (matches map_key_to_paths)."""
+        recipes_dir = os.path.join(self.tmpdir, "repo")
+        os.makedirs(recipes_dir)
+        first = os.path.join(recipes_dir, "First.recipe")
+        second = os.path.join(recipes_dir, "Second.recipe")
+        _write_plist_recipe(first, SAMPLE_RECIPE)
+        _write_plist_recipe(second, SAMPLE_RECIPE)  # same Identifier
+
+        autopkglib.add_recipe_to_map(first, is_override=False)
+        autopkglib.add_recipe_to_map(second, is_override=False)
+
+        self.assertEqual(
+            autopkglib.globalRecipeMap["identifiers"][SAMPLE_RECIPE["Identifier"]],
+            first,
+            "Second add must not overwrite the first (first-wins).",
+        )
+
+    def test_add_recipe_to_map_noops_when_disabled(self):
+        """Escape hatch: when the map is disabled, add_recipe_to_map
+        is a silent no-op."""
+        recipes_dir = os.path.join(self.tmpdir, "repo")
+        os.makedirs(recipes_dir)
+        recipe_path = os.path.join(recipes_dir, "Sample.recipe")
+        _write_plist_recipe(recipe_path, SAMPLE_RECIPE)
+
+        with patch.dict(os.environ, {"AUTOPKG_DISABLE_RECIPE_MAP": "1"}):
+            autopkglib.add_recipe_to_map(recipe_path, is_override=False)
+
+        self.assertNotIn(
+            SAMPLE_RECIPE["Identifier"],
+            autopkglib.globalRecipeMap.get("identifiers", {}),
+        )
+        self.assertFalse(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
 
 
 class TestRepoUpdateHeadDiffing(_RecipeMapIsolation, unittest.TestCase):

--- a/Code/tests/test_autopkg_recipe_map_regressions.py
+++ b/Code/tests/test_autopkg_recipe_map_regressions.py
@@ -326,20 +326,68 @@ class TestIssue903TrustInfoByPath(_RecipeMapIsolation, unittest.TestCase):
     user-supplied path. The fix uses the recipe map's overrides tables
     as the source of truth."""
 
-    def test_recipe_in_override_dir_via_map(self):
-        """A file listed in globalRecipeMap['overrides'] is considered
-        an override even when the path's parent isn't in override_dirs."""
-        override_path = os.path.join(self.tmpdir, "some", "path.recipe")
+    def test_recipe_in_override_dir_via_map_and_configured_dir(self):
+        """A file listed in globalRecipeMap['overrides'] AND residing
+        under a configured override dir is considered an override. The
+        map is a hint; the configured dir is the authoritative answer.
+        This is the shape of the #903 fix after the F-4 security
+        hardening."""
+        override_dir = os.path.join(self.tmpdir, "overrides")
+        os.makedirs(override_dir)
+        override_path = os.path.join(override_dir, "path.recipe")
         autopkglib.globalRecipeMap["overrides"]["SomeOverride"] = override_path
-        # override_dirs is deliberately empty — the map is what tells us
-        # this is an override.
-        self.assertTrue(autopkg.recipe_in_override_dir(override_path, override_dirs=[]))
+        self.assertTrue(autopkg.recipe_in_override_dir(override_path, [override_dir]))
 
-    def test_recipe_in_override_dir_via_map_identifiers_table(self):
-        """Same, but through the overrides-identifiers table."""
-        override_path = os.path.join(self.tmpdir, "o", "by-id.recipe")
+    def test_recipe_in_override_dir_via_map_identifiers_and_configured_dir(
+        self,
+    ):
+        """Same via the overrides-identifiers table."""
+        override_dir = os.path.join(self.tmpdir, "o")
+        os.makedirs(override_dir)
+        override_path = os.path.join(override_dir, "by-id.recipe")
         autopkglib.globalRecipeMap["overrides-identifiers"]["local.byid"] = (
             override_path
+        )
+        self.assertTrue(autopkg.recipe_in_override_dir(override_path, [override_dir]))
+
+    def test_recipe_in_override_dir_via_map_but_not_under_configured_dir(
+        self,
+    ):
+        """Security F-4: a map entry that points OUTSIDE any configured
+        override dir must NOT be trusted. This blocks the attack where
+        an attacker with write access to recipe_map.json plants an
+        arbitrary path in the overrides table to bypass trust checks."""
+        bogus_path = os.path.join(self.tmpdir, "notanoverridedir", "Sneaky.recipe")
+        autopkglib.globalRecipeMap["overrides"]["Sneaky"] = bogus_path
+
+        configured_dir = os.path.join(self.tmpdir, "configured_overrides")
+        with patch.object(autopkg, "log_err") as mock_log_err:
+            self.assertFalse(
+                autopkg.recipe_in_override_dir(bogus_path, [configured_dir])
+            )
+            # Should have logged a warning about the bogus map entry.
+            mock_log_err.assert_called()
+
+    def test_recipe_in_override_dir_via_configured_dir(self):
+        """The existing path-prefix check still works for files that the
+        map hasn't indexed yet."""
+        override_dir = os.path.join(self.tmpdir, "configured_overrides")
+        override_path = os.path.join(override_dir, "Unindexed.recipe")
+        self.assertTrue(autopkg.recipe_in_override_dir(override_path, [override_dir]))
+
+    def test_recipe_in_override_dir_negative(self):
+        """A file neither in the map nor under any configured override
+        dir is NOT classified as an override."""
+        self.assertFalse(
+            autopkg.recipe_in_override_dir("/some/random/Recipe.recipe", [self.tmpdir])
+        )
+
+    def test_recipe_in_override_dir_sibling_prefix_not_matched(self):
+        """Regression: prior to the fix, `/Users/a/Library/AutoPkg2`
+        could accidentally match `/Users/a/Library/AutoPkg`. Make sure
+        the normalised match requires a path separator."""
+        self.assertFalse(
+            autopkg.recipe_in_override_dir("/a/AutoPkg2/file.recipe", ["/a/AutoPkg"])
         )
         self.assertTrue(autopkg.recipe_in_override_dir(override_path, override_dirs=[]))
 
@@ -583,35 +631,42 @@ class TestAtomicWrite(_RecipeMapIsolation, unittest.TestCase):
     can't observe a half-written file (review recommendation: atomic
     writes for on-disk cache files)."""
 
-    def test_write_uses_tmp_and_replace(self):
-        """Verify write_recipe_map_to_disk writes to <path>.tmp then
-        renames into position."""
-        observed_writes: list[str] = []
-        real_open = open
+    def test_write_uses_mkstemp_and_replace(self):
+        """Verify write_recipe_map_to_disk writes via tempfile.mkstemp
+        (O_EXCL semantics) and renames into position. Security fix for
+        F-3: a plain open(tmp, 'w') would follow a pre-existing symlink."""
+        observed: dict = {"mkstemp_calls": 0, "replace_calls": 0}
+        import tempfile as real_tempfile
 
-        def tracking_open(path, *args, **kwargs):
-            if isinstance(path, str) and path.endswith(".json.tmp"):
-                observed_writes.append(path)
-            return real_open(path, *args, **kwargs)
+        real_mkstemp = real_tempfile.mkstemp
+        real_replace = os.replace
 
-        with patch("builtins.open", side_effect=tracking_open):
+        def tracking_mkstemp(*args, **kwargs):
+            observed["mkstemp_calls"] += 1
+            return real_mkstemp(*args, **kwargs)
+
+        def tracking_replace(src, dst):
+            observed["replace_calls"] += 1
+            return real_replace(src, dst)
+
+        with (
+            patch("tempfile.mkstemp", side_effect=tracking_mkstemp),
+            patch("os.replace", side_effect=tracking_replace),
+        ):
             autopkglib.write_recipe_map_to_disk()
 
-        self.assertTrue(
-            observed_writes,
-            "write_recipe_map_to_disk should have written to a .tmp file first.",
+        self.assertEqual(
+            observed["mkstemp_calls"],
+            1,
+            "write_recipe_map_to_disk should use tempfile.mkstemp.",
         )
-        # Final file exists; temp file was cleaned up (renamed away).
+        self.assertEqual(observed["replace_calls"], 1)
         self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
-        self.assertFalse(
-            os.path.exists(autopkglib.DEFAULT_RECIPE_MAP + ".tmp"),
-            "Temp file should have been renamed into position.",
-        )
 
     def test_write_failure_latches_and_is_silent_on_second_call(self):
         """First OSError logs a warning and latches the write-disabled
         flag so subsequent calls in the same process are no-ops."""
-        with patch("builtins.open", side_effect=OSError("no space left")):
+        with patch("tempfile.mkstemp", side_effect=OSError("no space left")):
             with patch.object(autopkglib, "log_err") as mock_log_err:
                 autopkglib.write_recipe_map_to_disk()
                 # First call logs.
@@ -620,31 +675,22 @@ class TestAtomicWrite(_RecipeMapIsolation, unittest.TestCase):
                 # Second call is a silent no-op.
                 self.assertEqual(mock_log_err.call_count, 1)
 
-    def test_failed_temp_file_is_cleaned_up(self):
-        """A failed write must not leave the .tmp turd on disk."""
-        target = autopkglib.DEFAULT_RECIPE_MAP
-        tmp = target + ".tmp"
+    def test_failed_replace_cleans_up_tempfile(self):
+        """A failed os.replace must not leave the tempfile behind."""
+        import glob as _glob
 
-        def fail_after_partial_write(path, *args, **kwargs):
-            # Write a partial tempfile then raise.
-            if path.endswith(".tmp"):
-                with (
-                    open.__wrapped__(path, *args, **kwargs)
-                    if hasattr(open, "__wrapped__")
-                    else open(path, *args, **kwargs) as f
-                ):
-                    f.write("partial")
-                raise OSError("interrupted")
-            return open(path, *args, **kwargs)
-
-        # Simpler approach: use the real open but patch os.replace to fail.
         autopkglib._recipe_map_write_disabled = False
+        map_dir = os.path.dirname(autopkglib.DEFAULT_RECIPE_MAP)
+        # Ensure dir exists so mkstemp can create there.
+        os.makedirs(map_dir, exist_ok=True)
         with patch("os.replace", side_effect=OSError("nope")):
             autopkglib.write_recipe_map_to_disk()
 
+        # No leftover tempfile matching our naming pattern should remain.
+        leftovers = _glob.glob(os.path.join(map_dir, ".recipe_map.json.tmp*"))
         self.assertFalse(
-            os.path.exists(tmp),
-            "Temp file should have been unlinked after the failed replace.",
+            leftovers,
+            f"Tempfile(s) should have been cleaned up but found: {leftovers}",
         )
 
 

--- a/Code/tests/test_autopkg_recipe_map_regressions.py
+++ b/Code/tests/test_autopkg_recipe_map_regressions.py
@@ -1,0 +1,896 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests pinned to specific upstream issues closed by the
+recipe-map backport. Each test class has a docstring citing the GitHub
+issue number so future changes that break the behaviour show up in CI
+with a direct pointer to the original bug report."""
+
+import importlib
+import importlib.machinery
+import json
+import os
+import plistlib
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import autopkglib
+
+autopkg_path = os.path.join(os.path.dirname(__file__), "..", "autopkg")
+loader = importlib.machinery.SourceFileLoader("autopkg", autopkg_path)
+autopkg = loader.load_module()
+sys.modules["autopkg"] = autopkg
+
+
+SAMPLE_RECIPE = {
+    "Description": "Sample test recipe.",
+    "Identifier": "com.example.test.sample",
+    "Input": {"NAME": "Sample"},
+    "MinimumVersion": "2.3",
+    "Process": [{"Processor": "URLDownloader"}],
+}
+
+SAMPLE_OVERRIDE = {
+    "Identifier": "local.sample.override",
+    "Input": {"NAME": "Sample"},
+    "ParentRecipe": "com.example.test.sample",
+    "ParentRecipeTrustInfo": {"parent_recipes": {}, "non_core_processors": {}},
+}
+
+
+def _write_plist_recipe(path, recipe_dict):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        plistlib.dump(recipe_dict, f)
+
+
+class _RecipeMapIsolation:
+    """Shared fixture: redirect DEFAULT_RECIPE_MAP to a per-test tempdir
+    and reset globalRecipeMap between tests."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="autopkg_regression_")
+        self.addCleanup(lambda: shutil.rmtree(self.tmpdir, ignore_errors=True))
+
+        self._saved_map = dict(autopkglib.globalRecipeMap)
+        self._saved_default = autopkglib.DEFAULT_RECIPE_MAP
+        self._saved_write_disabled = autopkglib._recipe_map_write_disabled
+        autopkglib._recipe_map_write_disabled = False
+        autopkglib.DEFAULT_RECIPE_MAP = os.path.join(self.tmpdir, "recipe_map.json")
+        autopkg.DEFAULT_RECIPE_MAP = autopkglib.DEFAULT_RECIPE_MAP
+
+        for sub in (
+            "identifiers",
+            "shortnames",
+            "overrides",
+            "overrides-identifiers",
+        ):
+            autopkglib.globalRecipeMap.setdefault(sub, {}).clear()
+
+        # Reset the cross-test latch so one test's miss-rebuild doesn't
+        # prevent another test from exercising the same code path.
+        autopkg._set_locate_recipe_rebuild_attempted(False)
+
+    def tearDown(self):
+        autopkglib.globalRecipeMap.clear()
+        autopkglib.globalRecipeMap.update(self._saved_map)
+        autopkglib.DEFAULT_RECIPE_MAP = self._saved_default
+        autopkg.DEFAULT_RECIPE_MAP = self._saved_default
+        autopkglib._recipe_map_write_disabled = self._saved_write_disabled
+
+
+class TestIssue918And908And886CliPrecedence(_RecipeMapIsolation, unittest.TestCase):
+    """Regression tests for upstream issues #886, #908, #918 (related to
+    #894): the recipe map is pref-scoped, so when the user passes
+    ``--search-dir`` / ``--override-dir`` with values that differ from the
+    configured preferences, autopkg must scan those dirs directly rather
+    than silently returning whatever the map happens to know about.
+
+    See https://github.com/autopkg/autopkg/issues/918 for the original
+    report. The old dev-2.x on-disk scanner respected the CLI flags; the
+    initial backport of the map silently broke that contract."""
+
+    def setUp(self):
+        super().setUp()
+        # "Primary" repo configured in prefs - goes into the map.
+        self.primary_dir = os.path.join(self.tmpdir, "primary")
+        os.makedirs(self.primary_dir)
+        _write_plist_recipe(
+            os.path.join(self.primary_dir, "Primary.recipe"),
+            {**SAMPLE_RECIPE, "Identifier": "com.example.primary"},
+        )
+        # "Scoped" dir is the CLI-supplied one, NOT in prefs, NOT in map.
+        self.scoped_dir = os.path.join(self.tmpdir, "scoped")
+        os.makedirs(self.scoped_dir)
+        _write_plist_recipe(
+            os.path.join(self.scoped_dir, "Scoped.recipe"),
+            {**SAMPLE_RECIPE, "Identifier": "com.example.scoped"},
+        )
+
+        # Seed the in-memory map as if `generate-recipe-map` had been run
+        # when only the primary dir was configured.
+        autopkglib.globalRecipeMap.update(
+            {
+                "identifiers": {
+                    "com.example.primary": os.path.join(
+                        self.primary_dir, "Primary.recipe"
+                    )
+                },
+                "shortnames": {
+                    "Primary": os.path.join(self.primary_dir, "Primary.recipe")
+                },
+                "overrides": {},
+                "overrides-identifiers": {},
+            }
+        )
+
+        # Pin the pref-backed dirs so _dirs_match_prefs compares against a
+        # known baseline.
+        self._prefs_patcher = patch.object(
+            autopkglib,
+            "get_pref",
+            side_effect=lambda k: {
+                "RECIPE_SEARCH_DIRS": [self.primary_dir],
+            }.get(k),
+        )
+        self._prefs_patcher.start()
+        self.addCleanup(self._prefs_patcher.stop)
+        self._override_patcher = patch.object(
+            autopkglib, "get_override_dirs", return_value=[]
+        )
+        self._override_patcher.start()
+        self.addCleanup(self._override_patcher.stop)
+
+    def test_cli_search_dir_not_in_prefs_is_scanned_on_disk(self):
+        """User running `autopkg run -d /scoped Scoped` must find the
+        recipe in /scoped even though the persisted map knows nothing
+        about it."""
+        result = autopkg.find_recipe(
+            "com.example.scoped", search_dirs=[self.scoped_dir]
+        )
+        self.assertEqual(result, os.path.join(self.scoped_dir, "Scoped.recipe"))
+
+    def test_cli_search_dir_wins_over_map_for_same_identifier(self):
+        """When the CLI dir contains a recipe with the same identifier as
+        one in the map, the CLI dir version wins. This is the dev-2.x
+        contract (recipes in the Recipes/ folder override those in
+        installed repos) that #886 documents."""
+        # Create a /scoped copy with the SAME identifier as the one in
+        # the map but a different location.
+        same_id_path = os.path.join(self.scoped_dir, "LocalOverrideOfPrimary.recipe")
+        _write_plist_recipe(
+            same_id_path,
+            {**SAMPLE_RECIPE, "Identifier": "com.example.primary"},
+        )
+
+        result = autopkg.find_recipe(
+            "com.example.primary", search_dirs=[self.scoped_dir]
+        )
+        self.assertEqual(
+            result,
+            same_id_path,
+            "CLI-supplied dir must take precedence over the map.",
+        )
+
+    def test_no_cli_dirs_uses_map(self):
+        """The common case: no CLI dirs → map-first."""
+        # Add a pref-dir entry that _also_ exists on disk so find_recipe's
+        # _dirs_match_prefs check passes.
+        result = autopkg.find_recipe("com.example.primary")
+        self.assertEqual(result, os.path.join(self.primary_dir, "Primary.recipe"))
+
+    def test_empty_cli_dirs_falls_back_to_prefs(self):
+        """Passing an empty list / None should be equivalent to omitting
+        the kwarg — map-first stays in effect."""
+        self.assertEqual(
+            autopkg.find_recipe("com.example.primary", search_dirs=[]),
+            os.path.join(self.primary_dir, "Primary.recipe"),
+        )
+        self.assertEqual(
+            autopkg.find_recipe("com.example.primary", search_dirs=None),
+            os.path.join(self.primary_dir, "Primary.recipe"),
+        )
+
+
+class TestIssue894ProcessorLookup(_RecipeMapIsolation, unittest.TestCase):
+    """Regression tests for issue #894: shared-processor recipes in the
+    current working directory weren't being found because
+    find_processor_path only walked RECIPE_SEARCH_DIRS on disk, ignoring
+    the map, and never triggered the cwd-inclusive rebuild."""
+
+    def test_find_processor_path_map_hit(self):
+        """A shared-processor identifier present in the map is resolved
+        without any on-disk scan."""
+        # Write a real recipe on disk so find_recipe_by_id_in_map's
+        # valid_recipe_file check succeeds.
+        shared_dir = os.path.join(self.tmpdir, "shared")
+        os.makedirs(shared_dir)
+        shared_recipe = os.path.join(shared_dir, "SharedRecipe.recipe")
+        _write_plist_recipe(
+            shared_recipe,
+            {**SAMPLE_RECIPE, "Identifier": "com.example.shared"},
+        )
+        autopkglib.globalRecipeMap["identifiers"]["com.example.shared"] = shared_recipe
+
+        with (
+            patch("autopkg.find_recipe_by_identifier_on_disk") as mock_disk,
+            # Make the processor file appear to exist so the verb returns
+            # a truthy path.
+            patch(
+                "os.path.exists",
+                side_effect=lambda p: p.endswith("MyProc.py"),
+            ),
+        ):
+            result = autopkg.find_processor_path(
+                "com.example.shared/MyProc",
+                recipe={"RECIPE_PATH": "/recipes/x.recipe"},
+                env={"RECIPE_SEARCH_DIRS": []},
+            )
+        self.assertIsNotNone(result)
+        # On-disk scan must NOT have been invoked.
+        mock_disk.assert_not_called()
+
+    def test_find_processor_path_falls_back_to_disk(self):
+        """If the map doesn't know the identifier, on-disk fallback
+        kicks in — preserving the legacy behaviour."""
+        with (
+            patch(
+                "autopkg.find_recipe_by_identifier_on_disk",
+                return_value="/disk/Shared.recipe",
+            ) as mock_disk,
+            patch("os.path.exists", return_value=True),
+        ):
+            autopkg.find_processor_path(
+                "com.example.notmapped/MyProc",
+                recipe={"RECIPE_PATH": "/recipes/x.recipe"},
+                env={"RECIPE_SEARCH_DIRS": ["/search"]},
+            )
+        mock_disk.assert_called_once_with("com.example.notmapped", ["/search"])
+
+    def test_find_processor_path_triggers_cwd_rebuild_once(self):
+        """Issue #894: when a shared-processor recipe lives in the cwd,
+        find_processor_path should trigger a one-shot cwd-inclusive
+        rebuild. Subsequent misses in the same process must NOT trigger
+        a second rebuild (review recommendation: avoid pathological
+        multi-miss rebuilds)."""
+        autopkg._set_locate_recipe_rebuild_attempted(False)
+
+        # Write a real recipe for the first lookup so the rebuild has
+        # something to find.
+        cwd_dir = os.path.join(self.tmpdir, "cwd")
+        os.makedirs(cwd_dir)
+        shared_recipe = os.path.join(cwd_dir, "Shared.recipe")
+        _write_plist_recipe(
+            shared_recipe,
+            {**SAMPLE_RECIPE, "Identifier": "com.example.cwd.shared"},
+        )
+
+        def fake_calc(*args, **kwargs):
+            autopkglib.globalRecipeMap["identifiers"]["com.example.cwd.shared"] = (
+                shared_recipe
+            )
+
+        with (
+            patch("autopkg.calculate_recipe_map", side_effect=fake_calc) as mock_calc,
+            patch(
+                "autopkg.find_recipe_by_identifier_on_disk",
+                return_value=None,
+            ),
+        ):
+            # First call: map miss → rebuild once → find in rebuilt map.
+            autopkg.find_processor_path(
+                "com.example.cwd.shared/MyProc",
+                recipe={"RECIPE_PATH": "/recipes/x.recipe"},
+                env={"RECIPE_SEARCH_DIRS": []},
+            )
+            first_calls = mock_calc.call_count
+            self.assertEqual(
+                first_calls,
+                1,
+                "First map miss should trigger exactly one rebuild.",
+            )
+
+            # Second call with a different unmapped identifier: latch
+            # prevents another rebuild.
+            autopkg.find_processor_path(
+                "com.example.other.shared/MyProc",
+                recipe={"RECIPE_PATH": "/recipes/x.recipe"},
+                env={"RECIPE_SEARCH_DIRS": []},
+            )
+            self.assertEqual(
+                mock_calc.call_count,
+                first_calls,
+                "Second miss must not trigger another full rebuild "
+                "Pathological multi-miss runs must not trigger N full rebuilds.",
+            )
+
+
+class TestIssue903TrustInfoByPath(_RecipeMapIsolation, unittest.TestCase):
+    """Regression test for issue #903: `autopkg verify-trust-info
+    <path/to/override.recipe>` failed to recognise the file as an override
+    because the configured override_dirs didn't contain the parent of the
+    user-supplied path. The fix uses the recipe map's overrides tables
+    as the source of truth."""
+
+    def test_recipe_in_override_dir_via_map(self):
+        """A file listed in globalRecipeMap['overrides'] is considered
+        an override even when the path's parent isn't in override_dirs."""
+        override_path = os.path.join(self.tmpdir, "some", "path.recipe")
+        autopkglib.globalRecipeMap["overrides"]["SomeOverride"] = override_path
+        # override_dirs is deliberately empty — the map is what tells us
+        # this is an override.
+        self.assertTrue(autopkg.recipe_in_override_dir(override_path, override_dirs=[]))
+
+    def test_recipe_in_override_dir_via_map_identifiers_table(self):
+        """Same, but through the overrides-identifiers table."""
+        override_path = os.path.join(self.tmpdir, "o", "by-id.recipe")
+        autopkglib.globalRecipeMap["overrides-identifiers"]["local.byid"] = (
+            override_path
+        )
+        self.assertTrue(autopkg.recipe_in_override_dir(override_path, override_dirs=[]))
+
+    def test_recipe_in_override_dir_via_configured_dir(self):
+        """The existing path-prefix check still works for files that the
+        map hasn't indexed yet."""
+        override_dir = os.path.join(self.tmpdir, "configured_overrides")
+        override_path = os.path.join(override_dir, "Unindexed.recipe")
+        self.assertTrue(autopkg.recipe_in_override_dir(override_path, [override_dir]))
+
+    def test_recipe_in_override_dir_negative(self):
+        """A file neither in the map nor under any configured override
+        dir is NOT classified as an override."""
+        self.assertFalse(
+            autopkg.recipe_in_override_dir("/some/random/Recipe.recipe", [self.tmpdir])
+        )
+
+    def test_recipe_in_override_dir_sibling_prefix_not_matched(self):
+        """Regression: prior to the fix, `/Users/a/Library/AutoPkg2`
+        could accidentally match `/Users/a/Library/AutoPkg`. Make sure
+        the normalised match requires a path separator."""
+        self.assertFalse(
+            autopkg.recipe_in_override_dir("/a/AutoPkg2/file.recipe", ["/a/AutoPkg"])
+        )
+
+
+class TestIssue874MissingOverridesIdentifiers(_RecipeMapIsolation, unittest.TestCase):
+    """Regression for issue #874: a map file written by an older version
+    of autopkg doesn't have the ``overrides-identifiers`` key. The old
+    code did ``globalRecipeMap["overrides-identifiers"]`` directly,
+    producing a KeyError. The backport must either tolerate the missing
+    key OR reject the file and trigger a rebuild."""
+
+    def test_legacy_map_without_overrides_identifiers_is_rejected(self):
+        """A persisted map missing the key should be treated as invalid
+        and trigger an auto-rebuild rather than crashing."""
+        legacy = {
+            "identifiers": {"com.example.a": "/a.recipe"},
+            "shortnames": {"A": "/a.recipe"},
+            "overrides": {},
+            # no 'overrides-identifiers' key on purpose
+        }
+        with open(autopkglib.DEFAULT_RECIPE_MAP, "w") as f:
+            json.dump(legacy, f)
+
+        self.assertFalse(autopkglib.validate_recipe_map(legacy))
+
+        with patch.object(autopkglib, "calculate_recipe_map") as mock_calc:
+            autopkglib.read_recipe_map()
+            mock_calc.assert_called_once()
+
+    def test_lookup_tolerates_missing_key_in_memory(self):
+        """Even if globalRecipeMap is mutated by a third party to drop
+        the key, lookups should not raise KeyError."""
+        autopkglib.globalRecipeMap.pop("overrides-identifiers", None)
+        try:
+            self.assertIsNone(
+                autopkglib.find_recipe_by_id_in_map("com.example.anything")
+            )
+        except KeyError:
+            self.fail(
+                "find_recipe_by_id_in_map raised KeyError when the "
+                "'overrides-identifiers' key was missing."
+            )
+
+
+class TestIssue869InvalidRecipeRobustness(_RecipeMapIsolation, unittest.TestCase):
+    """Regression for issue #869: a syntactically-invalid recipe in a
+    search dir used to crash ``calculate_recipe_map`` with a TypeError
+    during the JSON sort because ``get_identifier_from_recipe_file``
+    returned None. The backport must skip such files with a warning."""
+
+    def test_invalid_recipe_does_not_crash_map_build(self):
+        repo_dir = os.path.join(self.tmpdir, "bad_repo")
+        os.makedirs(repo_dir)
+        # A corrupt plist file with a .recipe extension.
+        with open(os.path.join(repo_dir, "Broken.recipe"), "wb") as f:
+            f.write(b'<?xml version="1.0"?><broken!!!><not-a-recipe/>')
+        # A second, valid recipe so the map has something to load.
+        _write_plist_recipe(
+            os.path.join(repo_dir, "OK.recipe"),
+            {**SAMPLE_RECIPE, "Identifier": "com.example.ok"},
+        )
+
+        with patch.object(
+            autopkglib,
+            "get_pref",
+            side_effect=lambda k: {
+                "RECIPE_SEARCH_DIRS": [repo_dir],
+            }.get(k),
+        ):
+            # Must not raise.
+            autopkglib.calculate_recipe_map()
+
+        # Valid recipe indexed, broken one skipped.
+        self.assertIn(
+            "com.example.ok",
+            autopkglib.globalRecipeMap["identifiers"],
+        )
+        self.assertEqual(
+            len(autopkglib.globalRecipeMap["identifiers"]),
+            1,
+            "Broken recipe should not have been added to the map.",
+        )
+
+    def test_recipe_without_identifier_does_not_crash(self):
+        """A valid-plist recipe that's missing an Identifier field is
+        skipped, not added with a None key."""
+        repo_dir = os.path.join(self.tmpdir, "no_id_repo")
+        os.makedirs(repo_dir)
+        _write_plist_recipe(
+            os.path.join(repo_dir, "NoIdentifier.recipe"),
+            {
+                "Input": {"NAME": "Foo"},
+                "Process": [{"Processor": "URLDownloader"}],
+            },
+        )
+
+        with patch.object(
+            autopkglib,
+            "get_pref",
+            side_effect=lambda k: {
+                "RECIPE_SEARCH_DIRS": [repo_dir],
+            }.get(k),
+        ):
+            autopkglib.calculate_recipe_map()
+
+        self.assertNotIn(None, autopkglib.globalRecipeMap["identifiers"])
+        self.assertEqual(autopkglib.globalRecipeMap["identifiers"], {})
+
+
+class TestIssue901RecipeMapPathOverride(unittest.TestCase):
+    """Regression for issue #901: the recipe map location should be
+    configurable so CI pipelines that don't use ``~/Library/AutoPkg``
+    (e.g. ephemeral runners that clone everything into ``/workspace``)
+    can keep the map alongside their recipes."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="autopkg_mp_")
+        self.addCleanup(lambda: shutil.rmtree(self.tmpdir, ignore_errors=True))
+
+    def test_env_var_overrides_default_path(self):
+        """AUTOPKG_RECIPE_MAP_PATH takes precedence over the default."""
+        custom = os.path.join(self.tmpdir, "my_map.json")
+        with patch.dict(os.environ, {"AUTOPKG_RECIPE_MAP_PATH": custom}):
+            self.assertEqual(autopkglib._recipe_map_path(), custom)
+
+    def test_env_var_takes_precedence_over_pref(self):
+        """Env beats pref so CI can override a baked-in config."""
+        env_path = os.path.join(self.tmpdir, "env.json")
+        pref_path = os.path.join(self.tmpdir, "pref.json")
+        with (
+            patch.dict(os.environ, {"AUTOPKG_RECIPE_MAP_PATH": env_path}),
+            patch.object(
+                autopkglib,
+                "get_pref",
+                side_effect=lambda k: pref_path if k == "RECIPE_MAP_PATH" else None,
+            ),
+        ):
+            self.assertEqual(autopkglib._recipe_map_path(), env_path)
+
+    def test_pref_used_when_no_env(self):
+        """Without the env var, the RECIPE_MAP_PATH pref wins."""
+        pref_path = os.path.join(self.tmpdir, "pref.json")
+        # Clear the env var explicitly so this test works even if the
+        # developer has it set in their shell.
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch.object(
+                autopkglib,
+                "get_pref",
+                side_effect=lambda k: pref_path if k == "RECIPE_MAP_PATH" else None,
+            ),
+        ):
+            os.environ.pop("AUTOPKG_RECIPE_MAP_PATH", None)
+            self.assertEqual(autopkglib._recipe_map_path(), pref_path)
+
+    def test_default_used_when_neither_env_nor_pref(self):
+        """Falls back to the user's ~/Library/AutoPkg/recipe_map.json."""
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch.object(autopkglib, "get_pref", return_value=None),
+        ):
+            os.environ.pop("AUTOPKG_RECIPE_MAP_PATH", None)
+            expected = os.path.abspath(
+                os.path.expanduser(autopkglib.DEFAULT_RECIPE_MAP)
+            )
+            self.assertEqual(autopkglib._recipe_map_path(), expected)
+
+
+class TestSchemaVersion(_RecipeMapIsolation, unittest.TestCase):
+    """Tests for the RECIPE_MAP_SCHEMA_VERSION field added for forward-
+    compatibility."""
+
+    def test_persisted_file_includes_schema_version(self):
+        autopkglib.globalRecipeMap["identifiers"]["x"] = "/x.recipe"
+        autopkglib.write_recipe_map_to_disk()
+        with open(autopkglib.DEFAULT_RECIPE_MAP) as f:
+            on_disk = json.load(f)
+        self.assertEqual(
+            on_disk["schema_version"], autopkglib.RECIPE_MAP_SCHEMA_VERSION
+        )
+
+    def test_current_version_is_valid(self):
+        ok = {
+            "identifiers": {},
+            "shortnames": {},
+            "overrides": {},
+            "overrides-identifiers": {},
+            "schema_version": autopkglib.RECIPE_MAP_SCHEMA_VERSION,
+        }
+        self.assertTrue(autopkglib.validate_recipe_map(ok))
+
+    def test_legacy_file_without_version_is_accepted(self):
+        """Older map files predate the schema_version field; treat them
+        as v1 rather than forcing an unnecessary rebuild."""
+        legacy = {
+            "identifiers": {},
+            "shortnames": {},
+            "overrides": {},
+            "overrides-identifiers": {},
+        }
+        self.assertTrue(autopkglib.validate_recipe_map(legacy))
+
+    def test_future_version_is_rejected(self):
+        """A future version number means the format may be
+        incompatible; reject so we trigger a rebuild at this version's
+        level."""
+        future = {
+            "identifiers": {},
+            "shortnames": {},
+            "overrides": {},
+            "overrides-identifiers": {},
+            "schema_version": 999,
+        }
+        self.assertFalse(autopkglib.validate_recipe_map(future))
+
+
+class TestAtomicWrite(_RecipeMapIsolation, unittest.TestCase):
+    """The map write must be atomic so concurrent autopkg invocations
+    can't observe a half-written file (review recommendation: atomic
+    writes for on-disk cache files)."""
+
+    def test_write_uses_tmp_and_replace(self):
+        """Verify write_recipe_map_to_disk writes to <path>.tmp then
+        renames into position."""
+        observed_writes: list[str] = []
+        real_open = open
+
+        def tracking_open(path, *args, **kwargs):
+            if isinstance(path, str) and path.endswith(".json.tmp"):
+                observed_writes.append(path)
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=tracking_open):
+            autopkglib.write_recipe_map_to_disk()
+
+        self.assertTrue(
+            observed_writes,
+            "write_recipe_map_to_disk should have written to a .tmp file first.",
+        )
+        # Final file exists; temp file was cleaned up (renamed away).
+        self.assertTrue(os.path.exists(autopkglib.DEFAULT_RECIPE_MAP))
+        self.assertFalse(
+            os.path.exists(autopkglib.DEFAULT_RECIPE_MAP + ".tmp"),
+            "Temp file should have been renamed into position.",
+        )
+
+    def test_write_failure_latches_and_is_silent_on_second_call(self):
+        """First OSError logs a warning and latches the write-disabled
+        flag so subsequent calls in the same process are no-ops."""
+        with patch("builtins.open", side_effect=OSError("no space left")):
+            with patch.object(autopkglib, "log_err") as mock_log_err:
+                autopkglib.write_recipe_map_to_disk()
+                # First call logs.
+                self.assertEqual(mock_log_err.call_count, 1)
+                autopkglib.write_recipe_map_to_disk()
+                # Second call is a silent no-op.
+                self.assertEqual(mock_log_err.call_count, 1)
+
+    def test_failed_temp_file_is_cleaned_up(self):
+        """A failed write must not leave the .tmp turd on disk."""
+        target = autopkglib.DEFAULT_RECIPE_MAP
+        tmp = target + ".tmp"
+
+        def fail_after_partial_write(path, *args, **kwargs):
+            # Write a partial tempfile then raise.
+            if path.endswith(".tmp"):
+                with (
+                    open.__wrapped__(path, *args, **kwargs)
+                    if hasattr(open, "__wrapped__")
+                    else open(path, *args, **kwargs) as f
+                ):
+                    f.write("partial")
+                raise OSError("interrupted")
+            return open(path, *args, **kwargs)
+
+        # Simpler approach: use the real open but patch os.replace to fail.
+        autopkglib._recipe_map_write_disabled = False
+        with patch("os.replace", side_effect=OSError("nope")):
+            autopkglib.write_recipe_map_to_disk()
+
+        self.assertFalse(
+            os.path.exists(tmp),
+            "Temp file should have been unlinked after the failed replace.",
+        )
+
+
+class TestEscapeHatch(_RecipeMapIsolation, unittest.TestCase):
+    """The AUTOPKG_DISABLE_RECIPE_MAP / DISABLE_RECIPE_MAP escape hatch
+    (review recommendation: provide an operational bypass)."""
+
+    def test_env_var_disables_map_reading(self):
+        with patch.dict(os.environ, {"AUTOPKG_DISABLE_RECIPE_MAP": "1"}):
+            self.assertTrue(autopkglib._recipe_map_disabled())
+            # read_recipe_map should be a no-op.
+            before = dict(autopkglib.globalRecipeMap)
+            autopkglib.read_recipe_map()
+            self.assertEqual(autopkglib.globalRecipeMap, before)
+
+    def test_pref_disables_map_reading(self):
+        with patch.object(
+            autopkglib,
+            "get_pref",
+            side_effect=lambda k: True if k == "DISABLE_RECIPE_MAP" else None,
+        ):
+            self.assertTrue(autopkglib._recipe_map_disabled())
+
+    def test_disabled_flag_skips_writes(self):
+        """When disabled, write_recipe_map_to_disk doesn't touch the
+        filesystem."""
+        with patch.dict(os.environ, {"AUTOPKG_DISABLE_RECIPE_MAP": "1"}):
+            autopkglib.write_recipe_map_to_disk()
+        self.assertFalse(
+            os.path.exists(autopkglib.DEFAULT_RECIPE_MAP),
+            "Map file should not be written when the escape hatch is set.",
+        )
+
+
+class TestRepoAddSingleRebuild(_RecipeMapIsolation, unittest.TestCase):
+    """Regression: repo-add was calling calculate_recipe_map() twice.
+    Assert it now calls it exactly once."""
+
+    def test_repo_add_rebuilds_map_exactly_once(self):
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.get_search_dirs", return_value=[]),
+            patch("autopkg.get_pref", return_value={}),
+            patch("autopkg.expand_repo_url", side_effect=lambda x: x),
+            patch(
+                "autopkg.get_recipe_repo",
+                return_value="/cloned/repo",
+            ),
+            patch("autopkg.save_pref_or_warn"),
+            patch("autopkg.log"),
+            patch("autopkg.read_recipe_map"),
+            patch("autopkg.calculate_recipe_map") as mock_calc,
+        ):
+            mock_parser.return_value = Mock()
+            mock_parse.return_value = (Mock(), ["recipes"])
+
+            autopkg.repo_add([None, "repo-add", "recipes"])
+
+        self.assertEqual(
+            mock_calc.call_count,
+            1,
+            "repo-add should call calculate_recipe_map exactly once.",
+        )
+
+
+class TestRepoUpdateHeadDiffing(_RecipeMapIsolation, unittest.TestCase):
+    """Regression: `autopkg repo-update` should only rebuild the map
+    when git pull actually changed HEAD."""
+
+    def test_no_change_no_rebuild(self):
+        """Same HEAD before and after pull → no rebuild."""
+        same_hash = "abc1234\n"
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.get_pref", return_value={}),
+            patch("autopkg.get_repo_info", return_value={"path": "/repo"}),
+            patch("autopkg.expand_repo_url", side_effect=lambda x: x),
+            patch("autopkg.run_git") as mock_run_git,
+            patch("autopkg.read_recipe_map"),
+            patch("autopkg.calculate_recipe_map") as mock_calc,
+            patch("autopkg.log"),
+        ):
+            mock_parser.return_value = Mock()
+            mock_parse.return_value = (Mock(), ["recipes"])
+            mock_run_git.return_value = same_hash
+
+            autopkg.repo_update([None, "repo-update", "recipes"])
+
+        mock_calc.assert_not_called()
+
+    def test_change_triggers_rebuild(self):
+        """Different HEAD hashes → rebuild."""
+        hashes = iter(["oldhash\n", "newhash\n"])
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch("autopkg.get_pref", return_value={}),
+            patch("autopkg.get_repo_info", return_value={"path": "/repo"}),
+            patch("autopkg.expand_repo_url", side_effect=lambda x: x),
+            patch("autopkg.run_git") as mock_run_git,
+            patch("autopkg.read_recipe_map"),
+            patch("autopkg.calculate_recipe_map") as mock_calc,
+            patch("autopkg.log"),
+        ):
+            mock_parser.return_value = Mock()
+            mock_parse.return_value = (Mock(), ["recipes"])
+
+            def run_git_sides(args, git_directory=None):
+                if args == ["rev-parse", "HEAD"]:
+                    return next(hashes)
+                return "Pulled new commits"
+
+            mock_run_git.side_effect = run_git_sides
+
+            autopkg.repo_update([None, "repo-update", "recipes"])
+
+        mock_calc.assert_called_once()
+
+
+class TestRepoDeletePrefMapConsistency(_RecipeMapIsolation, unittest.TestCase):
+    """Regression: repo-delete must keep prefs and the persisted map
+    consistent even when rmtree fails."""
+
+    def test_rmtree_failure_still_rebuilds_map(self):
+        """A failed removal logs an error but must still update prefs
+        and rebuild the map so the two agree on which repos exist."""
+        with (
+            patch("autopkg.common_parse") as mock_parse,
+            patch("autopkg.gen_common_parser") as mock_parser,
+            patch(
+                "autopkg.get_pref",
+                return_value={"/repo": {"URL": "https://example/repo"}},
+            ),
+            patch("autopkg.get_search_dirs", return_value=["/repo"]),
+            patch(
+                "autopkg.get_repo_info",
+                return_value={"path": "/repo"},
+            ),
+            patch("autopkg.expand_repo_url", side_effect=lambda x: x),
+            patch("shutil.rmtree", side_effect=OSError("Permission denied")),
+            patch("autopkg.save_pref_or_warn") as mock_save_pref,
+            patch("autopkg.read_recipe_map"),
+            patch("autopkg.calculate_recipe_map") as mock_calc,
+            patch("autopkg.log"),
+            patch("autopkg.log_err"),
+        ):
+            mock_parser.return_value = Mock()
+            mock_parse.return_value = (Mock(), ["repo"])
+
+            autopkg.repo_delete([None, "repo-delete", "repo"])
+
+        # Prefs saved.
+        mock_save_pref.assert_any_call("RECIPE_REPOS", {})
+        mock_save_pref.assert_any_call("RECIPE_SEARCH_DIRS", [])
+        # Map rebuilt.
+        mock_calc.assert_called_once()
+
+
+class TestReadRecipeMapRebuildForce(_RecipeMapIsolation, unittest.TestCase):
+    """Review finding: rebuild=True must always rebuild, even when
+    the on-disk file happens to be valid."""
+
+    def test_rebuild_true_always_rebuilds(self):
+        valid = {
+            "identifiers": {"x": "/x"},
+            "shortnames": {"X": "/x"},
+            "overrides": {},
+            "overrides-identifiers": {},
+            "schema_version": autopkglib.RECIPE_MAP_SCHEMA_VERSION,
+        }
+        with open(autopkglib.DEFAULT_RECIPE_MAP, "w") as f:
+            json.dump(valid, f)
+
+        with patch.object(autopkglib, "calculate_recipe_map") as mock_calc:
+            autopkglib.read_recipe_map(rebuild=True)
+            mock_calc.assert_called_once()
+
+    def test_rebuild_false_skips_rebuild_when_valid(self):
+        """Negative control: without rebuild=True, a valid file is
+        loaded without a full recalculation."""
+        valid = {
+            "identifiers": {"x": "/x"},
+            "shortnames": {"X": "/x"},
+            "overrides": {},
+            "overrides-identifiers": {},
+            "schema_version": autopkglib.RECIPE_MAP_SCHEMA_VERSION,
+        }
+        with open(autopkglib.DEFAULT_RECIPE_MAP, "w") as f:
+            json.dump(valid, f)
+
+        with patch.object(autopkglib, "calculate_recipe_map") as mock_calc:
+            autopkglib.read_recipe_map()
+            mock_calc.assert_not_called()
+        self.assertEqual(autopkglib.globalRecipeMap["identifiers"], {"x": "/x"})
+
+
+class TestGlobalRecipeMapInPlaceMutation(_RecipeMapIsolation, unittest.TestCase):
+    """Review finding: calculate_recipe_map must mutate in place so
+    ``from autopkglib import globalRecipeMap`` importers see fresh
+    data, not a stale reference to the original empty dict."""
+
+    def test_calculate_keeps_same_object_identity(self):
+        initial_id = id(autopkglib.globalRecipeMap)
+        with patch.object(autopkglib, "get_pref", side_effect=lambda k: []):
+            autopkglib.calculate_recipe_map()
+        self.assertEqual(
+            id(autopkglib.globalRecipeMap),
+            initial_id,
+            "calculate_recipe_map reassigned the global dict; importers "
+            "with a cached reference would see stale data.",
+        )
+
+    def test_autopkg_module_sees_fresh_data(self):
+        """The autopkg CLI module imports globalRecipeMap by name.
+        After calculate_recipe_map runs, the CLI module must see the
+        updated contents."""
+        # Seed a recipe to be discovered.
+        repo = os.path.join(self.tmpdir, "repo")
+        os.makedirs(repo)
+        _write_plist_recipe(
+            os.path.join(repo, "Foo.recipe"),
+            {**SAMPLE_RECIPE, "Identifier": "com.example.foo"},
+        )
+        with (
+            patch.object(
+                autopkglib,
+                "get_pref",
+                side_effect=lambda k: [repo] if k == "RECIPE_SEARCH_DIRS" else None,
+            ),
+            patch.object(autopkglib, "get_override_dirs", return_value=[]),
+        ):
+            autopkglib.calculate_recipe_map()
+
+        # The autopkg module's imported name and autopkglib's live dict
+        # must both reflect the new state.
+        self.assertIn(
+            "com.example.foo",
+            autopkg.globalRecipeMap["identifiers"],
+        )
+        self.assertIn(
+            "com.example.foo",
+            autopkglib.globalRecipeMap["identifiers"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Code/tests/test_autopkg_recipe_map_regressions.py
+++ b/Code/tests/test_autopkg_recipe_map_regressions.py
@@ -1267,9 +1267,7 @@ class TestStaleOverrideIdentifier(_RecipeMapIsolation, unittest.TestCase):
         autopkglib.globalRecipeMap["overrides-identifiers"][
             "local.myapp.original"
         ] = override_path
-        autopkglib.globalRecipeMap["identifiers"][
-            "local.myapp.original"
-        ] = stock_path
+        autopkglib.globalRecipeMap["identifiers"]["local.myapp.original"] = stock_path
 
         result = autopkglib.find_recipe_by_identifier_in_map("local.myapp.original")
         self.assertEqual(

--- a/Code/tests/test_autopkg_recipe_map_regressions.py
+++ b/Code/tests/test_autopkg_recipe_map_regressions.py
@@ -1119,5 +1119,165 @@ class TestLoadRecipeToleratesStaleMapEntry(_RecipeMapIsolation, unittest.TestCas
         )
 
 
+class TestStaleOverrideIdentifier(_RecipeMapIsolation, unittest.TestCase):
+    """Regression test: if a user edits an override file to change its
+    Identifier (e.g. when copying an override for a multi-arch setup), the
+    on-disk map still indexes the file under the old identifier. A lookup by
+    old identifier would return the file path (it still exists), then the
+    recipe would load with the new identifier, making RECIPE_CACHE_DIR
+    disagree with the resolved path.
+
+    The fix: cross-check the file's identifier for overrides-identifiers
+    entries. A mismatch is treated as a stale hit (returns None + warning)
+    rather than silently returning the wrong path.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.overrides_dir = os.path.join(self.tmpdir, "RecipeOverrides")
+        os.makedirs(self.overrides_dir)
+
+    def _write_override(self, name, identifier):
+        path = os.path.join(self.overrides_dir, f"{name}.recipe")
+        _write_plist_recipe(
+            path,
+            {
+                "Identifier": identifier,
+                "Input": {"NAME": name},
+                "ParentRecipe": "com.example.test.sample",
+            },
+        )
+        return path
+
+    def test_stale_override_identifier_returns_none(self):
+        """After the identifier in an override file is changed, a lookup by the
+        old identifier must return None rather than the mismatched path."""
+        path = self._write_override("MyApp", "local.myapp.original")
+        autopkglib.globalRecipeMap["overrides-identifiers"][
+            "local.myapp.original"
+        ] = path
+
+        # Simulate the user editing the file to change the identifier.
+        _write_plist_recipe(
+            path,
+            {
+                "Identifier": "local.myapp.arm64",
+                "Input": {"NAME": "MyApp"},
+                "ParentRecipe": "com.example.test.sample",
+            },
+        )
+
+        result = autopkglib.find_recipe_by_identifier_in_map("local.myapp.original")
+        self.assertIsNone(
+            result,
+            "Stale map entry with changed identifier must return None.",
+        )
+
+    def test_stale_override_identifier_logs_warning(self):
+        """A stale override entry must emit a warning directing the user to
+        run generate-recipe-map."""
+        path = self._write_override("MyApp", "local.myapp.original")
+        autopkglib.globalRecipeMap["overrides-identifiers"][
+            "local.myapp.original"
+        ] = path
+
+        _write_plist_recipe(
+            path,
+            {
+                "Identifier": "local.myapp.arm64",
+                "Input": {"NAME": "MyApp"},
+                "ParentRecipe": "com.example.test.sample",
+            },
+        )
+
+        with patch("autopkglib.log_err") as mock_log_err:
+            autopkglib.find_recipe_by_identifier_in_map("local.myapp.original")
+
+        warned = any(
+            "stale" in str(call).lower() or "generate-recipe-map" in str(call)
+            for call in mock_log_err.call_args_list
+        )
+        self.assertTrue(warned, "Expected a stale-map warning to be logged.")
+
+    def test_matching_override_identifier_still_returned(self):
+        """An override whose on-disk identifier still matches the map entry
+        must be returned normally (no false positive from the cross-check)."""
+        path = self._write_override("MyApp", "local.myapp.original")
+        autopkglib.globalRecipeMap["overrides-identifiers"][
+            "local.myapp.original"
+        ] = path
+
+        result = autopkglib.find_recipe_by_identifier_in_map("local.myapp.original")
+        self.assertEqual(result, path)
+
+    def test_new_identifier_found_via_disk_scan_after_stale_miss(self):
+        """After a stale map miss, the disk scanner must resolve the new
+        identifier to the same file — so the recipe still runs, just under
+        the new identifier."""
+        path = self._write_override("MyApp", "local.myapp.original")
+        autopkglib.globalRecipeMap["overrides-identifiers"][
+            "local.myapp.original"
+        ] = path
+
+        _write_plist_recipe(
+            path,
+            {
+                "Identifier": "local.myapp.arm64",
+                "Input": {"NAME": "MyApp"},
+                "ParentRecipe": "com.example.test.sample",
+            },
+        )
+
+        # Old identifier: stale miss.
+        self.assertIsNone(
+            autopkglib.find_recipe_by_identifier_in_map("local.myapp.original")
+        )
+        # New identifier: disk scan finds the file.
+        found = autopkglib.find_recipe_by_identifier_on_disk(
+            "local.myapp.arm64", [self.overrides_dir]
+        )
+        self.assertEqual(found, path)
+
+    def test_stale_override_falls_through_to_stock_recipe(self):
+        """A stale override entry must not block a valid stock-identifiers hit
+        for the same identifier. After rejecting the override, the function
+        must return the stock recipe path."""
+        stock_path = os.path.join(self.tmpdir, "StockRecipes", "MyApp.munki.recipe")
+        os.makedirs(os.path.dirname(stock_path), exist_ok=True)
+        _write_plist_recipe(
+            stock_path,
+            {
+                "Identifier": "local.myapp.original",
+                "Input": {"NAME": "MyApp"},
+                "Process": [],
+            },
+        )
+
+        override_path = self._write_override("MyApp", "local.myapp.original")
+        # Edit the override so its identifier no longer matches the map key.
+        _write_plist_recipe(
+            override_path,
+            {
+                "Identifier": "local.myapp.arm64",
+                "Input": {"NAME": "MyApp"},
+                "ParentRecipe": "com.example.test.sample",
+            },
+        )
+
+        autopkglib.globalRecipeMap["overrides-identifiers"][
+            "local.myapp.original"
+        ] = override_path
+        autopkglib.globalRecipeMap["identifiers"][
+            "local.myapp.original"
+        ] = stock_path
+
+        result = autopkglib.find_recipe_by_identifier_in_map("local.myapp.original")
+        self.assertEqual(
+            result,
+            stock_path,
+            "Stale override must fall through to a valid stock-identifiers hit.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Code/tests/test_autopkg_recipes.py
+++ b/Code/tests/test_autopkg_recipes.py
@@ -38,10 +38,25 @@ class TestAutoPkgRecipes(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures with a temporary directory."""
         self.tmp_dir = TemporaryDirectory()
+        # The recipe-map port made several verbs (new_recipe,
+        # make_override, locate_recipe) trigger map rebuilds via
+        # calculate_recipe_map/read_recipe_map. Those would otherwise
+        # walk the real user's RECIPE_SEARCH_DIRS during unit tests,
+        # slowing the suite down enormously and leaking state from the
+        # developer's machine. Silence them at the class level; tests
+        # that care about the map will patch it explicitly.
+        self._recipe_map_patches = [
+            patch("autopkg.calculate_recipe_map"),
+            patch("autopkg.read_recipe_map"),
+        ]
+        for patcher in self._recipe_map_patches:
+            patcher.start()
 
     def tearDown(self):
         """Clean up test fixtures."""
         self.tmp_dir.cleanup()
+        for patcher in self._recipe_map_patches:
+            patcher.stop()
 
     def test_recipe_has_step_processor_with_processor(self):
         """Test recipe_has_step_processor when recipe contains the specified processor."""

--- a/Code/tests/test_autopkg_recipes.py
+++ b/Code/tests/test_autopkg_recipes.py
@@ -699,19 +699,19 @@ class TestAutoPkgRecipes(unittest.TestCase):
         with open(recipe_file, "wb") as f:
             plistlib.dump(recipe_dict, f)
 
-        # Mock find_recipe_by_identifier to return our test file
-        original_find_by_id = autopkg.find_recipe_by_identifier
-        autopkg.find_recipe_by_identifier = lambda id_name, dirs: (
-            recipe_file if id_name == "com.example.testapp.download" else None
-        )
-
-        try:
+        # find_recipe delegates to find_recipe_by_identifier_on_disk when
+        # the caller-supplied dirs differ from the prefs baseline. Patch
+        # that canonical name rather than the deprecated alias.
+        with patch(
+            "autopkg.find_recipe_by_identifier_on_disk",
+            side_effect=lambda id_name, dirs: (
+                recipe_file if id_name == "com.example.testapp.download" else None
+            ),
+        ):
             result = autopkg.find_recipe(
                 "com.example.testapp.download", [self.tmp_dir.name]
             )
-            self.assertEqual(result, recipe_file)
-        finally:
-            autopkg.find_recipe_by_identifier = original_find_by_id
+        self.assertEqual(result, recipe_file)
 
     def test_find_recipe_finds_by_name(self):
         """Test find_recipe when recipe can be found by name but not identifier."""
@@ -727,28 +727,21 @@ class TestAutoPkgRecipes(unittest.TestCase):
         with open(recipe_file, "wb") as f:
             plistlib.dump(recipe_dict, f)
 
-        # Mock find_recipe_by_identifier to return None
-        original_find_by_id = autopkg.find_recipe_by_identifier
-        autopkg.find_recipe_by_identifier = lambda id_name, dirs: None
-
-        try:
+        # Force the identifier lookup to fail so the name-based fallback
+        # (find_recipe_by_name_on_disk) gets exercised.
+        with patch("autopkg.find_recipe_by_identifier_on_disk", return_value=None):
             result = autopkg.find_recipe("TestApp.download", [self.tmp_dir.name])
-            self.assertEqual(result, recipe_file)
-        finally:
-            autopkg.find_recipe_by_identifier = original_find_by_id
+        self.assertEqual(result, recipe_file)
 
     def test_find_recipe_not_found(self):
         """Test find_recipe when recipe cannot be found by identifier or name."""
 
-        # Mock find_recipe_by_identifier to return None
-        original_find_by_id = autopkg.find_recipe_by_identifier
-        autopkg.find_recipe_by_identifier = lambda id_name, dirs: None
-
-        try:
+        with (
+            patch("autopkg.find_recipe_by_identifier_on_disk", return_value=None),
+            patch("autopkg.find_recipe_by_name_on_disk", return_value=None),
+        ):
             result = autopkg.find_recipe("NonExistent.download", [self.tmp_dir.name])
-            self.assertIsNone(result)
-        finally:
-            autopkg.find_recipe_by_identifier = original_find_by_id
+        self.assertIsNone(result)
 
     def test_get_identifier_from_override_with_parent_recipe(self):
         """Test get_identifier_from_override when override has ParentRecipe key."""

--- a/Code/tests/test_autopkg_repos.py
+++ b/Code/tests/test_autopkg_repos.py
@@ -33,6 +33,20 @@ sys.modules["autopkg"] = autopkg
 class TestAutoPkgRepos(unittest.TestCase):
     """Test cases for repository-related functions of AutoPkg."""
 
+    def setUp(self):
+        """Silence recipe-map side effects triggered by repo-add/repo-delete/
+        repo-update. Tests that care about the map patch it explicitly."""
+        self._recipe_map_patches = [
+            patch("autopkg.calculate_recipe_map"),
+            patch("autopkg.read_recipe_map"),
+        ]
+        for patcher in self._recipe_map_patches:
+            patcher.start()
+
+    def tearDown(self):
+        for patcher in self._recipe_map_patches:
+            patcher.stop()
+
     def test_expand_single_autopkg_org_urls(self):
         """Expand single part short repo URLs in the AutoPkg org on GitHub"""
         url = autopkg.expand_repo_url("recipes")

--- a/Code/tests/test_autopkg_repos.py
+++ b/Code/tests/test_autopkg_repos.py
@@ -1103,8 +1103,13 @@ class TestAutoPkgRepos(unittest.TestCase):
 
         autopkg.repo_delete([None, "repo-delete", "recipes"])
 
-        mock_log_err.assert_called_with(
-            "ERROR: Could not remove /repo/path: Permission denied"
+        # Error message includes additional context about manual cleanup
+        # but must still start with the expected ERROR: prefix.
+        error_call = mock_log_err.call_args
+        assert error_call is not None
+        self.assertIn(
+            "ERROR: Could not remove /repo/path: Permission denied",
+            error_call.args[0],
         )
         # Verify preferences were still saved even though rmtree failed
         mock_save_pref.assert_called()
@@ -1181,13 +1186,17 @@ class TestAutoPkgRepos(unittest.TestCase):
         mock_get_repo_info.return_value = {"path": "/repo/path"}
         mock_expanduser.return_value = "/repo/path"
         mock_abspath.return_value = "/repo/path"
+        # repo_update now calls rev-parse before and after pull so it can
+        # decide whether to rebuild the recipe map. Return stable hashes
+        # that indicate no change so the test asserts behaviour in the
+        # "Already up to date" path.
         mock_run_git.return_value = "Already up to date."
 
         autopkg.repo_update([None, "repo-update", "recipes"])
 
         mock_expand_repo_url.assert_called_once_with("recipes")
         mock_get_repo_info.assert_called_once_with("https://github.com/autopkg/recipes")
-        mock_run_git.assert_called_once_with(["pull"], git_directory="/repo/path")
+        mock_run_git.assert_any_call(["pull"], git_directory="/repo/path")
         mock_log.assert_any_call("Attempting git pull for /repo/path...")
         mock_log.assert_any_call("Already up to date.")
 
@@ -1223,7 +1232,11 @@ class TestAutoPkgRepos(unittest.TestCase):
 
         autopkg.repo_update([None, "repo-update", "all"])
 
-        self.assertEqual(mock_run_git.call_count, 2)
+        # repo_update performs up to 3 git operations per repo (rev-parse
+        # before, pull, rev-parse after) so we assert on the pull calls
+        # specifically rather than the total call count.
+        pull_calls = [c for c in mock_run_git.call_args_list if c.args[0] == ["pull"]]
+        self.assertEqual(len(pull_calls), 2)
         mock_run_git.assert_any_call(["pull"], git_directory="/repo/path1")
         mock_run_git.assert_any_call(["pull"], git_directory="/repo/path2")
 

--- a/Code/tests/test_autopkg_run.py
+++ b/Code/tests/test_autopkg_run.py
@@ -36,10 +36,20 @@ class TestAutoPkgRun(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.tmp_dir = TemporaryDirectory()
+        # Silence recipe-map side effects (see test_autopkg_recipes for
+        # rationale).
+        self._recipe_map_patches = [
+            patch("autopkg.calculate_recipe_map"),
+            patch("autopkg.read_recipe_map"),
+        ]
+        for patcher in self._recipe_map_patches:
+            patcher.start()
 
     def tearDown(self):
         """Clean up after tests."""
         self.tmp_dir.cleanup()
+        for patcher in self._recipe_map_patches:
+            patcher.stop()
 
     def test_run_recipes_no_arguments(self):
         """Test run_recipes with no recipe arguments."""


### PR DESCRIPTION
## What this is

This PR backports the recipe map functionality from `dev-3.x` to `dev-2.x`, picking up the maintainer suggestion in #1026 that the existing PR be re-implemented from the dev-3.x state rather than rebased.

The recipe map is an on-disk JSON cache of every recipe and override on the system, indexed by identifier and shortname. Recipe resolution becomes O(1) instead of walking every configured `RECIPE_SEARCH_DIRS` entry on each invocation — the dominant cost for users with many recipe repos. The cache lives at `~/Library/AutoPkg/recipe_map.json` by default.

## Why this approach

I worked through the recipe-map commits on `dev-3.x`, but there are enough structural differences (the `common.py`/`prefs.py` split, the `Recipe` class refactor in `autopkglib/recipes/`) that cherry-picking would have produced a tangled history with conflicts in nearly every commit. Instead I synthesised a clean port targeted at the dev-2.x layout, with one logical commit per layer. Each commit builds and the full test suite passes on its own — easier to review, easier to revert if needed.

While I was in the area, I picked up every open recipe-map issue I could find in the tracker so this PR closes a meaningful set of bugs rather than introducing a fresh feature on top of known issues.

## What changed for users

- New `autopkg generate-recipe-map` subcommand to explicitly build and persist the map. Useful for fresh installs and CI/CD pipelines that want to pay the scan cost up front.
- The map auto-rebuilds on first use when it's missing or invalid — fresh installs and ephemeral runners "just work" without a manual bootstrap step. (This is a UX divergence from dev-3.x, which printed an error and exited.)
- `repo-add`, `repo-delete`, `repo-update`, `make-override` and `new-recipe` keep the map in sync automatically. `repo-update` only rebuilds when `git pull` actually changed `HEAD`, so no-op updates don't incur the scan cost.
- CLI `--search-dir` / `--override-dir` flags still scope resolution to exactly the supplied dirs when they differ from prefs. Preserves the dev-2.x "recipes in `~/Library/AutoPkg/Recipes` override installed repos" contract that #886 / #908 / #918 reported as broken in earlier recipe-map iterations.
- `find_processor_path` consults the map first, with a one-shot rebuild that pulls in the current working directory when a shared processor is missing from the persisted map (#894).
- Trust info verification (`verify-trust-info`, `update-trust-info`) correctly classifies override files passed by path (#903).
- Map location is configurable via the `RECIPE_MAP_PATH` preference or `AUTOPKG_RECIPE_MAP_PATH` env var, with env taking precedence (#901).
- Escape hatch: set `DISABLE_RECIPE_MAP=1` (or the env var) to bypass the map and fall back to the legacy on-disk scanners. No code change required if anyone hits a bug in production.

## Issues closed

`#869`, `#874`, `#884`, `#886`, `#893`, `#894`, `#898`, `#901`, `#903`, `#908`, `#918`. Each has at least one regression test pinned to it in `Code/tests/test_autopkg_recipe_map_regressions.py` so future changes that break the behaviour fail in CI with a direct pointer back to the original report.

## How it's structured

8 progressive commits on top of `dev-2.x`. Each commit passes the full test suite on its own:

1. **Pre-port refactor** — consolidate recipe helpers into `autopkglib`. No functional change.
2. **Recipe map core** — `globalRecipeMap`, `calculate_recipe_map`, `read_recipe_map`, lookup helpers, persistence.
3. **Wire into verbs** — integrate the map into `Code/autopkg`'s verbs and `find_recipe`.
4. **Initial test coverage** — 40 unit tests for the core.
5. **Review blockers and known bugs** — addresses every blocker from a code review pass plus the bug fixes for the issues above.
6. **Regression tests** — 38 tests pinned to specific upstream issues / review findings.
7. **Review findings + CHANGELOG** — addresses a follow-up review pass focused on hardening, plus the user-facing CHANGELOG entry.
8. **Post-review cleanup** — simplifications, hot-path perf fix, tightened docs and lint compliance.

## Implementation notes worth flagging

- **Atomic writes.** The persisted map goes through `tempfile.mkstemp` + `os.replace` so concurrent autopkg invocations can't observe a half-written file.
- **Schema version.** Persisted files carry a `schema_version` field; future format changes can trigger a clean rebuild rather than reading stale data.
- **YAML loader hardened.** `recipe_from_file` switched from `yaml.FullLoader` to `yaml.safe_load`. Recipe documents are always plain mappings of primitives so no legitimate recipe is affected, but the recipe map causes every `.recipe.yaml` in every search dir to be parsed on every map build/lookup — much wider attack surface than before this PR. `safe_load` closes that.
- **Root-redirect warning.** Redirecting the map path via env var or pref while running as root now emits a prominent log warning (`SECURITY WARNING: ...`). Ops teams running `sudo autopkg` should strip `AUTOPKG_*` from `env_keep` if they don't want unprivileged callers to influence where autopkg writes.
- **Tests are hermetic.** A shared test fixture redirects `DEFAULT_RECIPE_MAP` to a per-test tempdir and resets `globalRecipeMap`, so the suite never touches the developer's real `~/Library/AutoPkg`. Suite runtime stays at ~28 seconds.

## Reviewer walkthrough

### Automated checks (5 minutes)

```sh
/usr/local/autopkg/python Scripts/run_tests.py
# Expected: 817 tests, 12 skipped, 0 failures.
```

The 78 new tests live in `Code/tests/test_autopkg_recipe_map.py` (40 unit tests) and `Code/tests/test_autopkg_recipe_map_regressions.py` (38 regression tests). Each regression test class cites the issue number it covers in its docstring.

### Hands-on scenarios (~20 minutes)

The most important scenarios to walk through manually, since they cover the user-visible behaviour changes:

| # | Scenario | Validates |
|---|----------|-----------|
| 1 | `rm -f ~/Library/AutoPkg/recipe_map.json && autopkg repo-add recipes` — map auto-creates, no error. | #884, #893, #898 |
| 2 | `autopkg generate-recipe-map` from a fresh install. Persists to disk; reports counts. | New verb |
| 3 | A recipe in `~/Library/AutoPkg/Recipes` with the same identifier as a stock recipe. `autopkg info <id>` resolves to the local copy. | #886, #908, #918 |
| 4 | `autopkg info -d /tmp/scoped-dir <id>` — CLI dir wins over the map. | #886, #908, #918 |
| 5 | A shared-processor recipe in cwd. First reference triggers a rebuild and resolves; subsequent misses don't trigger another rebuild. | #894 |
| 6 | `autopkg update-trust-info ./Overrides/<file>.yaml` — file passed by path, classified as override via the map. | #903 |
| 7 | `autopkg repo-update all` on a fully-up-to-date tree — map mtime unchanged. | Perf |
| 8 | A syntactically-invalid recipe in a search dir. `generate-recipe-map` emits a warning, doesn't crash. | #869 |
| 9 | A pre-v1 map file (no `overrides-identifiers` key). `autopkg info` triggers an auto-rebuild rather than `KeyError`. | #874 |
| 10 | `RECIPE_MAP_PATH` pref or `AUTOPKG_RECIPE_MAP_PATH` env var redirects the persisted location; env wins. | #901 |
| 11 | `AUTOPKG_DISABLE_RECIPE_MAP=1 autopkg info <id>` — falls back to on-disk scan, no map references in log. | Escape hatch |
| 12 | Read-only target directory — write fails with actionable warning, no `.tmp` turd left behind. | Atomic write |

Happy to provide more detailed reproduction scripts for any of these on request.

### If something goes wrong

The CLI surface is additive. If a user hits a recipe-map bug in production:

1. **Bypass**: set `AUTOPKG_DISABLE_RECIPE_MAP=1` or the `DISABLE_RECIPE_MAP` pref to fall back to the dev-2.x on-disk scanners. No code change required.
2. **Rebuild**: delete the map and run `autopkg generate-recipe-map`.
3. **Revert**: the 8 commits are self-contained. Reverting the merge restores pre-backport behaviour exactly.

## Outstanding things

- Marked as draft because I'd appreciate maintainer eyes on the auto-create UX divergence from dev-3.x before this lands. Happy to switch back to the original "exit on missing map" if you'd prefer that to stay consistent with how dev-3.x behaves.
- I'm leaving the `find_recipe_by_identifier` alias in `autopkglib` for backwards compat with anything outside this repo that imports it. Nothing inside the tree uses it any more; it can come out in a follow-up if the maintainer prefers.

Let me know if there's anything else you'd like me to cover, restructure, or back out. Thanks for the suggestion to re-implement from dev-3.x in #1026 — it produced a much cleaner result than rebasing the original would have.
