### PR TITLE
Add `continue_on_error` input to PathDeleter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Multiple processors now confine paths to their intended directories, preventing 
 
 - Processors that handle disk images now preserve original mount failures instead of masking them with subsequent "not mounted" cleanup errors.
 - PkgCreator and AppPkgCreator: new `pkgbuild_args` input variable allows forwarding additional flags (e.g. `--filter`, `--large-payload`) to the `pkgbuild` tool (#981)
+- PathDeleter: new `continue_on_error` input variable (default `False`) makes deletion best-effort: a missing path is skipped instead of raising, and a directory that still can't be removed after a few retries is force-removed with errors ignored, so optional cleanup steps don't fail the recipe run. Directory removal now also retries transient failures (e.g. a path briefly held open after a build) with exponential backoff before giving up. The default behavior is unchanged: any failure still raises a `ProcessorError`.
 - macOS-only processors that rely on `hdiutil`, `pkgutil`, `xar`, or `pkgbuild` now fail with explicit platform errors on non-macOS instead of attempting to launch unavailable tools.
 - URLDownloaderPython now validates cached files against their actual size, exposes computed hashes, and preserves downloads when ETag or Last-Modified headers are missing.
 - URLDownloader now applies `curl_common_opts`, such as authorization headers, when prefetching filenames from authenticated URLs (#925, thanks to @n8felton)

--- a/Code/autopkglib/PathDeleter.py
+++ b/Code/autopkglib/PathDeleter.py
@@ -18,10 +18,17 @@
 
 import os
 import shutil
+import time
 
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["PathDeleter"]
+
+# Directories can briefly resist removal right after a build (for example a
+# file is still held open by another process), so removal is retried a few
+# times with exponential backoff before giving up.
+DIR_REMOVAL_MAX_ATTEMPTS = 3
+DIR_REMOVAL_INITIAL_DELAY = 1
 
 
 class PathDeleter(Processor):
@@ -36,9 +43,56 @@ class PathDeleter(Processor):
                 "An array or list of pathnames to be deleted, "
                 "even if that list contains a single item."
             ),
-        }
+        },
+        "continue_on_error": {
+            "required": False,
+            "description": (
+                "If True, PathDeleter will not raise a ProcessorError when a "
+                "path cannot be removed: a missing path is skipped, and a "
+                "directory that still cannot be removed after retrying is "
+                "force-removed with errors ignored. Useful for best-effort "
+                "cleanup steps (e.g. clearing a cache) that should never fail "
+                "the recipe run. Defaults to False, which preserves the "
+                "original behavior of raising on any failure."
+            ),
+            "default": False,
+        },
     }
     output_variables = {}
+
+    def _remove_directory(self, path: str, continue_on_error: bool) -> None:
+        """Remove a directory tree, retrying transient failures.
+
+        Retries shutil.rmtree with exponential backoff. Once the attempts are
+        exhausted, either raise a ProcessorError (the default) or, when
+        continue_on_error is True, force removal with errors ignored.
+        """
+        delay = DIR_REMOVAL_INITIAL_DELAY
+        last_err = None
+        for attempt in range(1, DIR_REMOVAL_MAX_ATTEMPTS + 1):
+            try:
+                shutil.rmtree(path)
+                self.output(f"Deleted {path}")
+                return
+            except OSError as err:
+                last_err = err
+                if attempt < DIR_REMOVAL_MAX_ATTEMPTS:
+                    self.output(
+                        f"Unable to remove {path} (attempt {attempt} of "
+                        f"{DIR_REMOVAL_MAX_ATTEMPTS}); retrying in {delay}s"
+                    )
+                    time.sleep(delay)
+                    delay *= 2
+
+        # Every attempt failed.
+        if continue_on_error:
+            self.output(f"Ignoring errors on final removal of {path}")
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            raise ProcessorError(
+                f"Could not remove {path} after "
+                f"{DIR_REMOVAL_MAX_ATTEMPTS} attempts: {last_err}"
+            ) from last_err
 
     def main(self) -> None:
         # if recipe writer gave us a single string instead of a list of strings,
@@ -46,24 +100,33 @@ class PathDeleter(Processor):
         if isinstance(self.env["path_list"], str):
             self.env["path_list"] = [self.env["path_list"]]
 
+        continue_on_error = self.env.get("continue_on_error", False)
+
         for path in self.env["path_list"]:
             try:
                 if os.path.isfile(path) or os.path.islink(path):
                     os.remove(path)
+                    self.output(f"Deleted {path}")
                 elif os.path.isdir(path):
-                    shutil.rmtree(path)
+                    self._remove_directory(path, continue_on_error)
                 elif not os.path.exists(path):
-                    raise ProcessorError(
-                        f"Could not remove {path} - it does not exist!"
-                    )
+                    if continue_on_error:
+                        self.output(f"Path does not exist, skipping: {path}")
+                    else:
+                        raise ProcessorError(
+                            f"Could not remove {path} - it does not exist! "
+                            "Set continue_on_error=True to skip missing paths."
+                        )
                 else:
                     raise ProcessorError(
                         f"Could not remove {path} - it is not a file, link, "
                         "or directory"
                     )
