### PR TITLE
Route MunkiOptionalReceiptEditor through repo plugin

### DIFF
--- a/Code/autopkglib/MunkiImporter.py
+++ b/Code/autopkglib/MunkiImporter.py
@@ -21,7 +21,7 @@ import subprocess
 from datetime import datetime
 
 from autopkglib import Processor, ProcessorError
-from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
+from autopkglib.munkirepolibs import fetch_repo_library
 from autopkglib.munkirepolibs.MunkiLib import MunkiLib
 
 __all__ = ["MunkiImporter"]
@@ -154,21 +154,6 @@ class MunkiImporter(Processor):
         },
     }
 
-    def _fetch_repo_library(
-        self,
-        munki_repo,
-        munki_repo_plugin,
-        munkilib_dir,
-        repo_subdirectory,
-        force_munki_lib,
-    ):
-        if munki_repo_plugin == "FileRepo" and not force_munki_lib:
-            return AutoPkgLib(munki_repo, repo_subdirectory)
-        else:
-            return MunkiLib(
-                munki_repo, munki_repo_plugin, munkilib_dir, repo_subdirectory
-            )
-
     def _find_matching_pkginfo(self, repo_library, pkginfo):
         """Looks through all catalog for items matching the one
         described by pkginfo. Returns a list of matching items if found."""
@@ -294,7 +279,7 @@ class MunkiImporter(Processor):
         return None
 
     def main(self) -> None:
-        library = self._fetch_repo_library(
+        library = fetch_repo_library(
             self.env["MUNKI_REPO"],
             self.env["MUNKI_REPO_PLUGIN"],
             self.env["MUNKILIB_DIR"],

--- a/Code/autopkglib/MunkiOptionalReceiptEditor.py
+++ b/Code/autopkglib/MunkiOptionalReceiptEditor.py
@@ -18,6 +18,7 @@
 import plistlib
 
 from autopkglib import Processor, ProcessorError
+from autopkglib.munkirepolibs import fetch_repo_library
 
 __all__ = ["MunkiOptionalReceiptEditor"]
 
@@ -36,16 +37,50 @@ class MunkiOptionalReceiptEditor(Processor):
             "required": True,
             "description": "Array of package IDs to turn optional for Munki",
         },
+        "MUNKI_REPO": {
+            "required": True,
+            "description": "Path to a mounted Munki repo.",
+        },
+        "MUNKI_REPO_PLUGIN": {
+            "required": False,
+            "description": (
+                "Munki repo plugin. Defaults to FileRepo. Munki must be installed and available "
+                "at MUNKILIB_DIR if a plugin other than FileRepo is specified."
+            ),
+            "default": "FileRepo",
+        },
+        "MUNKILIB_DIR": {
+            "required": False,
+            "description": (
+                "Directory path that contains munkilib. Defaults to /usr/local/munki"
+            ),
+            "default": "/usr/local/munki",
+        },
+        "force_munki_repo_lib": {
+            "required": False,
+            "description": (
+                "When True, munki code libraries will be utilized when the FileRepo plugin is "
+                "used. Munki must be installed and available at MUNKILIB_DIR"
+            ),
+            "default": False,
+        },
     }
-    output_variables = {}
+    output_variables = {
+        "munki_info": {
+            "description": "The updated pkginfo dictionary.",
+        },
+    }
 
     def main(self) -> None:
         if len(self.env["pkginfo_repo_path"]) < 1:
             self.output("No pkginfo_repo_path specified, skipping")
             return
 
-        with open(self.env["pkginfo_repo_path"], "rb") as f:
-            pkginfo = plistlib.load(f)
+        if "munki_info" in self.env and self.env["munki_info"]:
+            pkginfo = self.env["munki_info"]
+        else:
+            with open(self.env["pkginfo_repo_path"], "rb") as f:
+                pkginfo = plistlib.load(f)
 
         receipts_modified = []
         if "receipts" in pkginfo.keys():
@@ -61,11 +96,19 @@ class MunkiOptionalReceiptEditor(Processor):
             raise ProcessorError("pkginfo does not contain any receipts")
 
         if len(receipts_modified) > 0:
