### PR TITLE
Include PkgCreator script files in override trust verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,10 @@ A new `COMPUTE_HASHES` input variable (default: `False`) enables on-demand compu
 
 ### Other
 
-- Added preinstall/postinstall scripts used by PkgCreator to recipe override trust information.
+- Files in PkgCreator `scripts` directories are now included in recipe override trust information. Changes to preinstall/postinstall scripts or any other files bundled into packages will now trigger trust verification failures. Only git-tracked files are hashed when the scripts directory is inside a git repo, so untracked files like `.DS_Store` won't cause false trust failures. (#980)
 
     > [!NOTE]
-    > Overrides of recipes that reference preinstall/postinstall scripts should be updated with `autopkg update-trust-info` to add script trust info. In AutoPkg 3.0.0, untracked scripts produce a warning; starting in AutoPkg 3.0.1, this will be a trust verification error.
+    > Overrides of recipes that use PkgCreator scripts should be updated with `autopkg update-trust-info` to add script trust info. In AutoPkg 3.0.0, missing script trust info produces a warning; starting in AutoPkg 3.0.1, this will be a trust verification error.
 
 - PkgCreator and AppPkgCreator: new `pkgbuild_args` input variable allows forwarding additional flags (e.g. `--filter`, `--large-payload`) to the `pkgbuild` tool (#981)
 - MunkiOptionalReceiptEditor now routes pkginfo updates through the Munki repo plugin API, fixing silent data loss when using `GitFileRepo` or other non-filesystem repo plugins (#1031)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ A new `COMPUTE_HASHES` input variable (default: `False`) enables on-demand compu
 
 ### Other
 
+- Added preinstall/postinstall scripts used by PkgCreator to recipe override trust information.
+
+    > [!NOTE]
+    > Overrides of recipes that reference preinstall/postinstall scripts should be updated with `autopkg update-trust-info` to add script trust info. In AutoPkg 3.0.0, untracked scripts produce a warning; starting in AutoPkg 3.0.1, this will be a trust verification error.
+
 - PkgCreator and AppPkgCreator: new `pkgbuild_args` input variable allows forwarding additional flags (e.g. `--filter`, `--large-payload`) to the `pkgbuild` tool (#981)
 - MunkiOptionalReceiptEditor now routes pkginfo updates through the Munki repo plugin API, fixing silent data loss when using `GitFileRepo` or other non-filesystem repo plugins (#1031)
 - `make-override --format` can now be set globally via the `RECIPE_OVERRIDE_FORMAT` preference, so you don't need to pass `--format yaml` on every invocation (#1024)

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1606,6 +1606,20 @@ def find_scripts_dir_path(scripts_dir, recipe):
     return None
 
 
+def get_git_tracked_files(dirpath):
+    """Return the set of absolute paths of git-tracked files under dirpath,
+    or None if dirpath is not inside a git working tree."""
+    try:
+        output = run_git(["ls-files", "-z"], git_directory=dirpath)
+    except GitError:
+        return None
+    return {
+        os.path.normpath(os.path.join(dirpath, entry))
+        for entry in output.split("\0")
+        if entry
+    }
+
+
 def os_path_compressuser(pathname):
     """Sort of the inverse of os.path.expanduser"""
     home_dir = os.path.expanduser("~")
@@ -1658,7 +1672,7 @@ def get_trust_info(recipe, search_dirs=None):
         if git_hash:
             non_core_processor_hashes[processor]["git_hash"] = git_hash
 
-    # generate hashes for preinstall/postinstall scripts used by PkgCreator
+    # generate hashes for all files in PkgCreator scripts directories
     script_hashes = {}
     for step in recipe.get("Process", []):
         if step.get("Processor") != "PkgCreator":
@@ -1667,19 +1681,25 @@ def get_trust_info(recipe, search_dirs=None):
         scripts_path = find_scripts_dir_path(scripts_dir, recipe)
         if not scripts_path:
             continue
-        for script_name in ("preinstall", "postinstall"):
-            script_path = os.path.join(scripts_path, script_name)
-            if not os.path.isfile(script_path):
-                continue
-            script_key = os.path.join(scripts_dir, script_name)
-            script_hash = getsha256hash(script_path)
-            git_hash = get_git_commit_hash(script_path)
-            script_hashes[script_key] = {
-                "path": os_path_compressuser(script_path),
-                "sha256_hash": script_hash,
-            }
-            if git_hash:
-                script_hashes[script_key]["git_hash"] = git_hash
+        tracked_files = get_git_tracked_files(scripts_path)
+        for dirpath, _, filenames in os.walk(scripts_path):
+            for filename in sorted(filenames):
+                script_path = os.path.normpath(os.path.join(dirpath, filename))
+                if tracked_files is not None and script_path not in tracked_files:
+                    continue
+                script_key = os.path.join(
+                    scripts_dir, os.path.relpath(script_path, scripts_path)
+                )
+                if script_key in script_hashes:
+                    continue
+                script_hash = getsha256hash(script_path)
+                git_hash = get_git_commit_hash(script_path)
+                script_hashes[script_key] = {
+                    "path": os_path_compressuser(script_path),
+                    "sha256_hash": script_hash,
+                }
+                if git_hash:
+                    script_hashes[script_key]["git_hash"] = git_hash
 
     # return a dictionary containing the hashes we generated
     return {

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1688,7 +1688,8 @@ def get_trust_info(recipe, search_dirs=None):
                 if tracked_files is not None and script_path not in tracked_files:
                     continue
                 script_key = os.path.join(
-                    scripts_dir, os.path.relpath(script_path, scripts_path)
+                    os.path.normpath(scripts_dir),
+                    os.path.relpath(script_path, scripts_path),
                 )
                 if script_key in script_hashes:
                     continue

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1577,6 +1577,35 @@ def find_processor_path(processor_name, recipe, env=None):
     return None
 
 
+def find_scripts_dir_path(scripts_dir, recipe):
+    """Returns the pathname to a PkgCreator scripts directory.
+
+    NOTE: If multiple parent recipes each contain a subdirectory matching
+    scripts_dir, only the first one found is returned.  This means two
+    PkgCreator steps that specify the same relative scripts directory but
+    originate from different parent recipes will silently resolve to the
+    same path.  Fixing this would require associating each Process step
+    with the recipe it came from during recipe flattening.
+    """
+    if not scripts_dir:
+        return None
+    if os.path.isabs(scripts_dir) and os.path.isdir(scripts_dir):
+        return os.path.normpath(scripts_dir)
+    if recipe:
+        recipe_dir = os.path.dirname(recipe["RECIPE_PATH"])
+        scripts_search_dirs = [recipe_dir]
+        if recipe.get("PARENT_RECIPES"):
+            parent_recipe_dirs = list(
+                {os.path.dirname(item) for item in recipe["PARENT_RECIPES"]}
+            )
+            scripts_search_dirs.extend(parent_recipe_dirs)
+        for directory in scripts_search_dirs:
+            scripts_path = os.path.join(directory, scripts_dir)
+            if os.path.isdir(scripts_path):
+                return os.path.normpath(scripts_path)
+    return None
+
+
 def os_path_compressuser(pathname):
     """Sort of the inverse of os.path.expanduser"""
     home_dir = os.path.expanduser("~")
@@ -1629,9 +1658,33 @@ def get_trust_info(recipe, search_dirs=None):
         if git_hash:
             non_core_processor_hashes[processor]["git_hash"] = git_hash
 
+    # generate hashes for preinstall/postinstall scripts used by PkgCreator
+    script_hashes = {}
+    for step in recipe.get("Process", []):
+        if step.get("Processor") != "PkgCreator":
+            continue
+        scripts_dir = step.get("Arguments", {}).get("pkg_request", {}).get("scripts")
+        scripts_path = find_scripts_dir_path(scripts_dir, recipe)
+        if not scripts_path:
+            continue
+        for script_name in ("preinstall", "postinstall"):
+            script_path = os.path.join(scripts_path, script_name)
+            if not os.path.isfile(script_path):
+                continue
+            script_key = os.path.join(scripts_dir, script_name)
+            script_hash = getsha256hash(script_path)
+            git_hash = get_git_commit_hash(script_path)
+            script_hashes[script_key] = {
+                "path": os_path_compressuser(script_path),
+                "sha256_hash": script_hash,
+            }
+            if git_hash:
+                script_hashes[script_key]["git_hash"] = git_hash
+
     # return a dictionary containing the hashes we generated
     return {
         "non_core_processors": non_core_processor_hashes,
+        "scripts": script_hashes,
         "parent_recipes": parent_recipe_hashes,
     }
 
@@ -1851,6 +1904,39 @@ def verify_parent_trust(recipe, override_dirs, search_dirs, verbosity=0):
             processor_path = find_processor_path(processor, recipe)
             if processor_path:
                 trust_errors += f"    Path: {processor_path}\n"
+
+    # get detail on scripts
+    expected_scripts = expected_trust_info.get("scripts", {})
+    actual_scripts = actual_trust_info.get("scripts", {})
+    expected_script_keys = set(expected_scripts.keys())
+    actual_script_keys = set(actual_scripts.keys())
+    for script_key in expected_script_keys:
+        expected_hash = expected_scripts[script_key]["sha256_hash"]
+        git_hash = expected_scripts[script_key].get("git_hash")
+        script_path = expected_scripts[script_key].get("path", "")
+        actual_script = actual_scripts.get(script_key, {})
+        actual_hash = actual_script.get("sha256_hash")
+        if expected_hash != actual_hash:
+            if actual_script:
+                trust_errors += f"Script {script_key} contents differ from expected.\n"
+            else:
+                trust_errors += f"Expected script {script_key} can't be found.\n"
+            if script_path:
+                trust_errors += f"    Path: {script_path}\n"
+            if verbosity > 1 and git_hash and script_path:
+                trust_errors += get_git_diff(script_path, git_hash)
+                trust_errors += get_git_log(script_path, git_hash)
+                trust_errors += "\n"
+    for script_key in actual_script_keys:
+        if script_key not in expected_script_keys:
+            script_path = actual_scripts[script_key].get("path", "")
+            log_err(
+                f"WARNING: Script trust info missing for {script_key}.\n"
+                f"    Path: {script_path}\n"
+                f"    Run `autopkg update-trust-info` to add script trust info.\n"
+                f"    Starting in AutoPkg 3.0.1, this will be a trust verification "
+                f"error."
+            )
 
     # get detail on parent_recipes
     expected_parent_recipes = list(expected_trust_info["parent_recipes"].keys())

--- a/Code/tests/test_autopkg_overrides.py
+++ b/Code/tests/test_autopkg_overrides.py
@@ -136,6 +136,160 @@ class TestAutoPkgOverrides(unittest.TestCase):
             # Should log a warning
             mock_log_err.assert_called_once()
 
+    def test_find_scripts_dir_path_none_input(self):
+        """find_scripts_dir_path returns None for None or empty scripts_dir."""
+        self.assertIsNone(autopkg.find_scripts_dir_path(None, {}))
+        self.assertIsNone(autopkg.find_scripts_dir_path("", {}))
+
+    def test_find_scripts_dir_path_absolute(self):
+        """find_scripts_dir_path returns normalized path for existing absolute dir."""
+        scripts_dir = os.path.join(self.tmp_dir.name, "Scripts")
+        os.makedirs(scripts_dir)
+        result = autopkg.find_scripts_dir_path(scripts_dir, {})
+        self.assertEqual(result, os.path.normpath(scripts_dir))
+
+    def test_find_scripts_dir_path_absolute_missing(self):
+        """find_scripts_dir_path returns None for non-existent absolute dir."""
+        result = autopkg.find_scripts_dir_path("/no/such/dir", {})
+        self.assertIsNone(result)
+
+    def test_find_scripts_dir_path_relative_in_recipe_dir(self):
+        """find_scripts_dir_path finds scripts dir relative to recipe dir."""
+        recipe_dir = os.path.join(self.tmp_dir.name, "repo")
+        scripts_dir = os.path.join(recipe_dir, "Scripts")
+        os.makedirs(scripts_dir)
+        recipe = {"RECIPE_PATH": os.path.join(recipe_dir, "Test.recipe")}
+        result = autopkg.find_scripts_dir_path("Scripts", recipe)
+        self.assertEqual(result, os.path.normpath(scripts_dir))
+
+    def test_find_scripts_dir_path_relative_in_parent_recipe_dir(self):
+        """find_scripts_dir_path finds scripts dir relative to parent recipe dir."""
+        recipe_dir = os.path.join(self.tmp_dir.name, "override")
+        parent_dir = os.path.join(self.tmp_dir.name, "parent")
+        scripts_dir = os.path.join(parent_dir, "Scripts")
+        os.makedirs(recipe_dir)
+        os.makedirs(scripts_dir)
+        recipe = {
+            "RECIPE_PATH": os.path.join(recipe_dir, "Test.recipe"),
+            "PARENT_RECIPES": [os.path.join(parent_dir, "Parent.recipe")],
+        }
+        result = autopkg.find_scripts_dir_path("Scripts", recipe)
+        self.assertEqual(result, os.path.normpath(scripts_dir))
+
+    def test_find_scripts_dir_path_relative_not_found(self):
+        """find_scripts_dir_path returns None when relative dir not found."""
+        recipe_dir = os.path.join(self.tmp_dir.name, "repo")
+        os.makedirs(recipe_dir)
+        recipe = {"RECIPE_PATH": os.path.join(recipe_dir, "Test.recipe")}
+        result = autopkg.find_scripts_dir_path("NoSuchDir", recipe)
+        self.assertIsNone(result)
+
+    def test_find_scripts_dir_path_no_recipe(self):
+        """find_scripts_dir_path returns None when recipe is None."""
+        self.assertIsNone(autopkg.find_scripts_dir_path("Scripts", None))
+
+    def test_get_trust_info_pkgcreator_scripts(self):
+        """Test get_trust_info captures preinstall/postinstall script trust data."""
+        mock_recipe = {
+            "RECIPE_PATH": "/path/to/test.recipe",
+            "PARENT_RECIPES": [],
+            "Process": [
+                {"Processor": "URLDownloader"},
+                {
+                    "Processor": "PkgCreator",
+                    "Arguments": {"pkg_request": {"scripts": "Scripts"}},
+                },
+            ],
+        }
+
+        with (
+            patch.object(autopkg, "getsha256hash") as mock_hash,
+            patch.object(autopkg, "get_git_commit_hash") as mock_git_hash,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_identifier") as mock_get_identifier,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "find_scripts_dir_path") as mock_find_scripts_dir,
+            patch.object(autopkg, "os_path_compressuser") as mock_compress,
+            patch("autopkg.os.path.isfile") as mock_isfile,
+        ):
+            mock_hash.side_effect = ["recipe_hash", "pre_hash", "post_hash"]
+            mock_git_hash.side_effect = ["recipe_git", "pre_git", "post_git"]
+            mock_load_recipe.return_value = {"Identifier": "com.test.parent"}
+            mock_get_identifier.return_value = "com.test.recipe"
+            mock_core_processors.return_value = ["URLDownloader", "PkgCreator"]
+            mock_find_scripts_dir.return_value = "/path/to/Scripts"
+            mock_compress.side_effect = lambda x: x
+            mock_isfile.side_effect = lambda p: (
+                p
+                in {
+                    "/path/to/Scripts/preinstall",
+                    "/path/to/Scripts/postinstall",
+                }
+            )
+
+            result = autopkg.get_trust_info(mock_recipe)
+
+            self.assertIn("scripts", result)
+            self.assertIn("Scripts/preinstall", result["scripts"])
+            self.assertIn("Scripts/postinstall", result["scripts"])
+            self.assertEqual(
+                result["scripts"]["Scripts/preinstall"]["sha256_hash"],
+                "pre_hash",
+            )
+            self.assertEqual(
+                result["scripts"]["Scripts/preinstall"]["path"],
+                "/path/to/Scripts/preinstall",
+            )
+            self.assertEqual(
+                result["scripts"]["Scripts/postinstall"]["sha256_hash"],
+                "post_hash",
+            )
+            self.assertEqual(
+                result["scripts"]["Scripts/postinstall"]["path"],
+                "/path/to/Scripts/postinstall",
+            )
+
+    def test_get_trust_info_pkgcreator_scripts_dedupes_same_path(self):
+        """Test get_trust_info dedupes scripts used by multiple PkgCreator steps."""
+        mock_recipe = {
+            "RECIPE_PATH": "/path/to/test.recipe",
+            "PARENT_RECIPES": [],
+            "Process": [
+                {
+                    "Processor": "PkgCreator",
+                    "Arguments": {"pkg_request": {"scripts": "Scripts"}},
+                },
+                {
+                    "Processor": "PkgCreator",
+                    "Arguments": {"pkg_request": {"scripts": "Scripts"}},
+                },
+            ],
+        }
+
+        with (
+            patch.object(autopkg, "getsha256hash") as mock_hash,
+            patch.object(autopkg, "get_git_commit_hash") as mock_git_hash,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_identifier") as mock_get_identifier,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "find_scripts_dir_path") as mock_find_scripts_dir,
+            patch.object(autopkg, "os_path_compressuser") as mock_compress,
+            patch("autopkg.os.path.isfile") as mock_isfile,
+        ):
+            mock_hash.return_value = "hash"
+            mock_git_hash.return_value = "git_hash"
+            mock_load_recipe.return_value = {"Identifier": "com.test.parent"}
+            mock_get_identifier.return_value = "com.test.recipe"
+            mock_core_processors.return_value = []
+            mock_find_scripts_dir.return_value = "/path/to/Scripts"
+            mock_compress.side_effect = lambda x: x
+            mock_isfile.side_effect = lambda p: p == "/path/to/Scripts/preinstall"
+
+            result = autopkg.get_trust_info(mock_recipe)
+
+            self.assertEqual(len(result["scripts"]), 1)
+            self.assertIn("Scripts/preinstall", result["scripts"])
+
     def test_verify_parent_trust_no_trust_info_override(self):
         """Test verify_parent_trust with no trust info in override recipe."""
         mock_recipe = {
@@ -247,6 +401,94 @@ class TestAutoPkgOverrides(unittest.TestCase):
                 autopkg.verify_parent_trust(mock_recipe, ["/overrides"], ["/recipes"])
 
             self.assertIn("TestProcessor contents differ", str(context.exception))
+
+    def test_verify_parent_trust_mismatched_script_hash(self):
+        """Test verify_parent_trust with mismatched script hash."""
+        mock_recipe = {
+            "RECIPE_PATH": "/overrides/test.recipe",
+            "ParentRecipe": "com.test.parent",
+            "ParentRecipeTrustInfo": {
+                "non_core_processors": {},
+                "scripts": {
+                    "Scripts/preinstall": {
+                        "path": "/path/to/Scripts/preinstall",
+                        "sha256_hash": "old_hash",
+                    }
+                },
+                "parent_recipes": {},
+            },
+        }
+
+        with (
+            patch.object(autopkg, "recipe_in_override_dir") as mock_in_override,
+            patch.object(autopkg, "recipe_from_external_repo") as mock_external,
+            patch.object(autopkg, "get_pref") as mock_get_pref,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_trust_info") as mock_get_trust_info,
+        ):
+            mock_in_override.return_value = True
+            mock_external.return_value = False
+            mock_get_pref.return_value = "~/Library/AutoPkg/RecipeRepos"
+            mock_load_recipe.return_value = {"Identifier": "com.test.parent"}
+            mock_get_trust_info.return_value = {
+                "non_core_processors": {},
+                "scripts": {
+                    "Scripts/preinstall": {
+                        "path": "/path/to/Scripts/preinstall",
+                        "sha256_hash": "new_hash",
+                    }
+                },
+                "parent_recipes": {},
+            }
+
+            with self.assertRaises(autopkg.TrustVerificationError) as context:
+                autopkg.verify_parent_trust(mock_recipe, ["/overrides"], ["/recipes"])
+
+            self.assertIn(
+                "Script Scripts/preinstall contents differ",
+                str(context.exception),
+            )
+
+    def test_verify_parent_trust_legacy_trust_info_warns_for_scripts(self):
+        """Test older trust info warns (not errors) when scripts now exist."""
+        mock_recipe = {
+            "RECIPE_PATH": "/overrides/test.recipe",
+            "ParentRecipe": "com.test.parent",
+            "ParentRecipeTrustInfo": {
+                "non_core_processors": {},
+                "parent_recipes": {},
+            },
+        }
+
+        with (
+            patch.object(autopkg, "recipe_in_override_dir") as mock_in_override,
+            patch.object(autopkg, "recipe_from_external_repo") as mock_external,
+            patch.object(autopkg, "get_pref") as mock_get_pref,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_trust_info") as mock_get_trust_info,
+            patch.object(autopkg, "log_err") as mock_log_err,
+        ):
+            mock_in_override.return_value = True
+            mock_external.return_value = False
+            mock_get_pref.return_value = "~/Library/AutoPkg/RecipeRepos"
+            mock_load_recipe.return_value = {"Identifier": "com.test.parent"}
+            mock_get_trust_info.return_value = {
+                "non_core_processors": {},
+                "scripts": {
+                    "Scripts/preinstall": {
+                        "path": "/path/to/Scripts/preinstall",
+                        "sha256_hash": "new_hash",
+                    }
+                },
+                "parent_recipes": {},
+            }
+
+            autopkg.verify_parent_trust(mock_recipe, ["/overrides"], ["/recipes"])
+
+            mock_log_err.assert_called_once()
+            warning_msg = mock_log_err.call_args[0][0]
+            self.assertIn("Scripts/preinstall", warning_msg)
+            self.assertIn("3.0.1", warning_msg)
 
     @patch("sys.argv", ["autopkg", "update-trust-info", "test.recipe"])
     def test_update_trust_info_success(self):

--- a/Code/tests/test_autopkg_overrides.py
+++ b/Code/tests/test_autopkg_overrides.py
@@ -189,7 +189,7 @@ class TestAutoPkgOverrides(unittest.TestCase):
         self.assertIsNone(autopkg.find_scripts_dir_path("Scripts", None))
 
     def test_get_trust_info_pkgcreator_scripts(self):
-        """Test get_trust_info captures preinstall/postinstall script trust data."""
+        """Test get_trust_info captures all files in the scripts directory."""
         mock_recipe = {
             "RECIPE_PATH": "/path/to/test.recipe",
             "PARENT_RECIPES": [],
@@ -205,48 +205,50 @@ class TestAutoPkgOverrides(unittest.TestCase):
         with (
             patch.object(autopkg, "getsha256hash") as mock_hash,
             patch.object(autopkg, "get_git_commit_hash") as mock_git_hash,
+            patch.object(autopkg, "get_git_tracked_files") as mock_tracked,
             patch.object(autopkg, "load_recipe") as mock_load_recipe,
             patch.object(autopkg, "get_identifier") as mock_get_identifier,
             patch.object(autopkg, "core_processor_names") as mock_core_processors,
             patch.object(autopkg, "find_scripts_dir_path") as mock_find_scripts_dir,
             patch.object(autopkg, "os_path_compressuser") as mock_compress,
-            patch("autopkg.os.path.isfile") as mock_isfile,
+            patch("autopkg.os.walk") as mock_walk,
         ):
-            mock_hash.side_effect = ["recipe_hash", "pre_hash", "post_hash"]
-            mock_git_hash.side_effect = ["recipe_git", "pre_git", "post_git"]
+            mock_walk.return_value = [
+                ("/path/to/Scripts", [], ["helper.sh", "postinstall", "preinstall"]),
+            ]
+            mock_tracked.return_value = None
+            mock_hash.side_effect = [
+                "recipe_hash",
+                "helper_hash",
+                "post_hash",
+                "pre_hash",
+            ]
+            mock_git_hash.side_effect = [
+                "recipe_git",
+                "helper_git",
+                "post_git",
+                "pre_git",
+            ]
             mock_load_recipe.return_value = {"Identifier": "com.test.parent"}
             mock_get_identifier.return_value = "com.test.recipe"
             mock_core_processors.return_value = ["URLDownloader", "PkgCreator"]
             mock_find_scripts_dir.return_value = "/path/to/Scripts"
             mock_compress.side_effect = lambda x: x
-            mock_isfile.side_effect = lambda p: (
-                p
-                in {
-                    "/path/to/Scripts/preinstall",
-                    "/path/to/Scripts/postinstall",
-                }
-            )
 
             result = autopkg.get_trust_info(mock_recipe)
 
             self.assertIn("scripts", result)
+            self.assertEqual(len(result["scripts"]), 3)
             self.assertIn("Scripts/preinstall", result["scripts"])
             self.assertIn("Scripts/postinstall", result["scripts"])
+            self.assertIn("Scripts/helper.sh", result["scripts"])
+            self.assertEqual(
+                result["scripts"]["Scripts/helper.sh"]["sha256_hash"],
+                "helper_hash",
+            )
             self.assertEqual(
                 result["scripts"]["Scripts/preinstall"]["sha256_hash"],
                 "pre_hash",
-            )
-            self.assertEqual(
-                result["scripts"]["Scripts/preinstall"]["path"],
-                "/path/to/Scripts/preinstall",
-            )
-            self.assertEqual(
-                result["scripts"]["Scripts/postinstall"]["sha256_hash"],
-                "post_hash",
-            )
-            self.assertEqual(
-                result["scripts"]["Scripts/postinstall"]["path"],
-                "/path/to/Scripts/postinstall",
             )
 
     def test_get_trust_info_pkgcreator_scripts_dedupes_same_path(self):
@@ -269,13 +271,18 @@ class TestAutoPkgOverrides(unittest.TestCase):
         with (
             patch.object(autopkg, "getsha256hash") as mock_hash,
             patch.object(autopkg, "get_git_commit_hash") as mock_git_hash,
+            patch.object(autopkg, "get_git_tracked_files") as mock_tracked,
             patch.object(autopkg, "load_recipe") as mock_load_recipe,
             patch.object(autopkg, "get_identifier") as mock_get_identifier,
             patch.object(autopkg, "core_processor_names") as mock_core_processors,
             patch.object(autopkg, "find_scripts_dir_path") as mock_find_scripts_dir,
             patch.object(autopkg, "os_path_compressuser") as mock_compress,
-            patch("autopkg.os.path.isfile") as mock_isfile,
+            patch("autopkg.os.walk") as mock_walk,
         ):
+            mock_walk.return_value = [
+                ("/path/to/Scripts", [], ["preinstall"]),
+            ]
+            mock_tracked.return_value = None
             mock_hash.return_value = "hash"
             mock_git_hash.return_value = "git_hash"
             mock_load_recipe.return_value = {"Identifier": "com.test.parent"}
@@ -283,12 +290,61 @@ class TestAutoPkgOverrides(unittest.TestCase):
             mock_core_processors.return_value = []
             mock_find_scripts_dir.return_value = "/path/to/Scripts"
             mock_compress.side_effect = lambda x: x
-            mock_isfile.side_effect = lambda p: p == "/path/to/Scripts/preinstall"
 
             result = autopkg.get_trust_info(mock_recipe)
 
             self.assertEqual(len(result["scripts"]), 1)
             self.assertIn("Scripts/preinstall", result["scripts"])
+
+    def test_get_trust_info_skips_untracked_scripts_in_git_repo(self):
+        """Test get_trust_info skips untracked files when scripts dir is in a git repo."""
+        mock_recipe = {
+            "RECIPE_PATH": "/path/to/test.recipe",
+            "PARENT_RECIPES": [],
+            "Process": [
+                {
+                    "Processor": "PkgCreator",
+                    "Arguments": {"pkg_request": {"scripts": "Scripts"}},
+                },
+            ],
+        }
+
+        with (
+            patch.object(autopkg, "getsha256hash") as mock_hash,
+            patch.object(autopkg, "get_git_commit_hash") as mock_git_hash,
+            patch.object(autopkg, "get_git_tracked_files") as mock_tracked,
+            patch.object(autopkg, "load_recipe") as mock_load_recipe,
+            patch.object(autopkg, "get_identifier") as mock_get_identifier,
+            patch.object(autopkg, "core_processor_names") as mock_core_processors,
+            patch.object(autopkg, "find_scripts_dir_path") as mock_find_scripts_dir,
+            patch.object(autopkg, "os_path_compressuser") as mock_compress,
+            patch("autopkg.os.walk") as mock_walk,
+        ):
+            mock_walk.return_value = [
+                (
+                    "/path/to/Scripts",
+                    [],
+                    [".DS_Store", "postinstall", "preinstall"],
+                ),
+            ]
+            mock_tracked.return_value = {
+                "/path/to/Scripts/preinstall",
+                "/path/to/Scripts/postinstall",
+            }
+            mock_hash.side_effect = ["recipe_hash", "post_hash", "pre_hash"]
+            mock_git_hash.side_effect = ["recipe_git", "post_git", "pre_git"]
+            mock_load_recipe.return_value = {"Identifier": "com.test.parent"}
+            mock_get_identifier.return_value = "com.test.recipe"
+            mock_core_processors.return_value = []
+            mock_find_scripts_dir.return_value = "/path/to/Scripts"
+            mock_compress.side_effect = lambda x: x
+
+            result = autopkg.get_trust_info(mock_recipe)
+
+            self.assertEqual(len(result["scripts"]), 2)
+            self.assertIn("Scripts/preinstall", result["scripts"])
+            self.assertIn("Scripts/postinstall", result["scripts"])
+            self.assertNotIn("Scripts/.DS_Store", result["scripts"])
 
     def test_verify_parent_trust_no_trust_info_override(self):
         """Test verify_parent_trust with no trust info in override recipe."""


### PR DESCRIPTION
Files in PkgCreator scripts directories are now included in ParentRecipeTrustInfo. Previously, preinstall/postinstall scripts bundled into packages were not covered by trust verification, allowing undetected modifications after a repo-update.

- Hashes all git-tracked files in scripts directories (not just preinstall/postinstall), covering helper scripts, config files, and any other content that pkgbuild bundles into the package
- When the scripts directory is inside a git repo, only git-tracked files are hashed — untracked files like .DS_Store left by Finder won't cause false trust failures
- When outside a git repo, all files are hashed (matching how recipes and processors are handled outside git)
- Uses run_git() with -z (NUL-delimited) output for correct handling of filenames with special characters and consistency with GIT_PATH preference
- Existing overrides without script trust info get a warning (not an error) directing users to run autopkg update-trust-info; this becomes an error in 3.0.1

Closes #980