-                self.output(f"Deleted {path}")
             except OSError as err:
-                raise ProcessorError(f"Could not remove {path}: {err}")
+                if continue_on_error:
+                    self.output(f"Ignoring error removing {path}: {err}")
+                else:
+                    raise ProcessorError(f"Could not remove {path}: {err}") from err
 
 
 if __name__ == "__main__":

--- a/Code/tests/test_pathdeleter.py
+++ b/Code/tests/test_pathdeleter.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+import shutil
 import unittest
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -99,6 +100,88 @@ class TestPathDeleter(unittest.TestCase):
             self.assertRaisesRegex(ProcessorError, "Could not remove"),
         ):
             self.processor.main()
+
+    def test_continue_on_error_skips_missing_path(self):
+        missing_path = self._path("missing")
+        self.processor.env = {"path_list": [missing_path], "continue_on_error": True}
+
+        # Should not raise.
+        self.processor.main()
+
+    def test_continue_on_error_ignores_removal_error(self):
+        test_file = self._path("test.txt")
+        with open(test_file, "w") as f:
+            f.write("delete me")
+        self.processor.env = {"path_list": [test_file], "continue_on_error": True}
+
+        with patch("os.remove", side_effect=OSError("permission denied")):
+            # Should not raise.
+            self.processor.main()
+
+    def test_directory_removal_retries_then_succeeds(self):
+        test_dir = self._path("testdir")
+        os.makedirs(test_dir)
+        self.processor.env = {"path_list": [test_dir]}
+
+        real_rmtree = shutil.rmtree
+        calls = []
+
+        def flaky_rmtree(path, *args, **kwargs):
+            calls.append(path)
+            if len(calls) == 1:
+                raise OSError("temporarily busy")
+            return real_rmtree(path, *args, **kwargs)
+
+        with (
+            patch("time.sleep") as mock_sleep,
+            patch("shutil.rmtree", side_effect=flaky_rmtree),
+        ):
+            self.processor.main()
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(mock_sleep.call_count, 1)
+        self.assertFalse(os.path.exists(test_dir))
+
+    def test_directory_removal_raises_after_exhausting_retries(self):
+        test_dir = self._path("testdir")
+        os.makedirs(test_dir)
+        self.processor.env = {"path_list": [test_dir]}
+
+        with (
+            patch("time.sleep") as mock_sleep,
+            patch("shutil.rmtree", side_effect=OSError("still busy")) as mock_rmtree,
+            self.assertRaisesRegex(ProcessorError, "after 3 attempts"),
+        ):
+            self.processor.main()
+
+        self.assertEqual(mock_rmtree.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    def test_directory_removal_ignored_after_retries_when_continue_on_error(self):
+        test_dir = self._path("testdir")
+        os.makedirs(test_dir)
+        self.processor.env = {"path_list": [test_dir], "continue_on_error": True}
+
+        # Three failing attempts, then the final ignore_errors sweep.
+        with (
+            patch("time.sleep") as mock_sleep,
+            patch(
+                "shutil.rmtree",
+                side_effect=[
+                    OSError("busy"),
+                    OSError("busy"),
+                    OSError("busy"),
+                    None,
+                ],
+            ) as mock_rmtree,
+        ):
+            # Should not raise.
+            self.processor.main()
+
+        self.assertEqual(mock_rmtree.call_count, 4)
+        self.assertEqual(mock_sleep.call_count, 2)
+        _, final_kwargs = mock_rmtree.call_args
+        self.assertTrue(final_kwargs.get("ignore_errors"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds an optional `continue_on_error` input to the `PathDeleter` processor (defaulting to `False`). When enabled, deletion becomes best-effort so an optional cleanup step (for example clearing a cache, removing build artifacts, etc) won't fail an otherwise-successful recipe run:

- a missing path is skipped instead of raising an error
- a directory that still can't be removed after retries is force-removed with `ignore_errors=True`

Directory removal also retries transient `OSError`s (for example a path briefly held open right after a build) three times with exponential backoff before giving up.

## Backward compatibility

The default (`continue_on_error=False`) keeps the existing behaviour of the Processor: any failure still raises a `ProcessorError`. The one change in default mode is the transient-failure retry on directory removal, which makes an eventual failure more robust rather than changing its outcome.

## Testing

Adds `Code/tests/test_pathdeleter.py` (9 tests): file, link, and directory happy paths, missing-path handling in both modes, and the retry and disposition logic (retry then succeed, retry then raise, retry then ignore). All pass under the bundled AutoPkg Python. black, isort, and flake8 are clean.

## Background

This behaviour is being pulled from my [SharedProcessor `FriendlyPathDeleter`](https://github.com/autopkg/smithjw-recipes/blob/master/SharedProcessors/FriendlyPathDeleter.py), using a clearer input name (`continue_on_error`). One deliberate difference from that original is that `continue_on_error` is respected for file and symlink removals too, not just directories and missing paths, so the flag behaves consistently across every path type.