+            library = fetch_repo_library(
+                self.env["MUNKI_REPO"],
+                self.env["MUNKI_REPO_PLUGIN"],
+                self.env["MUNKILIB_DIR"],
+                None,
+                self.env["force_munki_repo_lib"],
+            )
             self.output(f"Writing pkginfo to {self.env['pkginfo_repo_path']}")
-            with open(self.env["pkginfo_repo_path"], "wb") as f:
-                plistlib.dump(pkginfo, f)
+            library.put_pkginfo_to_repo(pkginfo, self.env["pkginfo_repo_path"])
         else:
             self.output("No receipts modified, nothing to do")
+
+        self.env["munki_info"] = pkginfo
 
 
 if __name__ == "__main__":

--- a/Code/autopkglib/munkirepolibs/AutoPkgLib.py
+++ b/Code/autopkglib/munkirepolibs/AutoPkgLib.py
@@ -215,3 +215,13 @@ class AutoPkgLib:
                 f"Could not write pkginfo {pkginfo_path}: {err.strerror}"
             )
         return pkginfo_path
+
+    def put_pkginfo_to_repo(self, pkginfo, pkginfo_path) -> None:
+        """Updates an existing pkginfo file in the repo."""
+        try:
+            with open(pkginfo_path, "wb") as f:
+                plistlib.dump(pkginfo, f)
+        except OSError as err:
+            raise ProcessorError(
+                f"Could not write pkginfo {pkginfo_path}: {err.strerror}"
+            )

--- a/Code/autopkglib/munkirepolibs/MunkiLib.py
+++ b/Code/autopkglib/munkirepolibs/MunkiLib.py
@@ -1,5 +1,4 @@
 import os
-import plistlib
 import sys
 from urllib.parse import urlparse
 
@@ -63,8 +62,10 @@ class MunkiLib:
 
     def put_pkginfo_to_repo(self, pkginfo, pkginfo_path) -> None:
         """Updates an existing pkginfo file in the repo via the repo plugin."""
+        from munkilib import FoundationPlist
+
         relative_path = os.path.relpath(pkginfo_path, self.munki_repo)
