### PR TITLE
Add pkgbuild_args input variable to PkgCreator and AppPkgCreator

### DIFF
--- a/Code/autopkglib/AppPkgCreator.py
+++ b/Code/autopkglib/AppPkgCreator.py
@@ -73,6 +73,24 @@ class AppPkgCreator(DmgMounter, PkgCreator):
             ),
             "default": False,
         },
+        "pkgbuild_args": {
+            "required": False,
+            "description": (
+                "A list of additional arguments to pass to the pkgbuild "
+                "tool. For example, ['--large-payload'] for packages "
+                "over 8GB. You can also override pkgbuild's "
+                "default file exclusion filters. By default, pkgbuild "
+                "excludes .svn, CVS, .DS_Store, and .git from the "
+                "payload. Specifying even one --filter replaces ALL "
+                "default filters, so to keep .git files in your "
+                "package while still filtering out .DS_Store, use: "
+                "['--filter', '\\.DS_Store$']. Each --filter value is "
+                "a regular expression (use backslash escapes for "
+                "literal dots, etc.) matched against paths in the "
+                "package root."
+            ),
+            "default": None,
+        },
     }
     output_variables = {
         "new_package_request": {
@@ -196,6 +214,7 @@ class AppPkgCreator(DmgMounter, PkgCreator):
             "infofile": "",
             "chown": [{"path": "Applications", "user": "root", "group": "admin"}],
             "scripts": "",
+            "pkgbuild_args": self.env.get("pkgbuild_args") or [],
         }
 
         # Send packaging request.

--- a/Code/autopkglib/PkgCreator.py
+++ b/Code/autopkglib/PkgCreator.py
@@ -50,6 +50,24 @@ class PkgCreator(Processor):
             ),
             "default": False,
         },
+        "pkgbuild_args": {
+            "required": False,
+            "description": (
+                "A list of additional arguments to pass to the pkgbuild "
+                "tool. For example, ['--large-payload'] for packages "
+                "over 8GB. You can also override pkgbuild's "
+                "default file exclusion filters. By default, pkgbuild "
+                "excludes .svn, CVS, .DS_Store, and .git from the "
+                "payload. Specifying even one --filter replaces ALL "
+                "default filters, so to keep .git files in your "
+                "package while still filtering out .DS_Store, use: "
+                "['--filter', '\\.DS_Store$']. Each --filter value is "
+                "a regular expression (use backslash escapes for "
+                "literal dots, etc.) matched against paths in the "
+                "package root."
+            ),
+            "default": None,
+        },
     }
     output_variables = {
         "pkg_path": {"description": "The created package."},
@@ -194,6 +212,10 @@ class PkgCreator(Processor):
         # Make sure chown array is present.
         if "chown" not in request:
             request["chown"] = []
+
+        # Include extra pkgbuild arguments if provided.
+        if "pkgbuild_args" not in request:
+            request["pkgbuild_args"] = self.env.get("pkgbuild_args") or []
 
         # Convert relative paths to absolute.
         for key, value in list(request.items()):

--- a/Code/autopkgserver/autopkgserver
+++ b/Code/autopkgserver/autopkgserver
@@ -110,7 +110,6 @@ request_structure = {
     "infofile": str,
     "chown": list,
     "scripts": str,
-    "pkgbuild_args": list,
 }
 chown_structure = {"path": str, "user": (str, int), "group": (str, int), "mode": str}
 
@@ -177,11 +176,16 @@ class PkgHandler(socketserver.StreamRequestHandler):
                             )
                             syntax_ok = False
 
-            # Make sure all pkgbuild_args entries are strings.
-            for arg in plist["pkgbuild_args"]:
-                if not isinstance(arg, str):
-                    errors.append(f"pkgbuild_args entry is not a string: {arg!r}")
-                    syntax_ok = False
+            # Default pkgbuild_args to empty list if absent.
+            plist.setdefault("pkgbuild_args", [])
+            if not isinstance(plist["pkgbuild_args"], list):
+                errors.append(f"Request key pkgbuild_args is not of type {str(list)}")
+                syntax_ok = False
+            else:
+                for arg in plist["pkgbuild_args"]:
+                    if not isinstance(arg, str):
+                        errors.append(f"pkgbuild_args entry is not a string: {arg!r}")
+                        syntax_ok = False
 
         return (syntax_ok, errors)
 

--- a/Code/autopkgserver/autopkgserver
+++ b/Code/autopkgserver/autopkgserver
@@ -110,6 +110,7 @@ request_structure = {
     "infofile": str,
     "chown": list,
     "scripts": str,
+    "pkgbuild_args": list,
 }
 chown_structure = {"path": str, "user": (str, int), "group": (str, int), "mode": str}
 
