### PR TITLE
Improved handling of bad/expired GitHub tokens

### DIFF
--- a/Code/autopkg
+++ b/Code/autopkg
@@ -1075,7 +1075,7 @@ def do_gh_repo_contents_fetch(
             log_err(results.get("documentation_url", None))
 
         return None
-    if results is None or code is None:
+    if code is None or code != 200 or results is None:
         log_err("A GitHub API error occurred!")
         return None
     if decode:

--- a/Code/autopkgcmd/searchcmd.py
+++ b/Code/autopkgcmd/searchcmd.py
@@ -74,7 +74,7 @@ def check_search_cache(cache_path: str) -> None:
     # Use URLGetter to interact with GitHub API
     api = URLGetter()
 
-    # Use GitHub token if one exists
+    # GitHubSession filters malformed tokens; this path has its own fallback.
     token = GitHubSession().token
     headers = {"Authorization": f"Bearer {token}"} if token else {}
 

--- a/Code/autopkglib/github/__init__.py
+++ b/Code/autopkglib/github/__init__.py
@@ -30,20 +30,37 @@ TOKEN_LOCATION = os.path.expanduser("~/.autopkg_gh_token")
 DEFAULT_SEARCH_USER = "autopkg"
 
 
+def _sanitize_github_token(token: str | None, source: str) -> str | None:
+    """Return a usable GitHub token or None when it is clearly malformed."""
+    if token is None:
+        return None
+
+    token = token.strip()
+    if not token or re.search(r"\s", token):
+        log_err(
+            f"Ignoring malformed GitHub token from {source}; "
+            "continuing unauthenticated."
+        )
+        return None
+
+    return token
+
+
 def get_github_token(token_path: str | None = None) -> str | None:
     """Read token from preferences, then token_path."""
     token = get_pref("GITHUB_TOKEN")
     token_path = os.path.expanduser(token_path or TOKEN_LOCATION)
-    if not token and os.path.exists(token_path):
+    if token:
+        return _sanitize_github_token(token, "GITHUB_TOKEN preference")
+    if os.path.exists(token_path):
         try:
             with open(token_path) as tokenf:
-                token = tokenf.read().strip()
+                token = tokenf.read()
         except OSError as err:
             log_err(f"Couldn't read token file at {token_path}! Error: {err}")
             token = None
-    # TODO: validate token given we found one but haven't checked its
-    # auth status
-    return token
+        return _sanitize_github_token(token, token_path)
+    return None
 
 
 class GitHubSession(URLGetter):
@@ -112,7 +129,6 @@ To save the token, paste it to the following prompt.""")
             "--location",
             "--silent",
             "--show-error",
-            "--fail",
             "--dump-header",
             "-",
         ]
@@ -146,23 +162,7 @@ To save the token, paste it to the following prompt.""")
     def download_with_curl(self, curl_cmd):
         """Download file using curl and return raw headers."""
 
