### PR TITLE
Bump filelock from 3.20.0 to 3.20.3 in /.github/workflows

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -10,7 +10,7 @@ cffi==2.0.0
 cfgv==3.4.0
 click==8.3.0
 distlib==0.4.0
-filelock==3.20.0
+filelock==3.20.3
 flake8==7.3.0
 flake8-bugbear==24.12.12
 identify==2.6.15


### PR DESCRIPTION
Matches the root requirements.txt bump in #1020. Required so that virtualenv==20.36.1 (PR #1019) can install in CI, since virtualenv 20.36.1 depends on filelock>=3.20.1.