@@ -175,6 +176,12 @@ class PkgHandler(socketserver.StreamRequestHandler):
                                 f"Request key chown.{key} is not of type {str(keytype)}"
                             )
                             syntax_ok = False
+
+            # Make sure all pkgbuild_args entries are strings.
+            for arg in plist["pkgbuild_args"]:
+                if not isinstance(arg, str):
+                    errors.append(f"pkgbuild_args entry is not a string: {arg!r}")
+                    syntax_ok = False
 
         return (syntax_ok, errors)
 

--- a/Code/autopkgserver/packager.py
+++ b/Code/autopkgserver/packager.py
@@ -477,6 +477,8 @@ class Packager:
                 cmd.extend(["--info", self.request["infofile"]])
             if self.request["scripts"]:
                 cmd.extend(["--scripts", self.request["scripts"]])
+            if self.request.get("pkgbuild_args"):
+                cmd.extend(self.request["pkgbuild_args"])
             cmd.append(temppkgpath)
 
             # Execute pkgbuild.

--- a/Code/tests/test_autopkgserver.py
+++ b/Code/tests/test_autopkgserver.py
@@ -85,6 +85,7 @@ class TestPkgHandler(unittest.TestCase):
             "infofile": "",
             "chown": [],
             "scripts": "",
+            "pkgbuild_args": [],
         }
         syntax_ok, errors = self.handler.verify_request_syntax(plist)
 
@@ -128,6 +129,7 @@ class TestPkgHandler(unittest.TestCase):
             "infofile": "",
             "chown": "not_a_list",  # Should be a list
             "scripts": "",
+            "pkgbuild_args": [],
         }
         syntax_ok, errors = self.handler.verify_request_syntax(plist)
 
@@ -146,6 +148,7 @@ class TestPkgHandler(unittest.TestCase):
             "infofile": "",
             "chown": [],
             "scripts": "",
+            "pkgbuild_args": [],
         }
         syntax_ok, errors = self.handler.verify_request_syntax(plist)
 
@@ -164,6 +167,7 @@ class TestPkgHandler(unittest.TestCase):
             "infofile": "",
             "chown": ["not_a_dict"],  # Should be list of dicts
             "scripts": "",
+            "pkgbuild_args": [],
         }
         syntax_ok, errors = self.handler.verify_request_syntax(plist)
 
@@ -189,6 +193,7 @@ class TestPkgHandler(unittest.TestCase):
                 }
             ],
             "scripts": "",
+            "pkgbuild_args": [],
         }
         syntax_ok, errors = self.handler.verify_request_syntax(plist)
 
@@ -209,6 +214,7 @@ class TestPkgHandler(unittest.TestCase):
                 {"path": "Applications", "user": "root"}  # Missing group and mode
             ],
             "scripts": "",
+            "pkgbuild_args": [],
         }
         syntax_ok, errors = self.handler.verify_request_syntax(plist)
 
@@ -227,11 +233,50 @@ class TestPkgHandler(unittest.TestCase):
             "infofile": "",
             "chown": [{"path": "Applications", "user": 0, "group": 0, "mode": "0755"}],
             "scripts": "",
+            "pkgbuild_args": [],
         }
         syntax_ok, errors = self.handler.verify_request_syntax(plist)
 
         self.assertTrue(syntax_ok)
         self.assertEqual(errors, [])
+
+    def test_verify_request_syntax_valid_pkgbuild_args(self):
+        """Should return True for valid pkgbuild_args."""
+        plist = {
+            "pkgroot": "/tmp/pkgroot",
+            "pkgdir": "/tmp/output",
+            "pkgname": "TestPackage",
+            "pkgtype": "flat",
+            "id": "com.example.test",
+            "version": "1.0.0",
+            "infofile": "",
+            "chown": [],
+            "scripts": "",
+            "pkgbuild_args": ["--filter", ".git", "--large-payload"],
+        }
+        syntax_ok, errors = self.handler.verify_request_syntax(plist)
+
+        self.assertTrue(syntax_ok)
+        self.assertEqual(errors, [])
+
+    def test_verify_request_syntax_invalid_pkgbuild_args_entry(self):
+        """Should return False when pkgbuild_args contains non-string."""
+        plist = {
+            "pkgroot": "/tmp/pkgroot",
+            "pkgdir": "/tmp/output",
+            "pkgname": "TestPackage",
+            "pkgtype": "flat",
+            "id": "com.example.test",
+            "version": "1.0.0",
+            "infofile": "",
+            "chown": [],
+            "scripts": "",
+            "pkgbuild_args": ["--filter", 123],
+        }
+        syntax_ok, errors = self.handler.verify_request_syntax(plist)
+
+        self.assertFalse(syntax_ok)
+        self.assertTrue(any("pkgbuild_args" in error for error in errors))
 
 
 @unittest.skipUnless(sys.platform == "darwin", "Unix sockets are Unix-only")