-        p_stdout, p_stderr, retcode = self.execute_curl(curl_cmd)
-
-        if retcode:  # Non-zero exit code from curl => problem with download
-            curl_err = self.parse_curl_error(p_stderr)
-            log_err(
-                f"Curl failure: Could not retrieve URL {self.env['url']}: {curl_err}"
-            )
-
-            if retcode == 22:
-                # 22 means any 400 series return code. Note: header seems not to
-                # be dumped to STDOUT for immediate failures. Hence
-                # http_result_code is likely blank/000. Read it from stderr.
-                if re.search(r"URL returned error: [0-9]+", p_stderr):
-                    m = re.match(r".* (?P<status_code>\d+) .*", p_stderr)
-                    if m.group("status_code"):
-                        self.http_result_code = m.group("status_code")
-
+        p_stdout, _p_stderr, _retcode = self.execute_curl(curl_cmd)
         return p_stdout
 
     def search_for_name(
@@ -240,7 +240,7 @@ To save the token, paste it to the following prompt.""")
         data=None,
         headers=None,
         accept="application/vnd.github.v3+json",
-    ) -> tuple[Any, int]:
+    ) -> tuple[Any, int | None]:
         """Return a tuple of a serialized JSON response and HTTP status code
         from a call to a GitHub API endpoint. Certain APIs return no JSON
         result and so the first item in the tuple (the response) will be None.
@@ -253,33 +253,80 @@ To save the token, paste it to the following prompt.""")
         accept: optional Accept media type for exceptional APIs (like release
                 assets)."""
 
-        # Compose the URL
         self.env["url"] = self.url + endpoint
         if query:
             self.env["url"] += "?" + query
 
-        temp_content = tempfile.NamedTemporaryFile().name
-        # Prepare curl command
-        curl_cmd = self.prepare_curl_cmd(method, accept, headers, data, temp_content)
+        token_sent = bool(self.token)
+        resp_data, status = self._call_api_once(method, accept, headers, data)
+        if token_sent and self._status_code(status) == 401:
+            warning = (
+                "WARNING: Your GitHub token appears invalid or expired. "
+                "Regenerate it at https://github.com/settings/tokens."
+            )
+            if method.upper() == "GET":
+                log_err(f"{warning} Continuing without it.")
+                resp_data, status = self._call_api_once(
+                    method, accept, headers, data, suppress_auth=True
+                )
+            else:
+                log_err(warning)
 
-        # Execute curl command and parse headers
-        raw_headers = self.download_with_curl(curl_cmd)
-        header = self.parse_headers(raw_headers)
-        http_result_code = header.get("http_result_code")
-        if http_result_code and http_result_code != "000":
-            self.http_result_code = int(http_result_code)
+        return (resp_data, status)
 
-        resp_data = None
+    def _call_api_once(
+        self,
+        method: str,
+        accept: str,
+        headers,
+        data,
+        suppress_auth: bool = False,
+    ) -> tuple[Any, int | None]:
+        """Perform one GitHub API request and return response data and status."""
+        temp_file = tempfile.NamedTemporaryFile(delete=False)
+        temp_content = temp_file.name
+        temp_file.close()
         try:
-            with open(temp_content) as f:
-                resp_data = json.load(f)
-        except UnicodeDecodeError:
-            with open(temp_content, "rb") as f:
-                resp_data = json.load(f)
-        except json.JSONDecodeError as e:
-            self.output(f"JSONDecodeError: {e}")
+            original_token = self.token
+            try:
+                if suppress_auth:
+                    self.token = None
+                curl_cmd = self.prepare_curl_cmd(
+                    method, accept, headers, data, temp_content
+                )
+            finally:
+                self.token = original_token
 
-        return (resp_data, self.http_result_code)
+            self.http_result_code = None
+            raw_headers = self.download_with_curl(curl_cmd)
+            header = self.parse_headers(raw_headers)
+            http_result_code = header.get("http_result_code")
+            if http_result_code and http_result_code != "000":
+                self.http_result_code = int(http_result_code)
+
+            resp_data = None
+            try:
+                with open(temp_content) as f:
+                    resp_data = json.load(f)
+            except UnicodeDecodeError:
+                with open(temp_content, "rb") as f:
+                    resp_data = json.load(f)
+            except json.JSONDecodeError as e:
+                self.output(f"JSONDecodeError: {e}")
+
+            return (resp_data, self.http_result_code)
+        finally:
+            try:
+                os.unlink(temp_content)
+            except OSError:
+                pass
+
+    def _status_code(self, status) -> int:
+        """Return an integer HTTP status, defaulting to 0 when unset."""
+        try:
+            return int(status or 0)
+        except (TypeError, ValueError):
+            return 0
 
 
 def get_table_row(row_items, col_widths, header=False):

--- a/Code/tests/test_autopkg_repos.py
+++ b/Code/tests/test_autopkg_repos.py
@@ -451,6 +451,23 @@ class TestAutoPkgRepos(unittest.TestCase):
                 "Found this recipe in repository: test-recipes"
             )
 
