### PR TITLE
Add clear-cache verb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ URLDownloader now persists download metadata — including ETag, Last-Modified, 
 
 A new `COMPUTE_HASHES` input variable (default: `False`) enables on-demand computation of MD5, SHA1, and SHA256 hashes of the downloaded file. When enabled, hash values are available as output variables in subsequent processors.
 
+### New `clear-cache` verb
+
+AutoPkg 3.0.0 adds `autopkg clear-cache` for removing cached files when troubleshooting a recipe or reclaiming disk space. Pass a recipe name or identifier to clear that recipe's cache using the same lookup behavior as `run` and `info`, or use `autopkg clear-cache all` to empty the configured cache directory. (#1035)
+
 ### Other
 
 - Files in PkgCreator `scripts` directories are now included in recipe override trust information. Changes to preinstall/postinstall scripts or any other files bundled into packages will now trigger trust verification failures. Only git-tracked files are hashed when the scripts directory is inside a git repo, so untracked files like `.DS_Store` won't cause false trust failures. (#980)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ A new `COMPUTE_HASHES` input variable (default: `False`) enables on-demand compu
 
 ### New `clear-cache` verb
 
-AutoPkg 3.0.0 adds `autopkg clear-cache` for removing cached files when troubleshooting a recipe or reclaiming disk space. Pass a recipe name or identifier to clear that recipe's cache using the same lookup behavior as `run` and `info`, or use `autopkg clear-cache all` to empty the configured cache directory. (#1035)
+AutoPkg 3.0.0 adds `autopkg clear-cache` for removing cached files when troubleshooting a recipe or reclaiming disk space. Pass a recipe name or identifier to clear that recipe's cache using the same recipe resolution behavior as `run` and `info`, or use `autopkg clear-cache all` to empty the configured cache directory. Recipes must have an explicit identifier to clear their cache. (#1035)
 
 ### Other
 

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2322,6 +2322,123 @@ def parse_recipe_list(filename):
     return recipe_list
 
 
+def _list_cache_tree(path, action) -> None:
+    """Log every file and directory under path (for -vv output)."""
+    if os.path.isdir(path) and not os.path.islink(path):
+        for root, dirnames, filenames in os.walk(path):
+            for name in sorted(dirnames + filenames):
+                log(f"{action} {os.path.join(root, name)}")
+
+
+def _remove_cache_item(path, dry_run=False) -> bool:
+    """Remove a file or directory tree. Returns True on success."""
+    if dry_run:
+        return True
+    try:
+        if os.path.isdir(path) and not os.path.islink(path):
+            shutil.rmtree(path)
+        else:
+            os.unlink(path)
+    except OSError as err:
+        log_err(f"ERROR: Could not remove {path}: {err}")
+        return False
+    return True
+
+
+def clear_cache(argv):
+    """Clear cached artifacts for one recipe, or the whole cache."""
+    verb = argv[1]
+    parser = gen_common_parser()
+    parser.set_usage(
+        f"Usage: %prog {verb} [options] <recipe|all>\n"
+        "Remove cached download/work artifacts for a recipe, or all cache contents."
+    )
+    parser.add_option(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be removed without deleting anything.",
+    )
+    parser.add_option(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help=(
+            "Verbose output. -v lists each recipe cache directory removed; "
+            "-vv also lists every file within."
+        ),
+    )
+    add_search_and_override_dir_options(parser)
+    options, arguments = common_parse(parser, argv)
+
+    if len(arguments) != 1:
+        log_err(parser.get_usage())
+        return 1
+
+    cache_dir = os.path.abspath(
+        os.path.expanduser(get_pref("CACHE_DIR") or "~/Library/AutoPkg/Cache")
+    )
+    if not os.path.isdir(cache_dir):
+        log_err(f"ERROR: Cache directory does not exist: {cache_dir}")
+        return 1
+
+    action = "Would remove" if options.dry_run else "Removing"
+
+    if arguments[0] == "all":
+        try:
+            items = sorted(
+                os.path.join(cache_dir, name) for name in os.listdir(cache_dir)
+            )
+        except OSError as err:
+            log_err(f"ERROR: Could not list {cache_dir}: {err}")
+            return 1
+        if not items:
+            if options.verbose:
+                log(f"Cache directory is empty: {cache_dir}")
+            return 0
+        if not options.verbose:
+            log(f"{action} all cached items from {cache_dir}")
+        ok = True
+        for item in items:
+            if options.verbose:
+                log(f"{action} {item}")
+                if options.verbose >= 2:
+                    _list_cache_tree(item, action)
+            if not _remove_cache_item(item, options.dry_run):
+                ok = False
+        return 0 if ok else 1
+
+    override_dirs = options.override_dirs or get_override_dirs()
+    search_dirs = options.search_dirs or get_search_dirs()
+    recipe = load_recipe(
+        arguments[0],
+        override_dirs,
+        search_dirs,
+        make_suggestions=False,
+        search_github=False,
+    )
+    if not recipe:
+        log_err(f"No valid recipe found for {arguments[0]}")
+        return 1
+    identifier = get_identifier(recipe)
+    if not identifier:
+        log_err(f"ERROR: Could not determine recipe identifier for {arguments[0]}")
+        return 1
+    target = os.path.normpath(os.path.join(cache_dir, identifier))
+    if not is_path_under(target, cache_dir):
+        log_err(
+            f"ERROR: Recipe cache path {target} resolves outside CACHE_DIR {cache_dir}"
+        )
+        return 1
+    if not os.path.exists(target):
+        log_err(f"ERROR: Recipe cache directory does not exist: {target}")
+        return 1
+    log(f"{action} {target}")
+    if options.verbose >= 2:
+        _list_cache_tree(target, action)
+    return 0 if _remove_cache_item(target, options.dry_run) else 1
+
+
 def run_recipes(argv):  # noqa: C901
     """Run one or more recipes. If called with 'install' verb, run .install
     recipe"""