@@ -346,6 +391,7 @@ class TestConstants(unittest.TestCase):
             "infofile",
             "chown",
             "scripts",
+            "pkgbuild_args",
         ]
         for key in required_keys:
             self.assertIn(key, request_structure)

--- a/Code/tests/test_autopkgserver.py
+++ b/Code/tests/test_autopkgserver.py
@@ -278,6 +278,25 @@ class TestPkgHandler(unittest.TestCase):
         self.assertFalse(syntax_ok)
         self.assertTrue(any("pkgbuild_args" in error for error in errors))
 
+    def test_verify_request_syntax_missing_pkgbuild_args_defaults(self):
+        """Should default pkgbuild_args to empty list when absent."""
+        plist = {
+            "pkgroot": "/tmp/pkgroot",
+            "pkgdir": "/tmp/output",
+            "pkgname": "TestPackage",
+            "pkgtype": "flat",
+            "id": "com.example.test",
+            "version": "1.0.0",
+            "infofile": "",
+            "chown": [],
+            "scripts": "",
+        }
+        syntax_ok, errors = self.handler.verify_request_syntax(plist)
+
+        self.assertTrue(syntax_ok)
+        self.assertEqual(errors, [])
+        self.assertEqual(plist["pkgbuild_args"], [])
+
 
 @unittest.skipUnless(sys.platform == "darwin", "Unix sockets are Unix-only")
 class TestAutoPkgServer(unittest.TestCase):
@@ -391,7 +410,6 @@ class TestConstants(unittest.TestCase):
             "infofile",
             "chown",
             "scripts",
-            "pkgbuild_args",
         ]
         for key in required_keys:
             self.assertIn(key, request_structure)

--- a/Code/tests/test_packager.py
+++ b/Code/tests/test_packager.py
@@ -16,7 +16,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Only load the module on Darwin, otherwise create dummy
 if sys.platform == "darwin":
@@ -24,6 +24,7 @@ if sys.platform == "darwin":
     autopkgserver_path = Path(__file__).parent.parent / "autopkgserver" / "packager.py"
     spec = importlib.util.spec_from_file_location("packager", autopkgserver_path)
     packager_module = importlib.util.module_from_spec(spec)
+    sys.modules["packager"] = packager_module
     spec.loader.exec_module(packager_module)
     Packager = packager_module.Packager
 else:
@@ -66,6 +67,85 @@ class TestPackager(unittest.TestCase):
                 length,
                 f"Expected length {length}, got {len(result)}: {result}",
             )
+
+
+@unittest.skipUnless(sys.platform == "darwin", "Uses Unix grp module")
+class TestPackagerCreatePkgCommand(unittest.TestCase):
+    """Test that create_pkg builds the correct pkgbuild command."""
+
+    def _make_packager(self, request):
+        mock_log = MagicMock()
+        pkgr = Packager(log=mock_log, request=request, name="test", uid=501, gid=20)
+        pkgr.tmp_pkgroot = "/tmp/pkgroot"
+        pkgr.component_plist = "/tmp/component.plist"
+        pkgr.tmproot = "/tmp/tmproot"
+        return pkgr
+
+    @patch("packager.os.chown")
+    @patch("packager.os.rename")
+    @patch("packager.subprocess.Popen")
+    def test_pkgbuild_args_appear_before_output_path(
+        self, mock_popen, mock_rename, mock_chown
+    ):
+        """Extra pkgbuild_args should appear after standard flags but before the output path."""
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = ("", "")
+        mock_proc.returncode = 0
+        mock_popen.return_value = mock_proc
+
+        request = {
+            "pkgtype": "flat",
+            "pkgname": "Test",
+            "pkgdir": "/tmp/output",
+            "id": "com.example.test",
+            "version": "1.0",
+            "infofile": "",
+            "scripts": "",
+            "pkgbuild_args": ["--filter", "\\.DS_Store$", "--large-payload"],
+        }
+        pkgr = self._make_packager(request)
+        pkgr.create_pkg()
+
+        cmd = mock_popen.call_args[0][0]
+        # Extra args should be present
+        self.assertIn("--filter", cmd)
+        self.assertIn("\\.DS_Store$", cmd)
+        self.assertIn("--large-payload", cmd)
+        # Output path is always last
+        self.assertTrue(cmd[-1].endswith(".pkg"))
+        # Extra args come before output path
+        filter_idx = cmd.index("--filter")
+        self.assertLess(filter_idx, len(cmd) - 1)
+
+    @patch("packager.os.chown")
+    @patch("packager.os.rename")
+    @patch("packager.subprocess.Popen")
+    def test_no_pkgbuild_args_omits_extra_flags(
+        self, mock_popen, mock_rename, mock_chown
+    ):
+        """Without pkgbuild_args, command should have no extra flags."""
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = ("", "")
+        mock_proc.returncode = 0
+        mock_popen.return_value = mock_proc
+
+        request = {
+            "pkgtype": "flat",
+            "pkgname": "Test",
+            "pkgdir": "/tmp/output",
+            "id": "com.example.test",
+            "version": "1.0",
+            "infofile": "",
+            "scripts": "",
+        }
+        pkgr = self._make_packager(request)
+        pkgr.create_pkg()
+
+        cmd = mock_popen.call_args[0][0]
+        self.assertEqual(cmd[0], "/usr/bin/pkgbuild")
+        self.assertTrue(cmd[-1].endswith(".pkg"))
+        self.assertNotIn("--filter", cmd)
+        self.assertNotIn("--large-payload", cmd)
 
 
 if __name__ == "__main__":