+    @patch("autopkg.GitHubSession")
+    def test_do_gh_repo_contents_fetch_returns_none_on_api_error(
+        self, mock_github_session
+    ):
+        """GitHub API error bodies should not be treated as content responses."""
+        mock_session = Mock()
+        mock_github_session.return_value = mock_session
+        mock_session.call_api.return_value = ({"message": "Not Found"}, 404)
+
+        with patch("sys.stderr", new_callable=StringIO) as stderr:
+            result = autopkg.do_gh_repo_contents_fetch(
+                "recipes", "Missing/Missing.recipe"
+            )
+
+        self.assertIsNone(result)
+        self.assertIn("A GitHub API error occurred", stderr.getvalue())
+
     # Tests for get_recipe_repo function
     @patch("autopkg.run_git")
     @patch("autopkg.git_cmd")

--- a/Code/tests/test_github.py
+++ b/Code/tests/test_github.py
@@ -1,33 +1,213 @@
 #!/usr/local/autopkg/python
 
+import json
 import os
 import tempfile
 import unittest
+from io import StringIO
 from unittest.mock import patch
 
-from autopkglib.github import get_github_token
+from autopkglib.github import GitHubSession, get_github_token
 
 
 class TestGitHubToken(unittest.TestCase):
     """Tests for GitHub token discovery."""
 
-    def _write_token_file(self):
+    def _write_token_file(self, token="ghp_filetoken\n"):
         tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(tmpdir.cleanup)
         token_path = os.path.join(tmpdir.name, ".autopkg_gh_token")
         with open(token_path, "w") as token_file:
-            token_file.write("file-token\n")
+            token_file.write(token)
         return token_path
 
     def test_get_github_token_prefers_preferences(self):
         token_path = self._write_token_file()
-        with patch("autopkglib.github.get_pref", return_value="prefs-token"):
-            self.assertEqual(get_github_token(token_path), "prefs-token")
+        with patch("autopkglib.github.get_pref", return_value="ghp_prefstoken"):
+            self.assertEqual(get_github_token(token_path), "ghp_prefstoken")
 
     def test_get_github_token_reads_token_file(self):
         token_path = self._write_token_file()
         with patch("autopkglib.github.get_pref", return_value=None):