-        content = plistlib.dumps(pkginfo)
+        content = FoundationPlist.writePlistToString(pkginfo)
         self.repo.put(relative_path, content)
 
     def extract_and_copy_icon_to_repo(

--- a/Code/autopkglib/munkirepolibs/MunkiLib.py
+++ b/Code/autopkglib/munkirepolibs/MunkiLib.py
@@ -1,4 +1,5 @@
 import os
+import plistlib
 import sys
 from urllib.parse import urlparse
 
@@ -59,6 +60,12 @@ class MunkiLib:
             return self._full_path(path)
 
         return None
+
+    def put_pkginfo_to_repo(self, pkginfo, pkginfo_path) -> None:
+        """Updates an existing pkginfo file in the repo via the repo plugin."""
+        relative_path = os.path.relpath(pkginfo_path, self.munki_repo)
+        content = plistlib.dumps(pkginfo)
+        self.repo.put(relative_path, content)
 
     def extract_and_copy_icon_to_repo(
         self, pkg_path, pkginfo, import_multiple=True

--- a/Code/autopkglib/munkirepolibs/__init__.py
+++ b/Code/autopkglib/munkirepolibs/__init__.py
@@ -1,0 +1,12 @@
+from autopkglib.munkirepolibs.AutoPkgLib import AutoPkgLib
+from autopkglib.munkirepolibs.MunkiLib import MunkiLib
+
+
+def fetch_repo_library(
+    munki_repo, munki_repo_plugin, munkilib_dir, repo_subdirectory, force_munki_lib
+):
+    """Return the appropriate repo library for the given plugin configuration."""
+    if munki_repo_plugin == "FileRepo" and not force_munki_lib:
+        return AutoPkgLib(munki_repo, repo_subdirectory)
+    else:
+        return MunkiLib(munki_repo, munki_repo_plugin, munkilib_dir, repo_subdirectory)

--- a/Code/tests/test_githubreleasesinfoprovider.py
+++ b/Code/tests/test_githubreleasesinfoprovider.py
@@ -1,17 +1,36 @@
 #!/usr/local/autopkg/python
 
-import re
 import unittest
+from unittest.mock import patch
 
 from autopkglib import ProcessorError
 from autopkglib.GitHubReleasesInfoProvider import GitHubReleasesInfoProvider
+
+
+def _fake_release(tag_name="v3.0.2"):
+    """Build a minimal GitHub release list for one tag."""
+    return [
+        {
+            "tag_name": tag_name,
+            "name": tag_name,
+            "prerelease": False,
+            "body": "",
+            "assets": [
+                {
+                    "name": "test.pkg",
+                    "browser_download_url": "https://example.com/test.pkg",
+                    "url": "https://api.example.com/assets/1",
+                    "created_at": "2024-01-01T00:00:00Z",
+                }
+            ],
+        }
+    ]
 
 
 class TestGitHubReleasesInfoProvider(unittest.TestCase):
     """Test class for GitHubReleasesInfoProvider Processor."""
 
     def setUp(self):
-        self.vers_pattern = r"\d[\d\.]+"
         self.base_env = {
             "CURL_PATH": "/usr/bin/curl",
             "GITHUB_URL": "https://api.github.com",
@@ -19,61 +38,59 @@ class TestGitHubReleasesInfoProvider(unittest.TestCase):
         }
         self.processor = GitHubReleasesInfoProvider()
 
-    def tearDown(self):
-        pass
+    def _run(self, repo="autopkg/autopkg"):
+        """Set up env and run the processor, returning the env dict."""
+        env = {"github_repo": repo, **self.base_env}
+        self.processor.env = env
+        self.processor.main()
+        return env
 
     def test_raise_if_no_repo(self):
         """Raise an exception if missing a critical input variable."""
-        test_env = {"github_repo": ""}
-        test_env.update(self.base_env)
-        self.processor.env = test_env
+        self.processor.env = {"github_repo": "", **self.base_env}
         with self.assertRaises(ProcessorError):
             self.processor.main()
 
-    def test_no_fail_if_good_env(self):
+    @patch.object(
+        GitHubReleasesInfoProvider, "get_releases", return_value=_fake_release()
+    )
+    def test_no_fail_if_good_env(self, _mock):
         """The processor should not raise any exceptions if run normally."""
-        test_env = {"github_repo": "autopkg/autopkg"}
-        test_env.update(self.base_env)
-        self.processor.env = test_env
-        try:
-            self.processor.main()
-        except ProcessorError:
-            self.fail()
+        self._run()
 
-    def test_returns_version_from_tag1(self):
+    @patch.object(
+        GitHubReleasesInfoProvider, "get_releases", return_value=_fake_release()
+    )
+    def test_returns_version_from_tag(self, _mock):
         """The processor should return a version derived from a tag."""
-        test_env = {"github_repo": "autopkg/autopkg"}
-        test_env.update(self.base_env)
-        self.processor.env = test_env
-        self.processor.main()
-        m = re.match(self.vers_pattern, test_env["version"])
-        self.assertIsNotNone(m)
+        env = self._run()
+        self.assertRegex(env["version"], r"\d[\d.]+")
 
-    def test_returns_version_from_tag2(self):
-        """The processor should return a version derived from a tag, even if
-        the tag has an extra leading dot."""
-        test_env = {"github_repo": "macadmins/nudge"}
-        test_env.update(self.base_env)
-        self.processor.env = test_env
-        self.processor.main()
-        m = re.match(self.vers_pattern, test_env["version"])
-        self.assertIsNotNone(m)
+    @patch.object(
+        GitHubReleasesInfoProvider,
+        "get_releases",
+        return_value=_fake_release("v.1.1.16.1"),
+    )
+    def test_returns_version_from_tag_with_leading_dot(self, _mock):
+        """The processor should handle tags with an extra leading dot."""
+        env = self._run("macadmins/nudge")
+        self.assertRegex(env["version"], r"\d[\d.]+")
 
-    def test_returns_url(self):
+    @patch.object(
+        GitHubReleasesInfoProvider, "get_releases", return_value=_fake_release()
+    )
+    def test_returns_url(self, _mock):
         """The processor should return a URL."""
-        test_env = {"github_repo": "autopkg/autopkg"}
-        test_env.update(self.base_env)
-        self.processor.env = test_env
-        self.processor.main()
-        self.assertIsNotNone(test_env["url"])
+        env = self._run()
+        self.assertIsNotNone(env["url"])
 
-    def test_returns_asset_url(self):
+    @patch.object(
+        GitHubReleasesInfoProvider, "get_releases", return_value=_fake_release()
+    )
+    def test_returns_asset_url(self, _mock):
         """The processor should return an asset URL."""
-        test_env = {"github_repo": "autopkg/autopkg"}
-        test_env.update(self.base_env)
-        self.processor.env = test_env
-        self.processor.main()
-        self.assertIsNotNone(test_env["asset_url"])
+        env = self._run()
+        self.assertIsNotNone(env["asset_url"])
 
 
 if __name__ == "__main__":

--- a/Code/tests/test_munkiimporter.py
+++ b/Code/tests/test_munkiimporter.py
@@ -10,6 +10,9 @@ from unittest.mock import MagicMock, patch
 
 from autopkglib import ProcessorError
 from autopkglib.MunkiImporter import MunkiImporter
+from autopkglib.munkirepolibs import fetch_repo_library
+
+_munki_importer_mod = sys.modules["autopkglib.MunkiImporter"]
 
 
 @unittest.skipUnless(sys.platform == "darwin", "Munki is macOS-only")
@@ -69,51 +72,44 @@ class TestMunkiImporter(unittest.TestCase):
             ],
         }
 