--- a/Code/tests/test_pkgcreator.py
+++ b/Code/tests/test_pkgcreator.py
@@ -42,6 +42,7 @@ class TestPkgCreator(unittest.TestCase):
                 "infofile": "",
                 "scripts": "",
                 "chown": [],
+                "pkgbuild_args": [],
             },
             "RECIPE_CACHE_DIR": self.tmp_dir.name,
             "RECIPE_DIR": self.tmp_dir.name,
@@ -376,6 +377,39 @@ class TestPkgCreator(unittest.TestCase):
         self.assertIn("summary_text", summary)
         self.assertIn("data", summary)
         self.assertEqual(summary["data"]["pkg_path"], pkg_path)
+
+    def test_fills_in_default_pkgbuild_args(self):
+        """The processor should default pkgbuild_args to empty list."""
+        self.processor.env = deepcopy(self.minimal_env)
+
+        with patch("autopkglib.PkgCreator.pkg_already_exists", return_value=True):
+            self.processor.main()
+
+        request = self.processor.env["pkg_request"]
+        self.assertEqual(request["pkgbuild_args"], [])
+
+    def test_pkgbuild_args_from_env(self):
+        """The processor should use pkgbuild_args from env if not in request."""
+        self.processor.env = deepcopy(self.minimal_env)
+        self.processor.env["pkgbuild_args"] = ["--filter", ".git"]
+
+        with patch("autopkglib.PkgCreator.pkg_already_exists", return_value=True):
+            self.processor.main()
+
+        request = self.processor.env["pkg_request"]
+        self.assertEqual(request["pkgbuild_args"], ["--filter", ".git"])
+
+    def test_pkgbuild_args_in_request_not_overridden(self):
+        """pkgbuild_args in request should take precedence over env."""
+        self.processor.env = deepcopy(self.good_env)
+        self.processor.env["pkg_request"]["pkgbuild_args"] = ["--large-payload"]
+        self.processor.env["pkgbuild_args"] = ["--filter", ".git"]
+
+        with patch("autopkglib.PkgCreator.pkg_already_exists", return_value=True):
+            self.processor.main()
+
+        request = self.processor.env["pkg_request"]
+        self.assertEqual(request["pkgbuild_args"], ["--large-payload"])
 
     def test_force_pkg_build_overrides_existing(self):
         """Test that force_pkg_build overrides existing package check."""


### PR DESCRIPTION
Adds a `pkgbuild_args` input variable to `PkgCreator` and `AppPkgCreator` that forwards additional flags to the `pkgbuild` tool. This allows recipe authors to pass flags like `--filter`, `--large-payload`, or any other `pkgbuild` option without modifying AutoPkg itself.

Motivated by cases where pkgbuild's default behavior needs adjustment for specific packages — for example, apps containing files named `.git` that are stripped by pkgbuild's default filters, or packages exceeding 8GB that require `--large-payload`.

- `PkgCreator` and `AppPkgCreator`: new optional `pkgbuild_args` input variable (list of strings, defaults to empty)
- `autopkgserver`: added `pkgbuild_args` to the request structure with validation that all entries are strings
- `packager.py`: extra args are inserted into the `pkgbuild` command before the output path
- Tests updated for both autopkgserver validation and PkgCreator behavior (default, env-sourced, request-precedence)

Closes #981