-            self.assertEqual(get_github_token(token_path), "file-token")
+            self.assertEqual(get_github_token(token_path), "ghp_filetoken")
+
+    def test_get_github_token_strips_preferences_token(self):
+        with patch("autopkglib.github.get_pref", return_value="  ghp_prefstoken  "):
+            self.assertEqual(get_github_token("/missing/token"), "ghp_prefstoken")
+
+    def test_get_github_token_ignores_malformed_file_token(self):
+        token_path = self._write_token_file("ghp_bad token\n")
+
+        with (
+            patch("autopkglib.github.get_pref", return_value=None),
+            patch("sys.stderr", new=StringIO()) as stderr,
+        ):
+            self.assertIsNone(get_github_token(token_path))
+
+        self.assertIn("Ignoring malformed GitHub token", stderr.getvalue())
+        self.assertIn(token_path, stderr.getvalue())
+
+    def test_get_github_token_ignores_malformed_preference_token(self):
+        token_path = self._write_token_file("ghp_filetoken\n")
+
+        with (
+            patch("autopkglib.github.get_pref", return_value="ghp_bad token"),
+            patch("sys.stderr", new=StringIO()) as stderr,
+        ):
+            self.assertIsNone(get_github_token(token_path))
+
+        self.assertIn("GITHUB_TOKEN preference", stderr.getvalue())
+
+
+class TestGitHubSession(unittest.TestCase):
+    """Tests for GitHub API request handling."""
+
+    def _execute_curl_side_effect(self, responses, curl_cmds):
+        def _execute_curl(curl_cmd):
+            curl_cmds.append(curl_cmd)
+            output_path = curl_cmd[curl_cmd.index("--output") + 1]
+            response = responses.pop(0)
+            with open(output_path, "w") as response_file:
+                json.dump(response["body"], response_file)
+            return response["headers"], "", 0
+
+        return _execute_curl
+
+    def _session(self, token=None):
+        with patch.object(GitHubSession, "_get_token", return_value=token):
+            session = GitHubSession()
+        session.curl_binary = lambda: "curl"
+        return session
+
+    def test_prepare_curl_cmd_does_not_use_fail(self):
+        session = self._session()
+        curl_cmd = session.prepare_curl_cmd(
+            "GET",
+            "application/vnd.github.v3+json",
+            None,
+            None,
+            "/tmp/github-response.json",
+        )
+
+        self.assertNotIn("--fail", curl_cmd)
+
+    def test_call_api_retries_get_without_auth_after_401(self):
+        session = self._session(token="ghp_badtoken")
+        responses = [
+            {
+                "headers": "HTTP/2 401 Unauthorized\n\n",
+                "body": {"message": "Bad credentials"},
+            },
+            {
+                "headers": "HTTP/2 200 OK\n\n",
+                "body": {"name": "recipes"},
+            },
+        ]
+        curl_cmds = []
+
+        with (
+            patch.object(
+                session,
+                "execute_curl",
+                side_effect=self._execute_curl_side_effect(responses, curl_cmds),
+            ),
+            patch("sys.stderr", new=StringIO()) as stderr,
+        ):
+            data, status = session.call_api("/repos/autopkg/recipes")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data, {"name": "recipes"})
+        self.assertEqual(len(curl_cmds), 2)
+        self.assertIn("Authorization: token ghp_badtoken", curl_cmds[0])
+        self.assertNotIn("Authorization: token ghp_badtoken", curl_cmds[1])
+        self.assertIn("invalid or expired", stderr.getvalue())
+        self.assertIn("Continuing without it", stderr.getvalue())
+
+    def test_call_api_returns_anonymous_retry_failure(self):
+        session = self._session(token="ghp_badtoken")
+        responses = [
+            {
+                "headers": "HTTP/2 401 Unauthorized\n\n",
+                "body": {"message": "Bad credentials"},
+            },
+            {
+                "headers": "HTTP/2 404 Not Found\n\n",
+                "body": {"message": "Not Found"},
+            },
+        ]
+        curl_cmds = []
+
+        with (
+            patch.object(
+                session,
+                "execute_curl",
+                side_effect=self._execute_curl_side_effect(responses, curl_cmds),
+            ),
+            patch("sys.stderr", new=StringIO()) as stderr,
+        ):
+            data, status = session.call_api("/repos/autopkg/private-recipes")
+
+        self.assertEqual(status, 404)
+        self.assertEqual(data, {"message": "Not Found"})
+        self.assertEqual(len(curl_cmds), 2)
+        self.assertIn("Authorization: token ghp_badtoken", curl_cmds[0])
+        self.assertNotIn("Authorization: token ghp_badtoken", curl_cmds[1])
+        self.assertIn("Continuing without it", stderr.getvalue())
+
+    def test_call_api_does_not_retry_403(self):
+        session = self._session(token="ghp_goodtoken")
+        responses = [
+            {
+                "headers": "HTTP/2 403 Forbidden\n\n",
+                "body": {"message": "API rate limit exceeded"},
+            }
+        ]
+        curl_cmds = []
+
+        with (
+            patch.object(
+                session,
+                "execute_curl",
+                side_effect=self._execute_curl_side_effect(responses, curl_cmds),
+            ),
+            patch("sys.stderr", new=StringIO()) as stderr,
+        ):
+            data, status = session.call_api("/repos/autopkg/recipes")
+
+        self.assertEqual(status, 403)
+        self.assertEqual(data, {"message": "API rate limit exceeded"})
+        self.assertEqual(len(curl_cmds), 1)
+        self.assertIn("Authorization: token ghp_goodtoken", curl_cmds[0])
+        self.assertNotIn("invalid or expired", stderr.getvalue())
+
+    def test_call_api_does_not_retry_non_get_401(self):
+        session = self._session(token="ghp_badtoken")
+        responses = [
+            {
+                "headers": "HTTP/2 401 Unauthorized\n\n",
+                "body": {"message": "Bad credentials"},
+            }
+        ]
+        curl_cmds = []
+
+        with (
+            patch.object(
+                session,
+                "execute_curl",
+                side_effect=self._execute_curl_side_effect(responses, curl_cmds),
+            ),
+            patch("sys.stderr", new=StringIO()) as stderr,
+        ):
+            data, status = session.call_api(
+                "/repos/autopkg/recipes", method="POST", data={"name": "recipes"}
+            )
+
+        self.assertEqual(status, 401)
+        self.assertEqual(data, {"message": "Bad credentials"})
+        self.assertEqual(len(curl_cmds), 1)
+        self.assertIn("Authorization: token ghp_badtoken", curl_cmds[0])
+        self.assertIn("invalid or expired", stderr.getvalue())
+        self.assertNotIn("Continuing without it", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Users with a malformed or expired GitHub token currently see hard failures across all authenticated API calls. Recipe runs, repo operations, and searches can fail with no guidance on why. This change makes AutoPkg degrade gracefully to unauthenticated behavior and tell users what to do, so a stale token file doesn't silently break their setup.

**Token sanitization**

`get_github_token` now strips tokens and rejects ones that are empty or contain interior whitespace, logging a clear message and falling back to unauthenticated. A malformed preference token no longer silently falls through to the token file.

**401 retry**

If an authenticated GET returns 401, `call_api` logs a warning (with a link to regenerate the token) and retries once without auth. Non-GET requests get the warning but no retry, since anonymous writes/mutations don't make sense.

**Mechanics**

- Removed `--fail` from `GitHubSession`'s curl command so 4xx responses flow back as `(body, status)` instead of raising before status can be read. This also revives the existing 403/rate-limit handling path in `do_gh_repo_contents_fetch`, which was previously unreachable.
- Extracted `_call_api_once` to handle the single-request lifecycle, including a fix for a pre-existing temp file leak.
- Fixed a `KeyError` in `do_gh_repo_contents_fetch` where non-200 API error bodies (now returned instead of raised) could reach `results["content"]`.

**Validation**

In addition to the unit tests, which all pass, I used an AI agent to create a [one-off script](https://gist.github.com/homebysix/9474e41731b6a329bd475b44f9b9ed02) specifically to test the code paths that this PR changes. All pass:

```
Path 1: Malformed token (interior whitespace) is rejected
  [PASS] Returns None
  [PASS] Logs 'Ignoring malformed'
         stderr: Ignoring malformed GitHub token from /var/folders/5s/x9b8f6c11ln77h34hbwk_kzm0000gn/T/tmpo437lbf2/.autopkg_gh_token; continuing unauthenticated.
  [PASS] Names the source file
         stderr: Ignoring malformed GitHub token from /var/folders/5s/x9b8f6c11ln77h34hbwk_kzm0000gn/T/tmpo437lbf2/.autopkg_gh_token; continuing unauthenticated.

Path 2: Token without known prefix is accepted without warnings
  [PASS] Token is accepted
  [PASS] No warnings logged

Path 3: Unauthenticated session makes a successful API call
  (1 real network request to api.github.com)
  [PASS] HTTP 200 returned
         status: 200
  [PASS] Response contains expected repo name
         name field: autopkg
  [PASS] No token was sent (session.token is None)

Path 4: Bad token triggers 401, retries anonymously, succeeds
  (2 real network requests to api.github.com)
  stderr: WARNING: Your GitHub token appears invalid or expired. Regenerate it at https://github.com/settings/tokens. Continuing without it.
  [PASS] HTTP 200 returned after anonymous retry
         status: 200
  [PASS] Response contains expected repo name
         name field: autopkg
  [PASS] Warning: token invalid or expired
  [PASS] Warning: continuing without it

12 of 12 checks passed
```

I'm also running this today against a random sampling of AutoPkg in the org to check for regressions.

Closes #1037