-    # Test _fetch_repo_library method
+    # Test fetch_repo_library shared function
     def test_fetch_repo_library_returns_autopkglib_by_default(self):
-        """Test that _fetch_repo_library returns AutoPkgLib by default."""
-        library = self.processor._fetch_repo_library(
+        """Test that fetch_repo_library returns AutoPkgLib by default."""
+        library = fetch_repo_library(
             self.munki_repo, "FileRepo", "/usr/local/munki", None, False
         )
 
-        # Should return AutoPkgLib for FileRepo without force_munki_lib
         self.assertEqual(library.__class__.__name__, "AutoPkgLib")
 
-    def test_fetch_repo_library_returns_munkilib_when_forced(self):
-        """Test that _fetch_repo_library returns MunkiLib when forced."""
-        # Mock the entire method since we're testing logic, not actual instantiation
-        with patch.object(self.processor, "_fetch_repo_library") as mock_method:
-            mock_library = MagicMock()
-            mock_method.return_value = mock_library
+    @patch("autopkglib.munkirepolibs.MunkiLib")
+    def test_fetch_repo_library_returns_munkilib_when_forced(self, mock_munkilib_cls):
+        """Test that fetch_repo_library returns MunkiLib when forced."""
+        mock_library = MagicMock()
+        mock_munkilib_cls.return_value = mock_library
 
-            # Call the mocked method
-            result = self.processor._fetch_repo_library(
-                self.munki_repo, "FileRepo", "/usr/local/munki", None, True
-            )
+        result = fetch_repo_library(
+            self.munki_repo, "FileRepo", "/usr/local/munki", None, True
+        )
 
-            # Verify it was called and returned correctly
-            mock_method.assert_called_once_with(
-                self.munki_repo, "FileRepo", "/usr/local/munki", None, True
-            )
-            self.assertEqual(result, mock_library)
+        mock_munkilib_cls.assert_called_once_with(
+            self.munki_repo, "FileRepo", "/usr/local/munki", None
+        )
+        self.assertEqual(result, mock_library)
 
-    def test_fetch_repo_library_uses_munkilib_for_non_filerepo(self):
-        """Test that _fetch_repo_library uses MunkiLib for non-FileRepo plugins."""
-        # Mock the entire method since we're testing logic, not actual instantiation
-        with patch.object(self.processor, "_fetch_repo_library") as mock_method:
-            mock_library = MagicMock()
-            mock_method.return_value = mock_library
+    @patch("autopkglib.munkirepolibs.MunkiLib")
+    def test_fetch_repo_library_uses_munkilib_for_non_filerepo(self, mock_munkilib_cls):
+        """Test that fetch_repo_library uses MunkiLib for non-FileRepo plugins."""
+        mock_library = MagicMock()
+        mock_munkilib_cls.return_value = mock_library
 
-            # Call the mocked method
-            result = self.processor._fetch_repo_library(
-                self.munki_repo, "Git", "/usr/local/munki", "subdir", False
-            )
+        result = fetch_repo_library(
+            self.munki_repo, "Git", "/usr/local/munki", "subdir", False
+        )
 
-            # Verify it was called and returned correctly
-            mock_method.assert_called_once_with(
-                self.munki_repo, "Git", "/usr/local/munki", "subdir", False
-            )
-            self.assertEqual(result, mock_library)
+        mock_munkilib_cls.assert_called_once_with(
+            self.munki_repo, "Git", "/usr/local/munki", "subdir"
+        )
+        self.assertEqual(result, mock_library)
 
     # Test _find_matching_pkginfo method
     def test_find_matching_pkginfo_returns_none_without_hash(self):
@@ -161,7 +157,7 @@ class TestMunkiImporter(unittest.TestCase):
         mock_popen.return_value = mock_process
 
         # Mock library methods
-        with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+        with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
             mock_library = MagicMock()
             mock_library.copy_pkg_to_repo.return_value = self.pkg_path
             mock_library.copy_pkginfo_to_repo.return_value = "/path/to/pkginfo"
@@ -201,7 +197,7 @@ class TestMunkiImporter(unittest.TestCase):
         mock_popen.return_value = mock_process
 
         # Mock library methods
-        with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+        with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
             mock_library = MagicMock()
             mock_library.copy_pkg_to_repo.return_value = self.pkg_path
             mock_library.copy_pkginfo_to_repo.return_value = "/path/to/pkginfo"
@@ -261,7 +257,7 @@ class TestMunkiImporter(unittest.TestCase):
         mock_popen.return_value = mock_process
 
         # Mock library methods
-        with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+        with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
             mock_library = MagicMock()
             mock_library.copy_pkg_to_repo.return_value = self.pkg_path
             mock_library.copy_pkginfo_to_repo.return_value = "/path/to/pkginfo"
@@ -295,7 +291,7 @@ class TestMunkiImporter(unittest.TestCase):
         mock_popen.return_value = mock_process
 
         # Mock library methods
-        with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+        with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
             mock_library = MagicMock()
             mock_library.copy_pkg_to_repo.return_value = self.pkg_path
             mock_library.copy_pkginfo_to_repo.return_value = "/path/to/pkginfo"
@@ -326,7 +322,7 @@ class TestMunkiImporter(unittest.TestCase):
         mock_popen.return_value = mock_process
 
         # Mock library methods
-        with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+        with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
             mock_library = MagicMock()
             mock_library.copy_pkg_to_repo.return_value = self.pkg_path
             mock_library.copy_pkginfo_to_repo.return_value = "/path/to/pkginfo"
@@ -356,7 +352,7 @@ class TestMunkiImporter(unittest.TestCase):
         mock_process.returncode = 0
         mock_popen.return_value = mock_process
 
-        with patch.object(self.processor, "_fetch_repo_library"):
+        with patch.object(_munki_importer_mod, "fetch_repo_library"):
             with self.assertRaisesRegex(
                 ProcessorError, "version_comparison_key.*could not be found"
             ):
@@ -380,7 +376,7 @@ class TestMunkiImporter(unittest.TestCase):
             }
         ]
 