@@ -3334,6 +3451,10 @@ def main(argv):
     subcommands = {
         "help": {"function": display_help, "help": "Display this help"},
         "audit": {"function": audit, "help": "Audit one or more recipes."},
+        "clear-cache": {
+            "function": clear_cache,
+            "help": "Remove cached artifacts for a recipe or all cache contents",
+        },
         "info": {
             "function": get_info,
             "help": "Get info about configuration or a recipe",

--- a/Code/autopkg
+++ b/Code/autopkg
@@ -2364,8 +2364,8 @@ def clear_cache(argv):
         action="count",
         default=0,
         help=(
-            "Verbose output. -v lists each recipe cache directory removed; "
-            "-vv also lists every file within."
+            "Verbose output. With 'all', -v lists each top-level cache item. "
+            "-vv lists each item within removed directories."
         ),
     )
     add_search_and_override_dir_options(parser)
@@ -2420,6 +2420,8 @@ def clear_cache(argv):
     if not recipe:
         log_err(f"No valid recipe found for {arguments[0]}")
         return 1
+    # Require an explicit recipe identifier for deletion rather than using
+    # AutoPackager.get_recipe_identifier()'s path-derived fallback.
     identifier = get_identifier(recipe)
     if not identifier:
         log_err(f"ERROR: Could not determine recipe identifier for {arguments[0]}")

--- a/Code/tests/test_autopkg_other.py
+++ b/Code/tests/test_autopkg_other.py
@@ -15,7 +15,9 @@
 import importlib.machinery
 import importlib.util
 import os
+import plistlib
 import sys
+import tempfile
 import unittest
 import unittest.mock
 from io import StringIO
@@ -46,6 +48,329 @@ class TestAutoPkgOther(unittest.TestCase):
     def tearDown(self):
         for patcher in self._recipe_map_patches:
             patcher.stop()
+
+    def _write_recipe(self, path, recipe):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as f:
+            plistlib.dump(recipe, f)
+
+    def _run_clear_cache(
+        self, argv_tail, cache_dir, search_dirs=None, override_dirs=None
+    ):
+        search_dirs = search_dirs or []
+        override_dirs = override_dirs or []
+
+        def pref(key):
+            return cache_dir if key == "CACHE_DIR" else None
+
+        with (
+            patch("autopkg.get_pref", side_effect=pref),
+            patch("autopkg.get_search_dirs", return_value=search_dirs),
+            patch("autopkg.get_override_dirs", return_value=override_dirs),
+            patch.dict(
+                autopkg.globalRecipeMap,
+                {
+                    "identifiers": {},
+                    "shortnames": {},
+                    "overrides": {},
+                    "overrides-identifiers": {},
+                },
+                clear=True,
+            ),
+            patch("sys.stdout", new_callable=StringIO) as stdout,
+            patch("sys.stderr", new_callable=StringIO) as stderr,
+        ):
+            result = autopkg.clear_cache(["autopkg", "clear-cache", *argv_tail])
+            return result, stdout.getvalue(), stderr.getvalue()
+
+    def test_clear_cache_registered_in_subcommands(self):
+        """The clear-cache verb should show up in the main() dispatch dict."""
+        captured = []
+
+        def fake_display_help(argv, subcommands):
+            captured.append(subcommands)
+            return 1
+
+        with patch("autopkg.display_help", side_effect=fake_display_help):
+            autopkg.main(["autopkg", "help"])
+
+        self.assertTrue(captured)
+        self.assertIs(captured[0]["clear-cache"]["function"], autopkg.clear_cache)
+
+    def test_clear_cache_recipe_removes_resolved_identifier_cache(self):
+        """Recipe shortname lookup removes only that recipe's cache directory."""
+        recipe = {
+            "Description": "Test recipe",
+            "Identifier": "com.example.test",
+            "Input": {},
+            "Process": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            recipes_dir = os.path.join(tmp_dir, "recipes")
+            target = os.path.join(cache_dir, "com.example.test")
+            os.makedirs(os.path.join(target, "downloads"))
+            self._write_recipe(os.path.join(recipes_dir, "Test.recipe"), recipe)
+
+            result, stdout, stderr = self._run_clear_cache(
+                ["--search-dir", recipes_dir, "Test"],
+                cache_dir,
+                search_dirs=[recipes_dir],
+            )
+
+            self.assertEqual(result, 0, stderr)
+            self.assertIn(f"Removing {target}", stdout)
+            self.assertFalse(os.path.exists(target))
+            self.assertTrue(os.path.isdir(cache_dir))
+
+    def test_clear_cache_recipe_can_resolve_by_identifier(self):
+        """Recipe identifier lookup matches run/info resolution behavior."""
+        recipe = {
+            "Description": "Test recipe",
+            "Identifier": "com.example.identifier",
+            "Input": {},
+            "Process": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            recipes_dir = os.path.join(tmp_dir, "recipes")
+            target = os.path.join(cache_dir, "com.example.identifier")
+            os.makedirs(target)
+            self._write_recipe(
+                os.path.join(recipes_dir, "DifferentName.recipe"), recipe
+            )
+
+            result, stdout, stderr = self._run_clear_cache(
+                ["--search-dir", recipes_dir, "com.example.identifier"],
+                cache_dir,
+                search_dirs=[recipes_dir],
+            )
+
+            self.assertEqual(result, 0, stderr)
+            self.assertIn(f"Removing {target}", stdout)
+            self.assertFalse(os.path.exists(target))
+
+    def test_clear_cache_recipe_dry_run_leaves_cache(self):
+        """Dry-run reports the recipe cache path without deleting it."""
+        recipe = {
+            "Description": "Test recipe",
+            "Identifier": "com.example.dryrun",
+            "Input": {},
+            "Process": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            recipes_dir = os.path.join(tmp_dir, "recipes")
+            target = os.path.join(cache_dir, "com.example.dryrun")
+            os.makedirs(target)
+            self._write_recipe(os.path.join(recipes_dir, "DryRun.recipe"), recipe)
+
+            result, stdout, stderr = self._run_clear_cache(
+                ["--dry-run", "--search-dir", recipes_dir, "DryRun"],
+                cache_dir,
+                search_dirs=[recipes_dir],
+            )
+
+            self.assertEqual(result, 0, stderr)
+            self.assertIn(f"Would remove {target}", stdout)
+            self.assertTrue(os.path.isdir(target))
+
+    def test_clear_cache_recipe_missing_cache_is_error(self):
+        """A resolved recipe with no cache directory is a non-zero result."""
+        recipe = {
+            "Description": "Test recipe",
+            "Identifier": "com.example.missing",
+            "Input": {},
+            "Process": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            recipes_dir = os.path.join(tmp_dir, "recipes")
+            os.makedirs(cache_dir)
+            self._write_recipe(os.path.join(recipes_dir, "Missing.recipe"), recipe)
+
+            result, stdout, stderr = self._run_clear_cache(
+                ["--search-dir", recipes_dir, "Missing"],
+                cache_dir,
+                search_dirs=[recipes_dir],
+            )
+
+            self.assertEqual(result, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("Recipe cache directory does not exist", stderr)
+
+    def test_clear_cache_all_removes_contents_not_cache_dir(self):
+        """The all target clears cache contents but leaves CACHE_DIR itself."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            child_dir = os.path.join(cache_dir, "com.example.one")
+            child_file = os.path.join(cache_dir, "autopkg_results.plist")
+            os.makedirs(child_dir)
+            with open(child_file, "w", encoding="utf-8") as f:
+                f.write("results")
+
+            result, stdout, stderr = self._run_clear_cache(["all"], cache_dir)
+
+            self.assertEqual(result, 0, stderr)
+            # Without -v, the all target prints a summary, not each item.
+            self.assertIn(cache_dir, stdout)
+            self.assertNotIn(child_dir, stdout)
+            self.assertNotIn(child_file, stdout)
+            self.assertTrue(os.path.isdir(cache_dir))
+            self.assertEqual(os.listdir(cache_dir), [])
+
+    def test_clear_cache_all_verbose_lists_recipe_dirs_not_files(self):
+        """-v lists each one-level cache item but not their contents."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            child_dir = os.path.join(cache_dir, "com.example.one")
+            nested_file = os.path.join(child_dir, "downloads", "App.dmg")
+            os.makedirs(os.path.dirname(nested_file))
+            with open(nested_file, "w", encoding="utf-8") as f:
+                f.write("dmg")
+
+            result, stdout, stderr = self._run_clear_cache(["-v", "all"], cache_dir)
+
+            self.assertEqual(result, 0, stderr)
+            self.assertIn(f"Removing {child_dir}", stdout)
+            self.assertNotIn(nested_file, stdout)
+            self.assertEqual(os.listdir(cache_dir), [])
+
+    def test_clear_cache_all_very_verbose_lists_files(self):
+        """-vv lists every file within each cache item."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            child_dir = os.path.join(cache_dir, "com.example.one")
+            nested_file = os.path.join(child_dir, "downloads", "App.dmg")
+            os.makedirs(os.path.dirname(nested_file))
+            with open(nested_file, "w", encoding="utf-8") as f:
+                f.write("dmg")
+
+            result, stdout, stderr = self._run_clear_cache(["-vv", "all"], cache_dir)
+
+            self.assertEqual(result, 0, stderr)
+            self.assertIn(f"Removing {child_dir}", stdout)
+            self.assertIn(f"Removing {nested_file}", stdout)
+            self.assertEqual(os.listdir(cache_dir), [])
+
+    def test_clear_cache_recipe_very_verbose_lists_files(self):
+        """-vv on a recipe lists the files inside its cache directory."""
+        recipe = {
+            "Description": "Test recipe",
+            "Identifier": "com.example.test",
+            "Input": {},
+            "Process": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            recipes_dir = os.path.join(tmp_dir, "recipes")
+            target = os.path.join(cache_dir, "com.example.test")
+            nested_file = os.path.join(target, "downloads", "App.dmg")
+            os.makedirs(os.path.dirname(nested_file))
+            with open(nested_file, "w", encoding="utf-8") as f:
+                f.write("dmg")
+            self._write_recipe(os.path.join(recipes_dir, "Test.recipe"), recipe)
+
+            result, stdout, stderr = self._run_clear_cache(
+                ["-vv", "--search-dir", recipes_dir, "Test"],
+                cache_dir,
+                search_dirs=[recipes_dir],
+            )
+
+            self.assertEqual(result, 0, stderr)
+            self.assertIn(f"Removing {target}", stdout)
+            self.assertIn(f"Removing {nested_file}", stdout)
+            self.assertFalse(os.path.exists(target))
+
+    def test_clear_cache_all_empty_cache_is_success(self):
+        """The all target treats an already-empty cache directory as success."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            os.makedirs(cache_dir)
+
+            result, stdout, stderr = self._run_clear_cache(["all"], cache_dir)
+
+            self.assertEqual(result, 0, stderr)
+            self.assertEqual(stdout, "")
+            self.assertEqual(os.listdir(cache_dir), [])
+
+    def test_clear_cache_missing_cache_dir_is_error(self):
+        """Missing CACHE_DIR is a non-zero result."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "missing")
+
+            result, stdout, stderr = self._run_clear_cache(["all"], cache_dir)
+
+            self.assertEqual(result, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("Cache directory does not exist", stderr)
+
+    def test_clear_cache_refuses_identifier_outside_cache_dir(self):
+        """A hostile recipe identifier cannot escape CACHE_DIR."""
+        recipe = {
+            "Description": "Bad recipe",
+            "Identifier": "../escape",
+            "Input": {},
+            "Process": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            recipes_dir = os.path.join(tmp_dir, "recipes")
+            os.makedirs(cache_dir)
+            self._write_recipe(os.path.join(recipes_dir, "Bad.recipe"), recipe)
+
+            result, stdout, stderr = self._run_clear_cache(
+                ["--search-dir", recipes_dir, "Bad"],
+                cache_dir,
+                search_dirs=[recipes_dir],
+            )
+
+            self.assertEqual(result, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("resolves outside CACHE_DIR", stderr)
+            self.assertFalse(os.path.exists(os.path.join(tmp_dir, "escape")))
+
+    def test_clear_cache_override_uses_override_identifier(self):
+        """Override resolution clears the override cache, matching run."""
+        parent = {
+            "Description": "Parent recipe",
+            "Identifier": "com.example.parent",
+            "Input": {"NAME": "Parent"},
+            "Process": [],
+        }
+        override = {
+            "Identifier": "local.parent.override",
+            "Input": {"NAME": "Override"},
+            "ParentRecipe": "com.example.parent",
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            recipes_dir = os.path.join(tmp_dir, "recipes")
+            overrides_dir = os.path.join(tmp_dir, "overrides")
+            target = os.path.join(cache_dir, "local.parent.override")
+            parent_target = os.path.join(cache_dir, "com.example.parent")
+            os.makedirs(target)
+            os.makedirs(parent_target)
+            self._write_recipe(os.path.join(recipes_dir, "Parent.recipe"), parent)
+            self._write_recipe(os.path.join(overrides_dir, "Parent.recipe"), override)
+
+            result, stdout, stderr = self._run_clear_cache(
+                [
+                    "--search-dir",
+                    recipes_dir,
+                    "--override-dir",
+                    overrides_dir,
+                    "Parent",
+                ],
+                cache_dir,
+                search_dirs=[recipes_dir],
+                override_dirs=[overrides_dir],
+            )
+
+            self.assertEqual(result, 0, stderr)
+            self.assertIn(f"Removing {target}", stdout)
+            self.assertFalse(os.path.exists(target))
+            self.assertTrue(os.path.isdir(parent_target))
 
     def test_display_help_basic_functionality(self):
         """Test display_help with basic subcommands."""

--- a/Code/tests/test_autopkg_other.py
+++ b/Code/tests/test_autopkg_other.py
@@ -199,6 +199,36 @@ class TestAutoPkgOther(unittest.TestCase):
             self.assertEqual(stdout, "")
             self.assertIn("Recipe cache directory does not exist", stderr)
 
+    def test_clear_cache_recipe_requires_explicit_identifier(self):
+        """Recipe cache deletion does not use the run-time pseudo identifier."""
+        recipe = {
+            "Description": "Test recipe",
+            "Input": {},
+            "Process": [],
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cache_dir = os.path.join(tmp_dir, "cache")
+            recipes_dir = os.path.join(tmp_dir, "recipes")
+            recipe_path = os.path.join(recipes_dir, "NoIdentifier.recipe")
+            self._write_recipe(recipe_path, recipe)
+
+            pseudo_identifier = "-".join(
+                autopkg.remove_recipe_extension(recipe_path).split("/")
+            )
+            pseudo_target = os.path.join(cache_dir, pseudo_identifier)
+            os.makedirs(pseudo_target)
+
+            result, stdout, stderr = self._run_clear_cache(
+                ["--search-dir", recipes_dir, "NoIdentifier"],
+                cache_dir,
+                search_dirs=[recipes_dir],
+            )
+
+            self.assertEqual(result, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("Could not determine recipe identifier", stderr)
+            self.assertTrue(os.path.isdir(pseudo_target))
+
     def test_clear_cache_all_removes_contents_not_cache_dir(self):
         """The all target clears cache contents but leaves CACHE_DIR itself."""
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Adds new `autopkg clear-cache` verb for removing cached artifacts from the configured AutoPkg cache directory. (Closes #1035.)

## Details

- `autopkg clear-cache <recipe>` resolves the recipe using normal recipe lookup and removes `CACHE_DIR/<identifier>`.
- `autopkg clear-cache all` removes all contents of `CACHE_DIR` while preserving the cache directory itself.
- Recipes must have an explicit `Identifier` to clear their cache — no path-derived fallback.
- Refuses recipe cache paths that resolve outside `CACHE_DIR`.
- Add `--dry-run` to preview removals.
- `-v` lists each top-level item removed by `all`; `-vv` also lists files within removed directories.

## Test output

These commands were run with an installed AutoPkg built from this branch. They use the configured `CACHE_DIR` and real recipes from the AutoPkg org. They intentionally clear the configured AutoPkg cache, for real-world verisimilitude (word of the day).

### Clear one recipe cache

```sh
% autopkg run -vvc SlackUniversal.download
```

```console
Processing SlackUniversal.download...
WARNING: SlackUniversal.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Slack-Universal.pkg',
           'url': 'https://slack.com/api/desktop.latestRelease?platform=mac&arch=universal&variant=pkg&redirect=true'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Storing metadata to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/downloads/Slack-Universal.pkg.info.json
URLDownloader: Metadata contents:
{
    "download_url": "https://slack.com/api/desktop.latestRelease?platform=mac&arch=universal&variant=pkg&redirect=true",
    "file_name": "Slack-Universal.pkg",
    "file_size": 227026861,
    "http_headers": {
        "Content-Length": 227026861,
        "ETag": "\"ccfe1fc9643a0fb07e0dfe20dddec010\"",
        "Last-Modified": "Wed, 20 May 2026 17:21:48 GMT"
    }
}
URLDownloader: Storing new Last-Modified header: Wed, 20 May 2026 17:21:48 GMT
URLDownloader: Storing new ETag header: "ccfe1fc9643a0fb07e0dfe20dddec010"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/downloads/Slack-Universal.pkg
{'Output': {'download_changed': True,
            'etag': '"ccfe1fc9643a0fb07e0dfe20dddec010"',
            'last_modified': 'Wed, 20 May 2026 17:21:48 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/downloads/Slack-Universal.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/downloads/Slack-Universal.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/receipts/SlackUniversal-receipt-20260530-185342.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/downloads/Slack-Universal.pkg
```

```sh
% autopkg clear-cache SlackUniversal.download
```

```console
Removing ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal
```

### Clear one recipe cache by identifier

```sh
% autopkg run -vvc coconutBattery.download
```

```console
Processing coconutBattery.download...
WARNING: coconutBattery.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://coconut-flavour.com/updates/coconutBattery_4.xml'}}
SparkleUpdateInfoProvider: No value supplied for alternate_xmlns_url, setting default value of: http://www.andymatuschak.org/xml-namespaces/sparkle
SparkleUpdateInfoProvider: No value supplied for urlencode_path_component, setting default value of: True
SparkleUpdateInfoProvider: Items in feed: 3
SparkleUpdateInfoProvider: Items in default channel: 2
SparkleUpdateInfoProvider: Version retrieved from appcast: 209
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 4.3.0
SparkleUpdateInfoProvider: Found URL https://www.coconut-flavour.com/downloads/coconutBattery_430_209.zip
{'Output': {'url': 'https://www.coconut-flavour.com/downloads/coconutBattery_430_209.zip',
            'version': '4.3.0'}}
URLDownloader
{'Input': {'filename': 'coconutBattery-4.3.0.zip',
           'url': 'https://www.coconut-flavour.com/downloads/coconutBattery_430_209.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Storing metadata to ~/Library/AutoPkg/Cache/com.github.homebysix.download.coconutBattery/downloads/coconutBattery-4.3.0.zip.info.json
URLDownloader: Metadata contents:
{
    "download_url": "https://www.coconut-flavour.com/downloads/coconutBattery_430_209.zip",
    "file_name": "coconutBattery-4.3.0.zip",
    "file_size": 6017528,
    "http_headers": {
        "Content-Length": 6017528,
        "ETag": "\"5bd1f8-64e93e9817b40\"",
        "Last-Modified": "Fri, 03 Apr 2026 20:10:45 GMT"
    }
}
URLDownloader: Storing new Last-Modified header: Fri, 03 Apr 2026 20:10:45 GMT
URLDownloader: Storing new ETag header: "5bd1f8-64e93e9817b40"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.homebysix.download.coconutBattery/downloads/coconutBattery-4.3.0.zip
{'Output': {'download_changed': True,
            'etag': '"5bd1f8-64e93e9817b40"',
            'last_modified': 'Fri, 03 Apr 2026 20:10:45 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.homebysix.download.coconutBattery/downloads/coconutBattery-4.3.0.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.homebysix.download.coconutBattery/downloads/coconutBattery-4.3.0.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.homebysix.download.coconutBattery/receipts/coconutBattery-receipt-20260530-185616.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.homebysix.download.coconutBattery/downloads/coconutBattery-4.3.0.zip
```

```sh
% autopkg clear-cache com.github.homebysix.download.coconutBattery
```

```console
Removing ~/Library/AutoPkg/Cache/com.github.homebysix.download.coconutBattery
```

### Dry run leaves recipe cache intact

```sh
% autopkg run -vvc Firefox.pkg
```

```console
Processing Firefox.pkg...
WARNING: Firefox.pkg is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
MozillaURLProvider
{'Input': {'locale': 'en-US', 'product_name': 'firefox', 'release': 'latest'}}
MozillaURLProvider: No value supplied for platform, setting default value of: osx
MozillaURLProvider: No value supplied for base_url, setting default value of: https://download.mozilla.org/?product={product_release}-ssl&os={platform}&lang={locale}
MozillaURLProvider: No value supplied for versions_base_url, setting default value of: https://product-details.mozilla.org/1.0/{product}_versions.json
MozillaURLProvider: Found URL https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US
{'Output': {'moz_original_version': '151.0.2',
            'moz_version': '151.0.2',
            'url': 'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US'}}
URLDownloader
{'Input': {'filename': 'Firefox.dmg',
           'url': 'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for COMPUTE_HASHES, setting default value of: False
URLDownloader: Storing metadata to ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.Firefox_EN/downloads/Firefox.dmg.info.json
URLDownloader: Metadata contents:
{
    "download_url": "https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US",
    "file_name": "Firefox.dmg",
    "file_size": 152278977,
    "http_headers": {
        "Content-Length": 152278977,
        "ETag": "\"0a6ffd9a48ceb021526c747a3cad8782\"",
        "Last-Modified": "Mon, 25 May 2026 18:51:20 GMT"
    }
}
URLDownloader: Storing new Last-Modified header: Mon, 25 May 2026 18:51:20 GMT
URLDownloader: Storing new ETag header: "0a6ffd9a48ceb021526c747a3cad8782"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.Firefox_EN/downloads/Firefox.dmg
{'Output': {'download_changed': True,
            'etag': '"0a6ffd9a48ceb021526c747a3cad8782"',
            'last_modified': 'Mon, 25 May 2026 18:51:20 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.Firefox_EN/downloads/Firefox.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.pkg.Firefox_EN/downloads/Firefox.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.Firefox_EN/receipts/Firefox-receipt-20260530-185923.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.Firefox_EN/downloads/Firefox.dmg
```

```sh
% autopkg clear-cache --dry-run Firefox.pkg
```

```console
Would remove ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.Firefox_EN
```

```sh
% autopkg clear-cache Firefox.pkg
```

```console
Removing ~/Library/AutoPkg/Cache/com.github.autopkg.pkg.Firefox_EN
```

### Clear all cache contents

```sh
% autopkg run -vc SlackUniversal.download GoogleChromeUniversal.download
```

```console
Processing SlackUniversal.download...
WARNING: SlackUniversal.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing metadata to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/downloads/Slack-Universal.pkg.info.json
URLDownloader: Storing new Last-Modified header: Wed, 20 May 2026 17:21:48 GMT
URLDownloader: Storing new ETag header: "ccfe1fc9643a0fb07e0dfe20dddec010"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/downloads/Slack-Universal.pkg
EndOfCheckPhase
Receipt written to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/receipts/SlackUniversal-receipt-20260530-190109.plist
Processing GoogleChromeUniversal.download...
WARNING: GoogleChromeUniversal.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
DeprecationWarning
DeprecationWarning: WARNING: Consider switching to the GoogleChrome recipes in the autopkg/recipes repo, which also download the Universal dmg for Chrome. This recipe is deprecated and will be removed in the future.
URLDownloader
URLDownloader: Storing metadata to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.googlechromeuniversal/downloads/GoogleChromeUniversal.dmg.info.json
URLDownloader: Storing new Last-Modified header: Wed, 27 May 2026 17:54:12 GMT
URLDownloader: Storing new ETag header: "5f643e7"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.rtrouton.download.googlechromeuniversal/downloads/GoogleChromeUniversal.dmg
EndOfCheckPhase
Receipt written to ~/Library/AutoPkg/Cache/com.github.rtrouton.download.googlechromeuniversal/receipts/GoogleChromeUniversal-receipt-20260530-190116.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal/downloads/Slack-Universal.pkg
    ~/Library/AutoPkg/Cache/com.github.rtrouton.download.googlechromeuniversal/downloads/GoogleChromeUniversal.dmg

The following recipes have deprecation warnings:
    Name                            Warning
    ----                            -------
    GoogleChromeUniversal.download  Consider switching to the GoogleChrome recipes in the autopkg/recipes repo, which also download the Universal dmg for Chrome. This recipe is deprecated and will be removed in the future.
```

```sh
% autopkg clear-cache all -v
```

```console
Removing ~/Library/AutoPkg/Cache/autopkg_results.plist
Removing ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal
Removing ~/Library/AutoPkg/Cache/com.github.rtrouton.download.googlechromeuniversal
```

### Clear all when cache is already empty

```sh
% autopkg clear-cache all -v
```

```console
Cache directory is empty: ~/Library/AutoPkg/Cache
```

### Resolved recipe with missing cache returns non-zero

```sh
% autopkg clear-cache SlackUniversal.download
```

```console
ERROR: Recipe cache directory does not exist: ~/Library/AutoPkg/Cache/com.github.rtrouton.download.SlackUniversal
```

```sh
% echo $?
```

```console
1
```

### Recipe not found returns non-zero

```sh
% autopkg clear-cache --search-dir rtrouton-recipes/Slack NoSuchRecipeForClearCache
```

```console
Rebuilding recipe map with current working directories (resolving 'NoSuchRecipeForClearCache')...
No valid recipe found for NoSuchRecipeForClearCache
```