-        with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+        with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
             mock_library = MagicMock()
             mock_library.munki_repo = self.munki_repo
             mock_fetch.return_value = mock_library
@@ -410,7 +406,7 @@ class TestMunkiImporter(unittest.TestCase):
         mock_popen.return_value = mock_process
 
         # Mock library methods
-        with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+        with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
             mock_library = MagicMock()
             mock_library.copy_pkg_to_repo.return_value = self.pkg_path
             mock_library.copy_pkginfo_to_repo.return_value = "/path/to/pkginfo"
@@ -440,7 +436,7 @@ class TestMunkiImporter(unittest.TestCase):
         mock_popen.return_value = mock_process
 
         # Mock library methods
-        with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+        with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
             mock_library = MagicMock()
             mock_library.copy_pkg_to_repo.side_effect = [
                 self.pkg_path,  # main package
@@ -472,7 +468,7 @@ class TestMunkiImporter(unittest.TestCase):
         mock_popen.return_value = mock_process
 
         # Mock library methods
-        with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+        with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
             mock_library = MagicMock()
             mock_library.copy_pkg_to_repo.return_value = os.path.join(
                 self.munki_repo, "pkgs", "TestApp-1.0.0.pkg"
@@ -512,7 +508,7 @@ class TestMunkiImporter(unittest.TestCase):
             mock_popen.return_value = mock_process
 
             # Mock library methods
-            with patch.object(self.processor, "_fetch_repo_library") as mock_fetch:
+            with patch.object(_munki_importer_mod, "fetch_repo_library") as mock_fetch:
                 mock_library = MagicMock()
                 mock_library.copy_pkg_to_repo.return_value = self.pkg_path
                 mock_library.copy_pkginfo_to_repo.return_value = "/path/to/pkginfo"

--- a/Code/tests/test_munkioptionalreceipteditor.py
+++ b/Code/tests/test_munkioptionalreceipteditor.py
@@ -1,0 +1,166 @@
+#!/usr/local/autopkg/python
+
+import os
+import plistlib
+import sys
+import unittest
+from copy import deepcopy
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+from autopkglib import ProcessorError
+from autopkglib.MunkiOptionalReceiptEditor import MunkiOptionalReceiptEditor
+
+_receipt_editor_mod = sys.modules["autopkglib.MunkiOptionalReceiptEditor"]
+
+
+@unittest.skipUnless(sys.platform == "darwin", "Munki is macOS-only")
+class TestMunkiOptionalReceiptEditor(unittest.TestCase):
+    """Test class for MunkiOptionalReceiptEditor Processor."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.munki_repo = os.path.join(self.tmp_dir.name, "munki_repo")
+        os.makedirs(os.path.join(self.munki_repo, "pkgsinfo"))
+
+        self.pkginfo = {
+            "name": "TestApp",
+            "version": "1.0.0",
+            "catalogs": ["testing"],
+            "receipts": [
+                {"packageid": "com.example.app", "version": "1.0.0"},
+                {"packageid": "com.example.helper", "version": "1.0.0"},
+                {"packageid": "com.example.extra", "version": "1.0.0"},
+            ],
+        }
+
+        self.pkginfo_path = os.path.join(
+            self.munki_repo, "pkgsinfo", "TestApp-1.0.0.plist"
+        )
+        with open(self.pkginfo_path, "wb") as f:
+            plistlib.dump(self.pkginfo, f)
+
+        self.good_env = {
+            "pkginfo_repo_path": self.pkginfo_path,
+            "pkg_ids_set_optional_true": ["com.example.helper"],
+            "MUNKI_REPO": self.munki_repo,
+            "MUNKI_REPO_PLUGIN": "FileRepo",
+            "MUNKILIB_DIR": "/usr/local/munki",
+            "force_munki_repo_lib": False,
+        }
+
+        self.processor = MunkiOptionalReceiptEditor()
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def test_sets_receipt_optional(self):
+        """Matching receipts are set to optional=True."""
+        self.processor.env = deepcopy(self.good_env)
+        self.processor.main()
+
+        with open(self.pkginfo_path, "rb") as f:
+            result = plistlib.load(f)
+
+        self.assertFalse(result["receipts"][0].get("optional", False))
+        self.assertTrue(result["receipts"][1]["optional"])
+        self.assertFalse(result["receipts"][2].get("optional", False))
+
+    def test_sets_multiple_receipts_optional(self):
+        """Multiple matching receipts are all set to optional."""
+        self.processor.env = deepcopy(self.good_env)
+        self.processor.env["pkg_ids_set_optional_true"] = [
+            "com.example.app",
+            "com.example.extra",
+        ]
+        self.processor.main()
+
+        with open(self.pkginfo_path, "rb") as f:
+            result = plistlib.load(f)
+
+        self.assertTrue(result["receipts"][0]["optional"])
+        self.assertFalse(result["receipts"][1].get("optional", False))
+        self.assertTrue(result["receipts"][2]["optional"])
+
+    def test_no_matching_receipts_does_not_write(self):
+        """When no receipts match, the file is not rewritten."""
+        self.processor.env = deepcopy(self.good_env)
+        self.processor.env["pkg_ids_set_optional_true"] = ["com.nonexistent.app"]
+
+        mtime_before = os.path.getmtime(self.pkginfo_path)
+        self.processor.main()
+        mtime_after = os.path.getmtime(self.pkginfo_path)
+
+        self.assertEqual(mtime_before, mtime_after)
+
+    def test_no_receipts_raises_error(self):
+        """Raises ProcessorError when pkginfo has no receipts key."""
+        pkginfo_no_receipts = {"name": "TestApp", "version": "1.0.0"}
+        with open(self.pkginfo_path, "wb") as f:
+            plistlib.dump(pkginfo_no_receipts, f)
+
+        self.processor.env = deepcopy(self.good_env)
+
+        with self.assertRaises(ProcessorError):
+            self.processor.main()
+
+    def test_empty_pkginfo_repo_path_skips(self):
+        """Empty pkginfo_repo_path causes early return."""
+        self.processor.env = deepcopy(self.good_env)
+        self.processor.env["pkginfo_repo_path"] = ""
+        self.processor.main()
+
+    def test_reads_from_munki_info_when_available(self):
+        """Uses in-memory munki_info instead of reading from disk."""
+        self.processor.env = deepcopy(self.good_env)
+        in_memory_pkginfo = deepcopy(self.pkginfo)
+        in_memory_pkginfo["receipts"][0]["version"] = "9.9.9"
+        self.processor.env["munki_info"] = in_memory_pkginfo
+
+        self.processor.main()
+
+        with open(self.pkginfo_path, "rb") as f:
+            result = plistlib.load(f)
+
+        self.assertEqual(result["receipts"][0]["version"], "9.9.9")
+        self.assertTrue(result["receipts"][1]["optional"])
+
+    def test_updates_munki_info_in_env(self):
+        """After modifying, munki_info is updated in the environment."""
+        self.processor.env = deepcopy(self.good_env)
+        self.processor.main()
+
+        self.assertIn("munki_info", self.processor.env)
+        self.assertTrue(self.processor.env["munki_info"]["receipts"][1]["optional"])
+
+    def test_sets_munki_info_when_no_receipts_modified(self):
+        """munki_info is set even when no receipts match."""
+        self.processor.env = deepcopy(self.good_env)
+        self.processor.env["pkg_ids_set_optional_true"] = ["com.nonexistent.app"]
+        self.processor.main()
+
+        self.assertIn("munki_info", self.processor.env)
+        self.assertEqual(
+            self.processor.env["munki_info"]["receipts"], self.pkginfo["receipts"]
+        )
+
+    @patch.object(_receipt_editor_mod, "fetch_repo_library")
+    def test_writes_through_repo_library(self, mock_fetch):
+        """Write is routed through the repo library, not raw open()."""
+        mock_library = MagicMock()
+        mock_fetch.return_value = mock_library
+
+        self.processor.env = deepcopy(self.good_env)
+        self.processor.main()
+
+        mock_library.put_pkginfo_to_repo.assert_called_once()
+        args = mock_library.put_pkginfo_to_repo.call_args
+        written_pkginfo = args[0][0]
+        written_path = args[0][1]
+
+        self.assertTrue(written_pkginfo["receipts"][1]["optional"])
+        self.assertEqual(written_path, self.pkginfo_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Code/tests/test_searchcmd.py
+++ b/Code/tests/test_searchcmd.py
@@ -603,12 +603,9 @@ class TestSearchCmd(unittest.TestCase):
             stdout_output = mock_stdout.getvalue()
             stderr_output = mock_stderr.getvalue()
 
-        # Should warn about exceeding limit (note: due to elif, this actually
-        # shows "nearing" instead of "greater than" - see searchcmd.py:115-117)
         combined_output = stdout_output + stderr_output
         self.assertIn("WARNING", combined_output)
-        # Due to the elif logic, size > 100MB will show "nearing" not "greater than"
-        self.assertIn("nearing", combined_output)
+        self.assertIn("greater than", combined_output)
 
     @patch("builtins.open", new_callable=mock_open)
     @patch("os.path.isfile")


### PR DESCRIPTION
Fixes #1031. `MunkiOptionalReceiptEditor` wrote directly to disk via `open()`/`plistlib.dump()`, bypassing the Munki repo plugin API. Changes made by this processor were silently lost when using `GitFileRepo` or other non-FileRepo plugins.

- Add `put_pkginfo_to_repo()` to both `AutoPkgLib` and `MunkiLib` for updating existing pkginfo files through the repo plugin
- Refactor `MunkiOptionalReceiptEditor` to read from in-memory `munki_info` when available and write through the repo library
- Extract `fetch_repo_library()` to `munkirepolibs/__init__.py` as a shared helper (previously private to `MunkiImporter`)
- Add unit tests for `MunkiOptionalReceiptEditor`