### PR TITLE
Update `URLDownloader` & `URLDownloaderPython` with new inputs/validation

### DIFF
--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -109,8 +109,8 @@ class URLDownloader(URLGetter):
             "required": False,
             "description": (
                 "List of HTTP headers to compare against the previous download "
-                "to detect changes. If 'CHECK_FILESIZE_ONLY' is enabled, this "
-                "list is overridden to ['Content-Length'] only."
+                "to detect changes. Their values are persisted in .info.json. "
+                "If 'CHECK_FILESIZE_ONLY' is enabled, only Content-Length is used."
             ),
             "default": ["ETag", "Last-Modified", "Content-Length"],
         },
@@ -121,7 +121,8 @@ class URLDownloader(URLGetter):
                 "download the file again. Defaults to True as most current "
                 "recipes expect the files to be present. This re-fetch does "
                 "not mark the item as changed (download_changed stays false); "
-                "download_changed reflects the remote resource only."
+                "download_changed reflects the remote resource only. A missing "
+                "or null value uses the default; a blank string disables it."
             ),
             "default": True,
         },
@@ -164,7 +165,7 @@ class URLDownloader(URLGetter):
 
         value = self.env[key]
         if value is None:
-            return False
+            return default
         if isinstance(value, bool):
             return value
         if isinstance(value, str):
@@ -174,10 +175,13 @@ class URLDownloader(URLGetter):
             if normalised in ("false", "no", "off", "0", ""):
                 return False
 
-        raise ProcessorError(
+        message = (
             f"{key} must be a boolean or boolean-like string "
             f"(true/false, yes/no, on/off, 1/0), not {value!r}"
         )
+        if key == "prefetch_filename":
+            message += "; use filename to override the downloaded filename"
+        raise ProcessorError(message)
 
     def prepare_base_curl_cmd(self) -> list[str]:
         """Assemble base curl command and return it."""
@@ -221,7 +225,6 @@ class URLDownloader(URLGetter):
         # unchanged content.
         if os.path.exists(self.env["pathname"]):
             metadata = self.get_metadata()
-            self.existing_file_size: int | None = os.path.getsize(self.env["pathname"])
             if not self.env_bool("CHECK_FILESIZE_ONLY"):
                 http_headers: dict[str, Any] = metadata.get("http_headers", {})
                 if etag := http_headers.get("ETag"):
@@ -248,7 +251,6 @@ class URLDownloader(URLGetter):
         self.env["last_modified"] = ""
         self.env["etag"] = ""
         self.env["download_url"] = ""
-        self.existing_file_size = None
 
     def prefetch_filename(self) -> str | None:
         """Attempt to find filename in HTTP headers."""
@@ -371,10 +373,7 @@ class URLDownloader(URLGetter):
             return
         hash_keys = ("file_sha1", "file_sha256", "file_md5")
         if os.path.isfile(self.env["pathname"]):
-            hashes = self.compute_hashes()
-            self.env["file_sha1"] = hashes["sha1"]
-            self.env["file_sha256"] = hashes["sha256"]
-            self.env["file_md5"] = hashes["md5"]
+            self.store_hashes_in_env(self.compute_hashes())
             return
         metadata = self.env.get("download_info") or {}
         if all(metadata.get(key) for key in hash_keys):
@@ -410,20 +409,35 @@ class URLDownloader(URLGetter):
         self.env["etag"] = previous_http_headers.get("ETag", "")
         self.env["download_url"] = metadata.get("download_url", "")
 
-    def metadata_header(self, metadata: dict[str, Any], header_name: str) -> Any:
-        """Return a stored HTTP header from canonical or lower-case metadata."""
-        http_headers = metadata.get("http_headers", {})
-        canonical_headers = {
+    @staticmethod
+    def header_value(headers, header_name: str) -> Any:
+        """Return an HTTP header value without regard to name casing."""
+        return next(
+            (
+                value
+                for name, value in headers.items()
+                if name.lower() == header_name.lower()
+            ),
+            None,
+        )
+
+    def download_headers(self, header, file_size: int) -> dict[str, Any]:
+        """Return the response headers persisted for future change checks."""
+        names = list(self.input_variables["HEADERS_TO_TEST"]["default"])
+        names.extend(self.env.get("HEADERS_TO_TEST") or [])
+        canonical_names = {
             "content-length": "Content-Length",
             "etag": "ETag",
             "last-modified": "Last-Modified",
         }
-        canonical_name = canonical_headers.get(header_name.lower(), header_name)
-        return http_headers.get(canonical_name, http_headers.get(header_name.lower()))
-
-    def response_header(self, header: dict[str, Any], header_name: str) -> Any:
-        """Return a response header from curl's lower-case parsed headers."""
-        return header.get(header_name.lower(), header.get(header_name))
+        return {
+            canonical_names.get(name.lower(), name): (
+                file_size
+                if name.lower() == "content-length"
+                else self.header_value(header, name) or ""
+            )
+            for name in names
+        }
 
     def download_changed(self, header) -> bool:
         """Return True if the remote item differs from the cached metadata.
@@ -436,7 +450,7 @@ class URLDownloader(URLGetter):
         metadata = self.get_metadata()
         self.publish_download_info(metadata)
 
-        if header["http_result_code"] == "304":
+        if self.header_value(header, "http_result_code") == "304":
             # resource not modified
             self.output("Item at URL is unchanged.")
             return False
@@ -452,14 +466,21 @@ class URLDownloader(URLGetter):
         previous_download_exists = bool(
             previous_download_path and os.path.isfile(previous_download_path)
         )
+        existing_file_size = (
+            os.path.getsize(previous_download_path)
+            if previous_download_exists
+            else None
+        )
 
         header_matches = 0
         for header_name in headers_to_test:
-            previous_header = self.metadata_header(metadata, header_name)
-            current_header = self.response_header(header, header_name)
+            previous_header = self.header_value(
+                metadata.get("http_headers", {}), header_name
+            )
+            current_header = self.header_value(header, header_name)
             if header_name.lower() == "content-length":
-                if previous_download_exists:
-                    previous_header = os.path.getsize(previous_download_path)
+                if existing_file_size is not None:
+                    previous_header = existing_file_size
                 try:
                     if int(previous_header) != int(current_header):
                         self.output("Content-Length is different", 2)
@@ -490,13 +511,23 @@ class URLDownloader(URLGetter):
         # file, see if it matches the size of the cached file.
         # Useful for webservers that don't provide Last-Modified
         # and ETag headers.
-        if not header.get("etag") and not header.get("last-modified"):
-            size_header = header.get("content-length")
-            if (
-                size_header
-                and self.existing_file_size is not None
-                and int(size_header) == self.existing_file_size
-            ):
+        if not self.header_value(header, "etag") and not self.header_value(
+            header, "last-modified"
+        ):
+            size_header = self.header_value(header, "content-length")
+            try:
+                size_matches = (
+                    size_header is not None
+                    and existing_file_size is not None
+                    and int(size_header) == existing_file_size
+                )
+            except (TypeError, ValueError) as err:
+                self.output(
+                    f"WARNING: 'Content-Length' invalid. ({type(err).__name__}) {err}",
+                    1,
+                )
+                size_matches = False
+            if size_matches:
                 self.output(
                     "File size returned by webserver matches that "
                     f"of the cached file: {size_header} bytes"
@@ -524,7 +555,6 @@ class URLDownloader(URLGetter):
     def store_headers(self, header) -> None:
         """Store last-modified and etag headers in pathname xattr."""
         if header.get("last-modified"):
-            self.env["last_modified"] = header.get("last-modified")
             xattr.setxattr(
                 self.env["pathname"],
                 self.xattr_last_modified,
@@ -533,10 +563,7 @@ class URLDownloader(URLGetter):
             self.output(
                 f"Storing new Last-Modified header: {header.get('last-modified')}"
             )
-
-        self.env["etag"] = ""
         if header.get("etag"):
-            self.env["etag"] = header.get("etag")
             xattr.setxattr(
                 self.env["pathname"], self.xattr_etag, header.get("etag").encode()
             )
@@ -544,22 +571,19 @@ class URLDownloader(URLGetter):
 
     def store_metadata(self, header: dict[str, Any]) -> None:
         """Write download metadata to .info.json and preserve legacy xattr metadata."""
-        pathname_info_json = self.env["pathname"] + ".info.json"
-
-        self.env["etag"] = header.get("etag", "")
         self.env["file_size"] = os.path.getsize(self.env["pathname"])
-        self.env["last_modified"] = header.get("last-modified", "")
-        self.env["download_url"] = header.get("http_redirected") or self.env["url"]
+        http_headers = self.download_headers(header, self.env["file_size"])
+        self.env["etag"] = http_headers["ETag"]
+        self.env["last_modified"] = http_headers["Last-Modified"]
+        self.env["download_url"] = (
+            self.header_value(header, "http_redirected") or self.env["url"]
+        )
 
         metadata_dict: dict[str, Any] = {
             "download_url": self.env["download_url"],
             "file_name": os.path.basename(self.env["pathname"]),
             "file_size": self.env["file_size"],
-            "http_headers": {
-                "Content-Length": self.env["file_size"],
-                "ETag": self.env["etag"],
-                "Last-Modified": self.env["last_modified"],
-            },
+            "http_headers": http_headers,
         }
         if self.env_bool("COMPUTE_HASHES"):
             self.store_hashes_in_env(self.compute_hashes())
@@ -571,7 +595,16 @@ class URLDownloader(URLGetter):
                 }
             )
 
-        metadata_str = json.dumps(metadata_dict, indent=4, sort_keys=True)
+        self.write_metadata(metadata_dict)
+
+        # Preserve legacy xattr metadata for callers that still read it.
+        self.store_headers(header)
+
+    def write_metadata(self, metadata: dict[str, Any]) -> None:
+        """Write download metadata atomically to the .info.json sidecar."""
+        self.env["download_info"] = metadata
+        pathname_info_json = self.env["pathname"] + ".info.json"
+        metadata_str = json.dumps(metadata, indent=4, sort_keys=True)
 
         # Write metadata atomically to avoid partial-write corruption
         self.output(f"Storing metadata to {pathname_info_json}")
@@ -588,8 +621,19 @@ class URLDownloader(URLGetter):
             os.remove(tmp_path)
             raise
 
-        # Preserve legacy xattr metadata for callers that still read it.
-        self.store_headers(header)
+    def report_download(self, version_changed: bool) -> None:
+        """Report a new download or the replacement of a missing cached file."""
+        if version_changed:
+            message = f"Downloaded {self.env['pathname']}"
+            summary = "The following new items were downloaded:"
+        else:
+            message = f"Re-downloaded missing file: {self.env['pathname']}"
+            summary = "The following missing items were re-downloaded:"
+        self.output(message)
+        self.env["url_downloader_summary_result"] = {
+            "summary_text": summary,
+            "data": {"download_path": self.env["pathname"]},
+        }
 
     def main(self) -> None:
         # Clear and initialize data structures
@@ -638,18 +682,7 @@ class URLDownloader(URLGetter):
         # Save .info.json metadata and legacy last-modified/etag xattrs.
         self.store_metadata(header)
 
-        # Generate output messages and variables
-        if version_changed:
-            self.output(f"Downloaded {self.env['pathname']}")
-            self.env["url_downloader_summary_result"] = {
-                "summary_text": "The following new items were downloaded:",
-                "data": {"download_path": self.env["pathname"]},
-            }
-        else:
-            self.output(
-                "Re-downloaded missing file (version unchanged): "
-                f"{self.env['pathname']}"
-            )
+        self.report_download(version_changed)
 
 
 if __name__ == "__main__":

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -105,6 +105,24 @@ class URLDownloader(URLGetter):
                 "the downloaded file."
             ),
         },
+        "HEADERS_TO_TEST": {
+            "required": False,
+            "description": (
+                "List of HTTP headers to compare against the previous download "
+                "to detect changes. If 'CHECK_FILESIZE_ONLY' is enabled, this "
+                "list is overridden to ['Content-Length'] only."
+            ),
+            "default": ["ETag", "Last-Modified", "Content-Length"],
+        },
+        "download_missing_file": {
+            "required": False,
+            "description": (
+                "If the file is missing but matching metadata is present, "
+                "download the file again. Defaults to True as most current "
+                "recipes expect the files to be present."
+            ),
+            "default": True,
+        },
     }
     output_variables = {
         "pathname": {"description": "Path to the downloaded file."},
@@ -112,12 +130,16 @@ class URLDownloader(URLGetter):
             "description": "last-modified header for the downloaded item."
         },
         "etag": {"description": "etag header for the downloaded item."},
+        "download_url": {
+            "description": "The final URL the file was downloaded from (after redirects)."
+        },
         "download_changed": {
             "description": (
                 "Boolean indicating if the download has changed since the "
                 "last time it was downloaded."
             )
         },
+        "download_info": {"description": "Info from previous or current download."},
         "file_sha1": {"description": "SHA-1 hash of the downloaded file."},
         "file_sha256": {"description": "SHA-256 hash of the downloaded file."},
         "file_md5": {"description": "MD5 hash of the downloaded file."},
@@ -132,6 +154,21 @@ class URLDownloader(URLGetter):
             "getxattr() has been removed from URLDownloader. "
             "Use get_metadata() to read cached download metadata."
         )
+
+    def env_bool(self, key: str, default: bool = False) -> bool:
+        """Return a boolean for AutoPkg env values that may arrive as strings."""
+        if key not in self.env:
+            return default
+
+        value = self.env[key]
+        if value is None:
+            return False
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() == "true"
+
+        raise ProcessorError(f"{key} must be a boolean, 'true', 'false', or null")
 
     def prepare_base_curl_cmd(self) -> list[str]:
         """Assemble base curl command and return it."""
@@ -176,8 +213,8 @@ class URLDownloader(URLGetter):
         if os.path.exists(self.env["pathname"]):
             metadata = self.get_metadata()
             self.existing_file_size: int | None = os.path.getsize(self.env["pathname"])
-            if not self.env.get("CHECK_FILESIZE_ONLY"):
-                http_headers: dict[str, str] = metadata.get("http_headers", {})
+            if not self.env_bool("CHECK_FILESIZE_ONLY"):
+                http_headers: dict[str, Any] = metadata.get("http_headers", {})
                 if etag := http_headers.get("ETag"):
                     headers["If-None-Match"] = etag
                 if last_modified := http_headers.get("Last-Modified"):
@@ -201,6 +238,7 @@ class URLDownloader(URLGetter):
         self.env["file_size"] = 0
         self.env["last_modified"] = ""
         self.env["etag"] = ""
+        self.env["download_url"] = ""
         self.existing_file_size = None
 
     def prefetch_filename(self) -> str | None:
@@ -245,7 +283,7 @@ class URLDownloader(URLGetter):
             self.output(f"Given {self.env['pathname']}, no download needed.")
             return None
 
-        if self.env.get("prefetch_filename", False):
+        if self.env_bool("prefetch_filename"):
             filename = self.prefetch_filename()
             if filename:
                 return filename
@@ -325,15 +363,100 @@ class URLDownloader(URLGetter):
         os.chmod(pathname_temporary, 0o644)
         return pathname_temporary
 
+    def publish_download_info(self, metadata: dict[str, Any]) -> None:
+        """Expose cached download metadata for downstream processors."""
+        if not metadata:
+            return
+
+        self.env["download_info"] = metadata
+        previous_http_headers = metadata.get("http_headers", {})
+        self.env["last_modified"] = previous_http_headers.get("Last-Modified", "")
+        self.env["etag"] = previous_http_headers.get("ETag", "")
+        self.env["download_url"] = metadata.get("download_url", "")
+
+    def metadata_header(self, metadata: dict[str, Any], header_name: str) -> Any:
+        """Return a stored HTTP header from canonical or lower-case metadata."""
+        http_headers = metadata.get("http_headers", {})
+        canonical_headers = {
+            "content-length": "Content-Length",
+            "etag": "ETag",
+            "last-modified": "Last-Modified",
+        }
+        canonical_name = canonical_headers.get(header_name.lower(), header_name)
+        return http_headers.get(canonical_name, http_headers.get(header_name.lower()))
+
+    def response_header(self, header: dict[str, Any], header_name: str) -> Any:
+        """Return a response header from curl's lower-case parsed headers."""
+        return header.get(header_name.lower(), header.get(header_name))
+
     def download_changed(self, header) -> bool:
         """Check if downloaded file changed on server."""
+        metadata = self.get_metadata()
+        self.publish_download_info(metadata)
+
+        previous_download_path = self.env.get("pathname")
+        previous_download_exists = bool(
+            previous_download_path and os.path.isfile(previous_download_path)
+        )
+        if not previous_download_exists and self.env_bool(
+            "download_missing_file", default=True
+        ):
+            return True
+
+        if header["http_result_code"] == "304":
+            # resource not modified
+            self.env["download_changed"] = False
+            self.output("Item at URL is unchanged.")
+            self.output(f"Using existing {self.env['pathname']}")
+            return False
+
+        headers_to_test = (
+            self.env.get("HEADERS_TO_TEST")
+            or self.input_variables["HEADERS_TO_TEST"]["default"]
+        )
+        if self.env_bool("CHECK_FILESIZE_ONLY"):
+            headers_to_test = ["Content-Length"]
+
+        header_matches = 0
+        for header_name in headers_to_test:
+            previous_header = self.metadata_header(metadata, header_name)
+            current_header = self.response_header(header, header_name)
+            if header_name.lower() == "content-length":
+                if previous_download_exists:
+                    previous_header = os.path.getsize(previous_download_path)
+                try:
+                    if int(previous_header) != int(current_header):
+                        self.output("Content-Length is different", 2)
+                        return True
+                    header_matches += 1
+                except (TypeError, ValueError) as err:
+                    self.output(
+                        "WARNING: 'Content-Length' missing. "
+                        f"({type(err).__name__}) {err}",
+                        1,
+                    )
+                continue
+
+            if current_header is None and previous_header in ("", None):
+                continue
+            if previous_header is None:
+                self.output(f"WARNING: header missing. (KeyError) {header_name}", 1)
+                continue
+            if previous_header != current_header:
+                self.output(f"{header_name} is different", 2)
+                return True
+            header_matches += 1
+
+        if header_matches:
+            self.env["download_changed"] = False
+            self.output(f"Using existing {self.env['pathname']}")
+            return False
+
         # If Content-Length header is present and we had a cached
         # file, see if it matches the size of the cached file.
         # Useful for webservers that don't provide Last-Modified
         # and ETag headers.
-        if (not header.get("etag") and not header.get("last-modified")) or self.env[
-            "CHECK_FILESIZE_ONLY"
-        ]:
+        if not header.get("etag") and not header.get("last-modified"):
             size_header = header.get("content-length")
             if (
                 size_header
@@ -352,13 +475,6 @@ class URLDownloader(URLGetter):
                 )
                 self.output(f"Using existing {self.env['pathname']}")
                 return False
-
-        if header["http_result_code"] == "304":
-            # resource not modified
-            self.env["download_changed"] = False
-            self.output("Item at URL is unchanged.")
-            self.output(f"Using existing {self.env['pathname']}")
-            return False
 
         return True
 
@@ -401,9 +517,10 @@ class URLDownloader(URLGetter):
         self.env["etag"] = header.get("etag", "")
         self.env["file_size"] = os.path.getsize(self.env["pathname"])
         self.env["last_modified"] = header.get("last-modified", "")
+        self.env["download_url"] = header.get("http_redirected") or self.env["url"]
 
         metadata_dict: dict[str, Any] = {
-            "download_url": self.env["url"],
+            "download_url": self.env["download_url"],
             "file_name": os.path.basename(self.env["pathname"]),
             "file_size": self.env["file_size"],
             "http_headers": {
@@ -412,7 +529,7 @@ class URLDownloader(URLGetter):
                 "Last-Modified": self.env["last_modified"],
             },
         }
-        if self.env.get("COMPUTE_HASHES", False):
+        if self.env_bool("COMPUTE_HASHES"):
             self.store_hashes_in_env(self.compute_hashes())
             metadata_dict.update(
                 {
@@ -466,7 +583,7 @@ class URLDownloader(URLGetter):
         else:
             # Discard the temp file
             os.remove(pathname_temporary)
-            if self.env.get("COMPUTE_HASHES", False):
+            if self.env_bool("COMPUTE_HASHES"):
                 self.store_hashes_in_env(self.compute_hashes())
             return
 

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -119,7 +119,9 @@ class URLDownloader(URLGetter):
             "description": (
                 "If the file is missing but matching metadata is present, "
                 "download the file again. Defaults to True as most current "
-                "recipes expect the files to be present."
+                "recipes expect the files to be present. This re-fetch does "
+                "not mark the item as changed (download_changed stays false); "
+                "download_changed reflects the remote resource only."
             ),
             "default": True,
         },
@@ -358,6 +360,33 @@ class URLDownloader(URLGetter):
         self.env["file_sha256"] = hashes["sha256"]
         self.env["file_md5"] = hashes["md5"]
 
+    def publish_existing_hashes(self) -> None:
+        """Expose hashes on a cache hit without failing on a missing file.
+
+        Computes from the cached file when present; otherwise reuses the hashes
+        stored in ``.info.json``. When neither is available it warns and skips,
+        so a metadata-only cache hit never crashes on an absent file.
+        """
+        if not self.env_bool("COMPUTE_HASHES"):
+            return
+        hash_keys = ("file_sha1", "file_sha256", "file_md5")
+        if os.path.isfile(self.env["pathname"]):
+            hashes = self.compute_hashes()
+            self.env["file_sha1"] = hashes["sha1"]
+            self.env["file_sha256"] = hashes["sha256"]
+            self.env["file_md5"] = hashes["md5"]
+            return
+        metadata = self.env.get("download_info") or {}
+        if all(metadata.get(key) for key in hash_keys):
+            for key in hash_keys:
+                self.env[key] = metadata[key]
+            self.output("Reusing hashes from .info.json (cached file absent).", 2)
+        else:
+            self.output(
+                "WARNING: COMPUTE_HASHES is set but the cached file is absent "
+                "and no stored hashes were found in .info.json; skipping hashes."
+            )
+
     def create_temp_file(self, download_dir) -> str:
         """Create temporary file and return its path."""
         temporary_file = tempfile.NamedTemporaryFile(dir=download_dir, delete=False)
@@ -397,24 +426,19 @@ class URLDownloader(URLGetter):
         return header.get(header_name.lower(), header.get(header_name))
 
     def download_changed(self, header) -> bool:
-        """Check if downloaded file changed on server."""
+        """Return True if the remote item differs from the cached metadata.
+
+        This is a pure version check against the stored ``.info.json``: it does
+        not depend on whether the cached file is present on disk, and it does
+        not force a download for a missing file. Re-fetching a file that has
+        gone missing is handled in ``main()`` via ``download_missing_file``.
+        """
         metadata = self.get_metadata()
         self.publish_download_info(metadata)
 
-        previous_download_path = self.env.get("pathname")
-        previous_download_exists = bool(
-            previous_download_path and os.path.isfile(previous_download_path)
-        )
-        if not previous_download_exists and self.env_bool(
-            "download_missing_file", default=True
-        ):
-            return True
-
         if header["http_result_code"] == "304":
             # resource not modified
-            self.env["download_changed"] = False
             self.output("Item at URL is unchanged.")
-            self.output(f"Using existing {self.env['pathname']}")
             return False
 
         headers_to_test = (
@@ -423,6 +447,11 @@ class URLDownloader(URLGetter):
         )
         if self.env_bool("CHECK_FILESIZE_ONLY"):
             headers_to_test = ["Content-Length"]
+
+        previous_download_path = self.env.get("pathname")
+        previous_download_exists = bool(
+            previous_download_path and os.path.isfile(previous_download_path)
+        )
 
         header_matches = 0
         for header_name in headers_to_test:
@@ -455,8 +484,6 @@ class URLDownloader(URLGetter):
             header_matches += 1
 
         if header_matches:
-            self.env["download_changed"] = False
-            self.output(f"Using existing {self.env['pathname']}")
             return False
 
         # If Content-Length header is present and we had a cached
@@ -470,7 +497,6 @@ class URLDownloader(URLGetter):
                 and self.existing_file_size is not None
                 and int(size_header) == self.existing_file_size
             ):
-                self.env["download_changed"] = False
                 self.output(
                     "File size returned by webserver matches that "
                     f"of the cached file: {size_header} bytes"
@@ -480,7 +506,6 @@ class URLDownloader(URLGetter):
                     "fallback mechanism that does not guarantee "
                     "that a build is unchanged."
                 )
-                self.output(f"Using existing {self.env['pathname']}")
                 return False
 
         return True
@@ -585,27 +610,46 @@ class URLDownloader(URLGetter):
         raw_headers = self.download_with_curl(curl_cmd)
         header = self.parse_headers(raw_headers)
 
-        if self.download_changed(header):
-            self.env["download_changed"] = True
-        else:
-            # Discard the temp file
+        # download_changed reflects the remote resource only (remote vs .info.json).
+        version_changed = self.download_changed(header)
+        self.env["download_changed"] = version_changed
+
+        # download_missing_file only decides whether to re-fetch a file that
+        # has gone missing while the remote resource is unchanged; it never changes
+        # download_changed.
+        previous_download_exists = os.path.isfile(self.env["pathname"])
+        materialize_missing = not previous_download_exists and self.env_bool(
+            "download_missing_file", default=True
+        )
+
+        if not version_changed and not materialize_missing:
+            # Unchanged: keep the cached file, or skip entirely when it is
+            # absent and download_missing_file is false.
             os.remove(pathname_temporary)
-            if self.env_bool("COMPUTE_HASHES"):
-                self.store_hashes_in_env(self.compute_hashes())
+            self.publish_existing_hashes()
+            if previous_download_exists:
+                self.output(f"Using existing {self.env['pathname']}")
             return
 
-        # New resource was downloaded. Move the temporary download file to the pathname
+        # Either the remote changed, or the file was missing and we have been
+        # told to re-fetch it. Either way, keep the freshly downloaded bytes.
         self.move_temp_file(pathname_temporary)
 
         # Save .info.json metadata and legacy last-modified/etag xattrs.
         self.store_metadata(header)
 
         # Generate output messages and variables
-        self.output(f"Downloaded {self.env['pathname']}")
-        self.env["url_downloader_summary_result"] = {
-            "summary_text": "The following new items were downloaded:",
-            "data": {"download_path": self.env["pathname"]},
-        }
+        if version_changed:
+            self.output(f"Downloaded {self.env['pathname']}")
+            self.env["url_downloader_summary_result"] = {
+                "summary_text": "The following new items were downloaded:",
+                "data": {"download_path": self.env["pathname"]},
+            }
+        else:
+            self.output(
+                "Re-downloaded missing file (version unchanged): "
+                f"{self.env['pathname']}"
+            )
 
 
 if __name__ == "__main__":

--- a/Code/autopkglib/URLDownloader.py
+++ b/Code/autopkglib/URLDownloader.py
@@ -166,9 +166,16 @@ class URLDownloader(URLGetter):
         if isinstance(value, bool):
             return value
         if isinstance(value, str):
-            return value.strip().lower() == "true"
+            normalised = value.strip().lower()
+            if normalised in ("true", "yes", "on", "1"):
+                return True
+            if normalised in ("false", "no", "off", "0", ""):
+                return False
 
-        raise ProcessorError(f"{key} must be a boolean, 'true', 'false', or null")
+        raise ProcessorError(
+            f"{key} must be a boolean or boolean-like string "
+            f"(true/false, yes/no, on/off, 1/0), not {value!r}"
+        )
 
     def prepare_base_curl_cmd(self) -> list[str]:
         """Assemble base curl command and return it."""

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -16,7 +16,6 @@
 
 """See docstring for URLDownloaderPython class"""
 
-import json
 import os
 import ssl
 from hashlib import md5, sha1, sha256
@@ -37,244 +36,16 @@ class URLDownloaderPython(URLDownloader):
 
     description = __doc__
     lifecycle = {"introduced": "2.4.1"}
-    input_variables = {
-        "url": {"required": True, "description": "The URL to download."},
-        "request_headers": {
-            "required": False,
-            "description": (
-                "Optional dictionary of headers to include with the download request. "
-                "Keys are header names and values are header values."
-            ),
-        },
-        "download_dir": {
-            "required": False,
-            "description": (
-                "The directory where the file will be downloaded to. Defaults "
-                "to RECIPE_CACHE_DIR/downloads."
-            ),
-        },
-        "filename": {
-            "required": False,
-            "description": "Filename to override the URL's tail.",
-        },
-        "prefetch_filename": {
-            "required": False,
-            "description": (
-                "If True, URLDownloader attempts to determine filename from HTTP "
-                "headers downloaded before the file itself. 'prefetch_filename' "
-                "overrides 'filename' option. Filename is determined from the first "
-                "available source of information in this order:\n"
-                "\t1. Content-Disposition header\n"
-                "\t2. Location header\n"
-                "\t3. 'filename' option (if set)\n"
-                "\t4. last part of 'url'.  \n"
-                "'prefetch_filename' is useful for URLs with redirects."
-            ),
-            "default": False,
-        },
-        "CHECK_FILESIZE_ONLY": {
-            "required": False,
-            "description": (
-                "If True, a server's ETag and Last-Modified "
-                "headers will not be checked to verify whether "
-                "a download is newer than a cached item, and only "
-                "Content-Length (filesize) will be used. This "
-                "is useful for cases where a download always "
-                "redirects to different mirrors, which could "
-                "cause items to be needlessly re-downloaded. "
-                "Defaults to False."
-            ),
-            "default": False,
-        },
-        "PKG": {
-            "required": False,
-            "description": (
-                "Local path to the pkg/dmg we'd otherwise download. "
-                "If provided, the download is skipped and we just use "
-                "this package or disk image."
-            ),
-        },
-        "COMPUTE_HASHES": {
-            "required": False,
-            "description": (
-                "Determine whether to compute md5, sha1, and sha256 hashes of "
-                "the downloaded file."
-            ),
-            "default": False,
-        },
-        "HEADERS_TO_TEST": {
-            "required": False,
-            "description": (
-                "List of HTTP headers to compare against the previous download "
-                "to detect changes. If 'CHECK_FILESIZE_ONLY' is enabled, this "
-                "list is overridden to ['Content-Length'] only."
-            ),
-            "default": ["ETag", "Last-Modified", "Content-Length"],
-        },
-        "download_missing_file": {
-            "required": False,
-            "description": (
-                "If the file is missing but matching metadata is present, "
-                "download the file again. Defaults to True as most current "
-                "recipes expect the files to be present. This re-fetch does "
-                "not mark the item as changed (download_changed stays false); "
-                "download_changed reflects the remote resource only."
-            ),
-            "default": True,
-        },
+    input_variables = URLDownloader.input_variables.copy()
+    input_variables.pop("curl_opts")
+    input_variables["request_headers"] = {
+        "required": False,
+        "description": (
+            "Optional dictionary of headers to include with the download request. "
+            "Keys are header names and values are header values."
+        ),
     }
-    output_variables = {
-        "pathname": {"description": "Path to the downloaded file."},
-        "last_modified": {
-            "description": "last-modified header for the downloaded item."
-        },
-        "etag": {"description": "etag header for the downloaded item."},
-        "download_url": {
-            "description": "The final URL the file was downloaded from (after redirects)."
-        },
-        "download_changed": {
-            "description": (
-                "Boolean indicating if the download has changed since the "
-                "last time it was downloaded."
-            )
-        },
-        "download_info": {"description": "Info from previous or current download."},
-        "file_sha1": {"description": "SHA-1 hash of the downloaded file."},
-        "file_sha256": {"description": "SHA-256 hash of the downloaded file."},
-        "file_md5": {"description": "MD5 hash of the downloaded file."},
-        "url_downloader_summary_result": {
-            "description": "Description of interesting results."
-        },
-    }
-
-    def download_changed(self, header) -> bool:
-        """Check if downloaded file changed on server."""
-
-        self.output(f"HTTP Headers: \n{header}", 2)
-
-        # get the list of headers to check
-        headers_to_test = (
-            self.env.get("HEADERS_TO_TEST")
-            or self.input_variables["HEADERS_TO_TEST"]["default"]
-        )
-
-        self.output(
-            "headers_to_test: {headers_to_test}".format(
-                headers_to_test=headers_to_test
-            ),
-            2,
-        )
-
-        # get previous info to compare
-        previous_download_info = self.get_download_info_json()
-
-        if previous_download_info:
-            self.env["download_info"] = previous_download_info
-
-            previous_http_headers = previous_download_info.get("http_headers", {})
-            if "Last-Modified" in previous_http_headers:
-                self.env["last_modified"] = previous_http_headers["Last-Modified"]
-            if "ETag" in previous_http_headers:
-                self.env["etag"] = previous_http_headers["ETag"]
-            if "download_url" in previous_download_info:
-                self.env["download_url"] = previous_download_info["download_url"]
-
-        self.output(
-            "previous_download_info: \n{previous_download_info}\n".format(
-                previous_download_info=previous_download_info
-            ),
-            2,
-        )
-
-        header_matches = 0
-
-        # Whether the cached file is on disk. Used only to prefer the real
-        # file size over the stored Content-Length; it does not affect the
-        # remote resource decision (that is a pure remote-vs-.info.json comparison).
-        previous_download_path = self.env.get("pathname", None)
-        previous_download_exists = bool(
-            previous_download_path and os.path.isfile(previous_download_path)
-        )
-
-        previous_http_headers = {}
-        if previous_download_info:
-            previous_http_headers = previous_download_info.get("http_headers", {})
-
-        try:
-            # check Content-Length:
-            if "Content-Length" in headers_to_test:
-                previous_file_size = (
-                    os.path.getsize(previous_download_path)
-                    if previous_download_exists
-                    else int(previous_http_headers["Content-Length"])
-                )
-                if previous_file_size != int(header.get("Content-Length")):
-                    self.output("Content-Length is different", 2)
-                    return True
-                header_matches += 1
-        except (KeyError, TypeError, ValueError) as err:
-            self.output(
-                "WARNING: 'Content-Length' missing. ({err_type}) {err}".format(
-                    err=err, err_type=type(err).__name__
-                ),
-                1,
-            )
-
-        # check other headers:
-        for test in headers_to_test:
-            if test != "Content-Length":
-                try:
-                    previous_header = previous_http_headers[test]
-                    current_header = header.get(test)
-                    if current_header is None and previous_header in ("", None):
-                        continue
-                    if previous_header != current_header:
-                        self.output(f"{test} is different", 2)
-                        return True
-                    else:
-                        header_matches += 1
-                except (KeyError, TypeError, ValueError) as err:
-                    self.output(
-                        "WARNING: header missing. ({err_type}) {err}".format(
-                            err=err, err_type=type(err).__name__
-                        ),
-                        1,
-                    )
-
-        # if no header checks work without throwing exceptions:
-        if header_matches == 0:
-            return True
-        # if all above pass, then return False:
-        return False
-
-    def store_download_info_json(self, download_dictionary) -> None:
-        """If file is downloaded, store info"""
-        pathname = self.env.get("pathname")
-        pathname_info_json = pathname + ".info.json"
-        # https://stackoverflow.com/questions/16267767/python-writing-json-to-file
-        with open(pathname_info_json, "w", encoding="utf-8") as outfile:
-            json.dump(download_dictionary, outfile, indent=4)
-            # add newline at end of file:
-            outfile.write("\n")
-
-    def get_download_info_json(self) -> dict | None:
-        """get info from previous download"""
-        pathname = self.env.get("pathname")
-        pathname_info_json = pathname + ".info.json"
-
-        try:
-            with open(pathname_info_json, encoding="utf-8") as infile:
-                info_json = json.load(infile)
-        except FileNotFoundError as err:
-            self.output(
-                "WARNING: missing download info ({err_type})\n{err}\n".format(
-                    err=err, err_type=type(err).__name__
-                ),
-                1,
-            )
-            return None
-
-        return info_json
+    output_variables = URLDownloader.output_variables.copy()
 
     def ssl_context_certifi(self) -> ssl.SSLContext:
         """SSL context using certifi CAs or custom CAs if the env SSL_CERT_FILE is set"""
@@ -399,26 +170,16 @@ class URLDownloaderPython(URLDownloader):
         download_dictionary["download_url"] = download_url
         self.env["download_url"] = download_url
         # download_dictionary['http_headers'] = response.info()
-        download_dictionary["http_headers"] = {}
-        try:
-            content_length = int(response.headers.get("Content-Length", size))
-        except (TypeError, ValueError) as err:
-            self.output(
-                "WARNING: invalid Content-Length header ({err_type})\n{err}\n".format(
-                    err=err, err_type=type(err).__name__
-                ),
-                1,
-            )
-            content_length = size
-        download_dictionary["http_headers"]["Content-Length"] = content_length
-        download_dictionary["http_headers"]["ETag"] = response.headers.get("ETag") or ""
-        download_dictionary["http_headers"]["Last-Modified"] = (
-            response.headers.get("Last-Modified") or ""
+        download_dictionary["http_headers"] = self.download_headers(
+            response.headers, size
         )
         self.env["etag"] = download_dictionary["http_headers"]["ETag"]
         self.env["last_modified"] = download_dictionary["http_headers"]["Last-Modified"]
-        if download_dictionary["http_headers"]["Content-Length"] != size:
-            # should this be a halting error?
+        try:
+            content_length = int(response.headers.get("Content-Length", size))
+        except (TypeError, ValueError):
+            content_length = size
+        if content_length != size:
             self.output("WARNING: file size != content-length header")
 
         # We streamed a fresh copy (the remote resource changed, or the file was
@@ -459,10 +220,6 @@ class URLDownloaderPython(URLDownloader):
         # clear empty file from previous run
         self.clear_zero_file(self.env["pathname"])
 
-        # change headers to test if CHECK_FILESIZE_ONLY
-        if self.env_bool("CHECK_FILESIZE_ONLY"):
-            self.env["HEADERS_TO_TEST"] = ["Content-Length"]
-
         pathname_temporary = self.create_temp_file(download_dir)
 
         # download file
@@ -478,19 +235,11 @@ class URLDownloaderPython(URLDownloader):
         # clear temp file if 0 size
         self.clear_zero_file(pathname_temporary)
 
-        if self.env.get("download_changed", None):
-            if download_dictionary is None:
-                raise ProcessorError("Download did not produce metadata.")
-
-            # store download info for checking for existing download
-            self.store_download_info_json(download_dictionary)
-
-            # Generate output messages and variables
-            self.output(f"Downloaded {self.env['pathname']}")
-            self.env["url_downloader_summary_result"] = {
-                "summary_text": "The following new items were downloaded:",
-                "data": {"download_path": self.env["pathname"]},
-            }
+        if self.env["download_changed"] and download_dictionary is None:
+            raise ProcessorError("Download did not produce metadata.")
+        if download_dictionary is not None:
+            self.write_metadata(download_dictionary)
+            self.report_download(self.env["download_changed"])
 
         self.output(f"self.env: \n{self.env}\n", 4)
 

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -24,7 +24,6 @@ from typing import Any
 from urllib.request import Request, urlopen
 
 import certifi
-
 from autopkglib import ProcessorError
 from autopkglib.URLDownloader import URLDownloader
 
@@ -300,7 +299,7 @@ class URLDownloaderPython(URLDownloader):
         download_dictionary: dict[str, Any] = {}
 
         hashes = None
-        if self.env.get("COMPUTE_HASHES", None):
+        if self.env_bool("COMPUTE_HASHES"):
             hashes = (
                 sha1(usedforsecurity=False),
                 sha256(usedforsecurity=False),
@@ -332,7 +331,9 @@ class URLDownloaderPython(URLDownloader):
         request_obj = Request(url, headers=normalised_headers)
 
         # get http headers
-        response = urlopen(request_obj, context=self.ssl_context_certifi())  # nosec B310 - file:// is a supported url scheme
+        response = urlopen(
+            request_obj, context=self.ssl_context_certifi()
+        )  # nosec B310 - file:// is a supported url scheme
         response_headers = response.info()
 
         self.env["download_changed"] = self.download_changed(response_headers)
@@ -446,7 +447,7 @@ class URLDownloaderPython(URLDownloader):
         self.clear_zero_file(self.env["pathname"])
 
         # change headers to test if CHECK_FILESIZE_ONLY
-        if self.env.get("CHECK_FILESIZE_ONLY", None):
+        if self.env_bool("CHECK_FILESIZE_ONLY"):
             self.env["HEADERS_TO_TEST"] = ["Content-Length"]
 
         pathname_temporary = self.create_temp_file(download_dir)

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -24,6 +24,7 @@ from typing import Any
 from urllib.request import Request, urlopen
 
 import certifi
+
 from autopkglib import ProcessorError
 from autopkglib.URLDownloader import URLDownloader
 
@@ -115,7 +116,10 @@ class URLDownloaderPython(URLDownloader):
             "required": False,
             "description": (
                 "If the file is missing but matching metadata is present, "
-                "download the file again. Defaults to True as most current recipes expect the files to be present."
+                "download the file again. Defaults to True as most current "
+                "recipes expect the files to be present. This re-fetch does "
+                "not mark the item as changed (download_changed stays false); "
+                "download_changed reflects the remote resource only."
             ),
             "default": True,
         },
@@ -185,15 +189,13 @@ class URLDownloaderPython(URLDownloader):
 
         header_matches = 0
 
-        # check that previous download exists:
+        # Whether the cached file is on disk. Used only to prefer the real
+        # file size over the stored Content-Length; it does not affect the
+        # remote resource decision (that is a pure remote-vs-.info.json comparison).
         previous_download_path = self.env.get("pathname", None)
         previous_download_exists = bool(
             previous_download_path and os.path.isfile(previous_download_path)
         )
-        download_missing_file = self.env_bool("download_missing_file", default=True)
-        if not previous_download_exists and download_missing_file:
-            # previous download doesn't exist!
-            return True
 
         previous_http_headers = {}
         if previous_download_info:
@@ -331,18 +333,28 @@ class URLDownloaderPython(URLDownloader):
         request_obj = Request(url, headers=normalised_headers)
 
         # get http headers
-        response = urlopen(
-            request_obj, context=self.ssl_context_certifi()
-        )  # nosec B310 - file:// is a supported url scheme
+        response = urlopen(request_obj, context=self.ssl_context_certifi())  # nosec B310 - file:// is a supported url scheme
         response_headers = response.info()
 
-        self.env["download_changed"] = self.download_changed(response_headers)
-        # check if download changed from last run:
-        if not self.env.get("download_changed", None):
-            # Discard the temp file
+        version_changed = self.download_changed(response_headers)
+        self.env["download_changed"] = version_changed
+
+        # download_missing_file only decides whether to re-fetch a file that
+        # has gone missing while the remote resource is unchanged; it never changes
+        # download_changed.
+        previous_download_path = self.env.get("pathname")
+        previous_download_exists = bool(
+            previous_download_path and os.path.isfile(previous_download_path)
+        )
+        materialize_missing = not previous_download_exists and self.env_bool(
+            "download_missing_file", default=True
+        )
+
+        # Unchanged and either the cached file is present or we've been told
+        # not to re-fetch it: don't read the body, just reuse existing hashes.
+        if not version_changed and not materialize_missing:
             os.remove(file_save_path)
-            if hashes:
-                self.store_hashes_in_env(self.compute_hashes())
+            self.publish_existing_hashes()
             return None
 
         # download file
@@ -408,9 +420,9 @@ class URLDownloaderPython(URLDownloader):
             # should this be a halting error?
             self.output("WARNING: file size != content-length header")
 
-        if self.env.get("download_changed", None):
-            # Move the new temporary download file to the pathname
-            self.move_temp_file(file_save_path)
+        # We streamed a fresh copy (the remote resource changed, or the file was
+        # missing and download_missing_file is set), so move it into place.
+        self.move_temp_file(file_save_path)
 
         # Save last-modified and etag headers to files xattr
         # This is for backwards compatibility with URLDownloader

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -24,6 +24,7 @@ from typing import Any
 from urllib.request import Request, urlopen
 
 import certifi
+
 from autopkglib import ProcessorError
 from autopkglib.URLDownloader import URLDownloader
 
@@ -111,6 +112,14 @@ class URLDownloaderPython(URLDownloader):
             ),
             "default": ["ETag", "Last-Modified", "Content-Length"],
         },
+        "download_missing_file": {
+            "required": False,
+            "description": (
+                "If the file is missing but matching metadata is present, "
+                "download the file again. Defaults to True as most current recipes expect the files to be present."
+            ),
+            "default": True,
+        },
     }
     output_variables = {
         "pathname": {"description": "Path to the downloaded file."},
@@ -118,12 +127,16 @@ class URLDownloaderPython(URLDownloader):
             "description": "last-modified header for the downloaded item."
         },
         "etag": {"description": "etag header for the downloaded item."},
+        "download_url": {
+            "description": "The final URL the file was downloaded from (after redirects)."
+        },
         "download_changed": {
             "description": (
                 "Boolean indicating if the download has changed since the "
                 "last time it was downloaded."
             )
         },
+        "download_info": {"description": "Info from previous or current download."},
         "file_sha1": {"description": "SHA-1 hash of the downloaded file."},
         "file_sha256": {"description": "SHA-256 hash of the downloaded file."},
         "file_md5": {"description": "MD5 hash of the downloaded file."},
@@ -153,6 +166,17 @@ class URLDownloaderPython(URLDownloader):
         # get previous info to compare
         previous_download_info = self.get_download_info_json()
 
+        if previous_download_info:
+            self.env["download_info"] = previous_download_info
+
+            previous_http_headers = previous_download_info.get("http_headers", {})
+            if "Last-Modified" in previous_http_headers:
+                self.env["last_modified"] = previous_http_headers["Last-Modified"]
+            if "ETag" in previous_http_headers:
+                self.env["etag"] = previous_http_headers["ETag"]
+            if "download_url" in previous_download_info:
+                self.env["download_url"] = previous_download_info["download_url"]
+
         self.output(
             "previous_download_info: \n{previous_download_info}\n".format(
                 previous_download_info=previous_download_info
@@ -162,9 +186,13 @@ class URLDownloaderPython(URLDownloader):
 
         header_matches = 0
 
-        # check that previous download exits:
+        # check that previous download exists:
         previous_download_path = self.env.get("pathname", None)
-        if not previous_download_path or not os.path.isfile(previous_download_path):
+        previous_download_exists = bool(
+            previous_download_path and os.path.isfile(previous_download_path)
+        )
+        download_missing_file = self.env_bool("download_missing_file", default=True)
+        if not previous_download_exists and download_missing_file:
             # previous download doesn't exist!
             return True
 
@@ -175,7 +203,11 @@ class URLDownloaderPython(URLDownloader):
         try:
             # check Content-Length:
             if "Content-Length" in headers_to_test:
-                previous_file_size = os.path.getsize(previous_download_path)
+                previous_file_size = (
+                    os.path.getsize(previous_download_path)
+                    if previous_download_exists
+                    else int(previous_http_headers["Content-Length"])
+                )
                 if previous_file_size != int(header.get("Content-Length")):
                     self.output("Content-Length is different", 2)
                     return True
@@ -300,9 +332,7 @@ class URLDownloaderPython(URLDownloader):
         request_obj = Request(url, headers=normalised_headers)
 
         # get http headers
-        response = urlopen(
-            request_obj, context=self.ssl_context_certifi()
-        )  # nosec B310 - file:// is a supported url scheme
+        response = urlopen(request_obj, context=self.ssl_context_certifi())  # nosec B310 - file:// is a supported url scheme
         response_headers = response.info()
 
         self.env["download_changed"] = self.download_changed(response_headers)
@@ -351,7 +381,9 @@ class URLDownloaderPython(URLDownloader):
             download_dictionary["file_sha1"] = self.env["file_sha1"]
             download_dictionary["file_sha256"] = self.env["file_sha256"]
             download_dictionary["file_md5"] = self.env["file_md5"]
-        download_dictionary["download_url"] = url
+        download_url = response.url or url
+        download_dictionary["download_url"] = download_url
+        self.env["download_url"] = download_url
         # download_dictionary['http_headers'] = response.info()
         download_dictionary["http_headers"] = {}
         try:

--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -24,7 +24,6 @@ from typing import Any
 from urllib.request import Request, urlopen
 
 import certifi
-
 from autopkglib import ProcessorError
 from autopkglib.URLDownloader import URLDownloader
 
@@ -333,7 +332,9 @@ class URLDownloaderPython(URLDownloader):
         request_obj = Request(url, headers=normalised_headers)
 
         # get http headers
-        response = urlopen(request_obj, context=self.ssl_context_certifi())  # nosec B310 - file:// is a supported url scheme
+        response = urlopen(
+            request_obj, context=self.ssl_context_certifi()
+        )  # nosec B310 - file:// is a supported url scheme
         response_headers = response.info()
 
         version_changed = self.download_changed(response_headers)

--- a/Code/tests/test_urldownloader.py
+++ b/Code/tests/test_urldownloader.py
@@ -356,8 +356,10 @@ class TestURLDownloader(unittest.TestCase):
             self.processor.env["download_url"], "https://cdn.example.com/testfile.dmg"
         )
 
-    def test_download_changed_downloads_missing_file_by_default(self):
-        """Matching metadata does not suppress a download when the file is missing."""
+    def test_download_changed_is_version_only_ignores_missing_file(self):
+        """download_changed compares versions only. A missing file whose stored
+        metadata matches the remote is NOT 'changed', regardless of
+        download_missing_file (that only affects materialising in main())."""
         test_file = os.path.join(self.temp_dir, "missing.dmg")
         with open(test_file + ".info.json", "w", encoding="utf-8") as f:
             json.dump({"http_headers": {"Content-Length": 10}}, f)
@@ -366,28 +368,13 @@ class TestURLDownloader(unittest.TestCase):
         self.processor.env["HEADERS_TO_TEST"] = ["Content-Length"]
         self.processor.clear_vars()
 
-        changed = self.processor.download_changed(
-            {"http_result_code": "200", "content-length": "10"}
-        )
-
-        self.assertTrue(changed)
-
-    def test_download_changed_allows_metadata_only_cache_hit(self):
-        """download_missing_file=False permits a metadata-only unchanged result."""
-        test_file = os.path.join(self.temp_dir, "missing.dmg")
-        with open(test_file + ".info.json", "w", encoding="utf-8") as f:
-            json.dump({"http_headers": {"Content-Length": 10}}, f)
-
-        self.processor.env["pathname"] = test_file
-        self.processor.env["download_missing_file"] = "false"
-        self.processor.env["HEADERS_TO_TEST"] = ["Content-Length"]
-        self.processor.clear_vars()
-
-        changed = self.processor.download_changed(
-            {"http_result_code": "200", "content-length": "10"}
-        )
-
-        self.assertFalse(changed)
+        response = {"http_result_code": "200", "content-length": "10"}
+        for dmf in ("true", "false"):
+            self.processor.env["download_missing_file"] = dmf
+            self.assertFalse(
+                self.processor.download_changed(response),
+                f"download_missing_file={dmf} must not affect the version check",
+            )
 
     @unittest.skipUnless(
         sys.platform in ("darwin", "linux"), "xattr not reliable on Windows"
@@ -711,6 +698,83 @@ class TestURLDownloader(unittest.TestCase):
         self.assertEqual(
             self.processor.env["file_md5"], md5(cached_content).hexdigest()
         )
+
+    def _run_main_with_mocked_curl(self, content_length):
+        """Run main() with curl mocked to return a 200 of the given size."""
+        with (
+            patch.object(URLDownloader, "download_with_curl") as mock_download,
+            patch.object(URLDownloader, "parse_headers") as mock_parse_headers,
+        ):
+            mock_download.return_value = ""
+            mock_parse_headers.return_value = {
+                "http_result_code": "200",
+                "http_result_description": "OK",
+                "content-length": str(content_length),
+            }
+            self.processor.main()
+
+    def test_main_materializes_missing_file_without_marking_changed(self):
+        """Missing file + unchanged version + download_missing_file default:
+        re-fetch the file but keep download_changed False (version is the
+        signal, not file presence)."""
+        download_dir = os.path.join(self.temp_dir, "downloads")
+        os.makedirs(download_dir, exist_ok=True)
+        pathname = os.path.join(download_dir, "file.dmg")
+        # .info.json present, cached file absent.
+        with open(pathname + ".info.json", "w", encoding="utf-8") as f:
+            json.dump({"file_size": 5, "http_headers": {"Content-Length": 5}}, f)
+
+        self.processor.env["CHECK_FILESIZE_ONLY"] = True
+        self._run_main_with_mocked_curl(5)
+
+        self.assertFalse(self.processor.env["download_changed"])
+        self.assertTrue(os.path.isfile(pathname))
+
+    def test_main_metadata_only_skip_reuses_stored_hashes(self):
+        """download_missing_file=false + missing file + unchanged + COMPUTE_HASHES:
+        no crash; hashes are reused from .info.json and the file is not fetched."""
+        download_dir = os.path.join(self.temp_dir, "downloads")
+        os.makedirs(download_dir, exist_ok=True)
+        pathname = os.path.join(download_dir, "file.dmg")
+        with open(pathname + ".info.json", "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "file_size": 5,
+                    "http_headers": {"Content-Length": 5},
+                    "file_sha1": "aaa",
+                    "file_sha256": "bbb",
+                    "file_md5": "ccc",
+                },
+                f,
+            )
+
+        self.processor.env["download_missing_file"] = "false"
+        self.processor.env["COMPUTE_HASHES"] = True
+        self.processor.env["CHECK_FILESIZE_ONLY"] = True
+        self._run_main_with_mocked_curl(5)
+
+        self.assertFalse(self.processor.env["download_changed"])
+        self.assertFalse(os.path.isfile(pathname))
+        self.assertEqual(self.processor.env["file_sha1"], "aaa")
+        self.assertEqual(self.processor.env["file_sha256"], "bbb")
+        self.assertEqual(self.processor.env["file_md5"], "ccc")
+
+    def test_main_metadata_only_skip_without_stored_hashes_does_not_crash(self):
+        """Same as above but .info.json has no stored hashes: still no crash,
+        hashes are simply skipped."""
+        download_dir = os.path.join(self.temp_dir, "downloads")
+        os.makedirs(download_dir, exist_ok=True)
+        pathname = os.path.join(download_dir, "file.dmg")
+        with open(pathname + ".info.json", "w", encoding="utf-8") as f:
+            json.dump({"file_size": 5, "http_headers": {"Content-Length": 5}}, f)
+
+        self.processor.env["download_missing_file"] = "false"
+        self.processor.env["COMPUTE_HASHES"] = True
+        self.processor.env["CHECK_FILESIZE_ONLY"] = True
+        self._run_main_with_mocked_curl(5)  # must not raise
+
+        self.assertFalse(self.processor.env["download_changed"])
+        self.assertNotIn("file_sha1", self.processor.env)
 
     # Clear vars test
 

--- a/Code/tests/test_urldownloader.py
+++ b/Code/tests/test_urldownloader.py
@@ -129,6 +129,33 @@ class TestURLDownloader(unittest.TestCase):
             "Mon, 01 Jan 2024 00:00:00 GMT",
         )
 
+    def test_store_metadata_uses_redirected_download_url(self):
+        """store_metadata records the final redirected URL when curl reports one."""
+        test_file = os.path.join(self.temp_dir, "testfile.dmg")
+        with open(test_file, "wb") as f:
+            f.write(b"test file content")
+
+        self.processor.env["pathname"] = test_file
+        self.processor.env["url"] = "http://example.com/file.dmg"
+        self.processor.clear_vars()
+
+        header = {
+            "etag": '"abc123"',
+            "http_redirected": "https://cdn.example.com/file.dmg",
+            "last-modified": "Mon, 01 Jan 2024 00:00:00 GMT",
+        }
+
+        with patch.object(self.processor, "store_headers"):
+            self.processor.store_metadata(header)
+
+        with open(test_file + ".info.json", "r", encoding="utf-8") as f:
+            metadata = json.load(f)
+
+        self.assertEqual(metadata["download_url"], "https://cdn.example.com/file.dmg")
+        self.assertEqual(
+            self.processor.env["download_url"], "https://cdn.example.com/file.dmg"
+        )
+
     def test_metadata_retrieval_from_storage(self):
         """Test that metadata can be retrieved correctly from .info.json."""
         test_file = os.path.join(self.temp_dir, "testfile.dmg")
@@ -175,6 +202,24 @@ class TestURLDownloader(unittest.TestCase):
         """getxattr() must raise ProcessorError in .info.json metadata mode."""
         with self.assertRaises(ProcessorError):
             self.processor.getxattr("any.xattr.name")
+
+    def test_env_bool_accepts_strings(self):
+        """Boolean-like env strings must not be treated as truthy by default."""
+        self.processor.env["true_string"] = "true"
+        self.processor.env["false_string"] = "False"
+        self.processor.env["none_value"] = None
+
+        self.assertTrue(self.processor.env_bool("true_string"))
+        self.assertFalse(self.processor.env_bool("false_string"))
+        self.assertFalse(self.processor.env_bool("none_value", default=True))
+        self.assertTrue(self.processor.env_bool("missing", default=True))
+
+    def test_env_bool_rejects_non_boolean_values(self):
+        """Unexpected value types fail loudly instead of using Python truthiness."""
+        self.processor.env["bad_value"] = 1
+
+        with self.assertRaisesRegex(ProcessorError, "bad_value must be a boolean"):
+            self.processor.env_bool("bad_value")
 
     def test_get_metadata_returns_empty_on_corrupt_json(self):
         """get_metadata() must return {} and not raise when .info.json is corrupt."""
@@ -261,6 +306,75 @@ class TestURLDownloader(unittest.TestCase):
         self.assertEqual(headers, {})
         self.assertEqual(self.processor.existing_file_size, os.path.getsize(test_file))
         self.assertTrue(changed)
+
+    def test_download_changed_populates_cached_download_info(self):
+        """Cache-hit checks expose previous .info.json metadata in env."""
+        test_file = os.path.join(self.temp_dir, "testfile.dmg")
+        with open(test_file, "wb") as f:
+            f.write(b"test content")
+
+        metadata = {
+            "download_url": "https://cdn.example.com/testfile.dmg",
+            "file_size": 12,
+            "http_headers": {
+                "Content-Length": 12,
+                "ETag": '"cached"',
+                "Last-Modified": "Tue, 02 Jan 2024 00:00:00 GMT",
+            },
+        }
+        with open(test_file + ".info.json", "w", encoding="utf-8") as f:
+            json.dump(metadata, f)
+
+        self.processor.env["pathname"] = test_file
+        self.processor.env["HEADERS_TO_TEST"] = ["ETag"]
+        self.processor.clear_vars()
+
+        changed = self.processor.download_changed(
+            {"http_result_code": "200", "etag": '"cached"'}
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(self.processor.env["download_info"], metadata)
+        self.assertEqual(self.processor.env["etag"], '"cached"')
+        self.assertEqual(
+            self.processor.env["last_modified"], "Tue, 02 Jan 2024 00:00:00 GMT"
+        )
+        self.assertEqual(
+            self.processor.env["download_url"], "https://cdn.example.com/testfile.dmg"
+        )
+
+    def test_download_changed_downloads_missing_file_by_default(self):
+        """Matching metadata does not suppress a download when the file is missing."""
+        test_file = os.path.join(self.temp_dir, "missing.dmg")
+        with open(test_file + ".info.json", "w", encoding="utf-8") as f:
+            json.dump({"http_headers": {"Content-Length": 10}}, f)
+
+        self.processor.env["pathname"] = test_file
+        self.processor.env["HEADERS_TO_TEST"] = ["Content-Length"]
+        self.processor.clear_vars()
+
+        changed = self.processor.download_changed(
+            {"http_result_code": "200", "content-length": "10"}
+        )
+
+        self.assertTrue(changed)
+
+    def test_download_changed_allows_metadata_only_cache_hit(self):
+        """download_missing_file=False permits a metadata-only unchanged result."""
+        test_file = os.path.join(self.temp_dir, "missing.dmg")
+        with open(test_file + ".info.json", "w", encoding="utf-8") as f:
+            json.dump({"http_headers": {"Content-Length": 10}}, f)
+
+        self.processor.env["pathname"] = test_file
+        self.processor.env["download_missing_file"] = "false"
+        self.processor.env["HEADERS_TO_TEST"] = ["Content-Length"]
+        self.processor.clear_vars()
+
+        changed = self.processor.download_changed(
+            {"http_result_code": "200", "content-length": "10"}
+        )
+
+        self.assertFalse(changed)
 
     @unittest.skipUnless(
         sys.platform in ("darwin", "linux"), "xattr not reliable on Windows"

--- a/Code/tests/test_urldownloader.py
+++ b/Code/tests/test_urldownloader.py
@@ -204,15 +204,28 @@ class TestURLDownloader(unittest.TestCase):
             self.processor.getxattr("any.xattr.name")
 
     def test_env_bool_accepts_strings(self):
-        """Boolean-like env strings must not be treated as truthy by default."""
-        self.processor.env["true_string"] = "true"
-        self.processor.env["false_string"] = "False"
-        self.processor.env["none_value"] = None
+        """Boolean-like env strings are parsed, not evaluated with truthiness."""
+        for value in ("true", "True", "TRUE", "  true  ", "yes", "on", "1"):
+            self.processor.env["flag"] = value
+            self.assertTrue(
+                self.processor.env_bool("flag"), f"{value!r} should be True"
+            )
+        for value in ("false", "False", "no", "off", "0", ""):
+            self.processor.env["flag"] = value
+            self.assertFalse(
+                self.processor.env_bool("flag"), f"{value!r} should be False"
+            )
 
-        self.assertTrue(self.processor.env_bool("true_string"))
-        self.assertFalse(self.processor.env_bool("false_string"))
+        self.processor.env["none_value"] = None
         self.assertFalse(self.processor.env_bool("none_value", default=True))
         self.assertTrue(self.processor.env_bool("missing", default=True))
+
+    def test_env_bool_rejects_unknown_strings(self):
+        """Unrecognised strings fail loudly rather than silently defaulting."""
+        self.processor.env["bad_value"] = "ture"
+
+        with self.assertRaisesRegex(ProcessorError, "bad_value must be a boolean"):
+            self.processor.env_bool("bad_value")
 
     def test_env_bool_rejects_non_boolean_values(self):
         """Unexpected value types fail loudly instead of using Python truthiness."""

--- a/Code/tests/test_urldownloader.py
+++ b/Code/tests/test_urldownloader.py
@@ -123,6 +123,7 @@ class TestURLDownloader(unittest.TestCase):
 
         self.assertEqual(metadata["download_url"], "http://example.com/file.dmg")
         self.assertEqual(metadata["file_size"], len(test_content))
+        self.assertEqual(self.processor.env["download_info"], metadata)
         self.assertEqual(metadata["http_headers"]["ETag"], '"abc123"')
         self.assertEqual(
             metadata["http_headers"]["Last-Modified"],
@@ -138,6 +139,7 @@ class TestURLDownloader(unittest.TestCase):
         self.processor.env["pathname"] = test_file
         self.processor.env["url"] = "http://example.com/file.dmg"
         self.processor.clear_vars()
+        self.processor.env["download_url"] = "https://old.example.com/file.dmg"
 
         header = {
             "etag": '"abc123"',
@@ -155,6 +157,60 @@ class TestURLDownloader(unittest.TestCase):
         self.assertEqual(
             self.processor.env["download_url"], "https://cdn.example.com/file.dmg"
         )
+
+    def test_store_metadata_replaces_stale_redirect_with_current_url(self):
+        test_file = os.path.join(self.temp_dir, "testfile.dmg")
+        with open(test_file, "wb") as outfile:
+            outfile.write(b"test file content")
+        self.processor.env.update(
+            {
+                "download_url": "https://old.example.com/file.dmg",
+                "pathname": test_file,
+            }
+        )
+
+        with patch.object(self.processor, "store_headers"):
+            self.processor.store_metadata({})
+
+        with open(test_file + ".info.json", encoding="utf-8") as infile:
+            metadata = json.load(infile)
+        self.assertEqual(metadata["download_url"], self.processor.env["url"])
+
+    def test_download_changed_invalid_content_length_returns_changed(self):
+        test_file = os.path.join(self.temp_dir, "testfile.dmg")
+        with open(test_file, "wb") as outfile:
+            outfile.write(b"test data")
+        with open(test_file + ".info.json", "w", encoding="utf-8") as outfile:
+            json.dump({"http_headers": {}}, outfile)
+        self.processor.env["pathname"] = test_file
+
+        with patch.object(self.processor, "output") as mock_output:
+            changed = self.processor.download_changed(
+                {"http_result_code": "200", "content-length": "invalid"}
+            )
+
+        self.assertTrue(changed)
+        self.assertTrue(
+            any(
+                "Content-Length' invalid" in call.args[0]
+                for call in mock_output.call_args_list
+            )
+        )
+
+    def test_store_metadata_preserves_custom_headers(self):
+        test_file = os.path.join(self.temp_dir, "testfile.dmg")
+        with open(test_file, "wb") as outfile:
+            outfile.write(b"test file content")
+        self.processor.env.update(
+            {"HEADERS_TO_TEST": ["X-Release"], "pathname": test_file}
+        )
+
+        with patch.object(self.processor, "store_headers"):
+            self.processor.store_metadata({"x-release": "2026.08"})
+
+        with open(test_file + ".info.json", encoding="utf-8") as infile:
+            metadata = json.load(infile)
+        self.assertEqual(metadata["http_headers"]["X-Release"], "2026.08")
 
     def test_metadata_retrieval_from_storage(self):
         """Test that metadata can be retrieved correctly from .info.json."""
@@ -217,8 +273,14 @@ class TestURLDownloader(unittest.TestCase):
             )
 
         self.processor.env["none_value"] = None
-        self.assertFalse(self.processor.env_bool("none_value", default=True))
+        self.assertTrue(self.processor.env_bool("none_value", default=True))
         self.assertTrue(self.processor.env_bool("missing", default=True))
+
+    def test_env_bool_prefetch_error_mentions_filename(self):
+        self.processor.env["prefetch_filename"] = "file.dmg"
+
+        with self.assertRaisesRegex(ProcessorError, "use filename"):
+            self.processor.env_bool("prefetch_filename")
 
     def test_env_bool_rejects_unknown_strings(self):
         """Unrecognised strings fail loudly rather than silently defaulting."""
@@ -277,7 +339,6 @@ class TestURLDownloader(unittest.TestCase):
 
         self.assertEqual(headers["If-None-Match"], '"etag-value-123"')
         self.assertEqual(headers["If-Modified-Since"], "Wed, 03 Jan 2024 00:00:00 GMT")
-        self.assertIsNotNone(self.processor.existing_file_size)
 
     def test_produce_etag_headers_empty_when_no_metadata(self):
         """Test that produce_etag_headers returns empty dict when no metadata exists."""
@@ -317,7 +378,6 @@ class TestURLDownloader(unittest.TestCase):
         )
 
         self.assertEqual(headers, {})
-        self.assertEqual(self.processor.existing_file_size, os.path.getsize(test_file))
         self.assertTrue(changed)
 
     def test_download_changed_populates_cached_download_info(self):
@@ -701,9 +761,15 @@ class TestURLDownloader(unittest.TestCase):
 
     def _run_main_with_mocked_curl(self, content_length):
         """Run main() with curl mocked to return a 200 of the given size."""
+        temporary_path = os.path.join(self.temp_dir, "download.tmp")
+        with open(temporary_path, "wb") as outfile:
+            outfile.write(b"x" * content_length)
         with (
             patch.object(URLDownloader, "download_with_curl") as mock_download,
             patch.object(URLDownloader, "parse_headers") as mock_parse_headers,
+            patch.object(
+                URLDownloader, "create_temp_file", return_value=temporary_path
+            ),
         ):
             mock_download.return_value = ""
             mock_parse_headers.return_value = {
@@ -725,10 +791,28 @@ class TestURLDownloader(unittest.TestCase):
             json.dump({"file_size": 5, "http_headers": {"Content-Length": 5}}, f)
 
         self.processor.env["CHECK_FILESIZE_ONLY"] = True
-        self._run_main_with_mocked_curl(5)
+        with patch.object(self.processor, "output") as mock_output:
+            self._run_main_with_mocked_curl(5)
 
         self.assertFalse(self.processor.env["download_changed"])
         self.assertTrue(os.path.isfile(pathname))
+        with open(pathname, "rb") as infile:
+            self.assertEqual(infile.read(), b"xxxxx")
+        with open(pathname + ".info.json", encoding="utf-8") as infile:
+            self.assertEqual(json.load(infile)["file_size"], 5)
+        self.assertTrue(
+            any(
+                "Re-downloaded missing file" in call.args[0]
+                for call in mock_output.call_args_list
+            )
+        )
+        self.assertEqual(
+            self.processor.env["url_downloader_summary_result"],
+            {
+                "summary_text": "The following missing items were re-downloaded:",
+                "data": {"download_path": pathname},
+            },
+        )
 
     def test_main_metadata_only_skip_reuses_stored_hashes(self):
         """download_missing_file=false + missing file + unchanged + COMPUTE_HASHES:
@@ -789,8 +873,6 @@ class TestURLDownloader(unittest.TestCase):
 
         self.assertEqual(self.processor.env["last_modified"], "")
         self.assertEqual(self.processor.env["etag"], "")
-
-        self.assertIsNone(self.processor.existing_file_size)
 
     # Platform-specific xattr names
 

--- a/Code/tests/test_urldownloaderpython.py
+++ b/Code/tests/test_urldownloaderpython.py
@@ -164,6 +164,74 @@ class TestURLDownloaderPython(unittest.TestCase):
         with open(cached_path, "rb") as infile:
             self.assertEqual(infile.read(), cached_body)
 
+    def _write_info_json(self, extra=None):
+        """Create downloads/download.bin.info.json with matching size, no file."""
+        download_dir = os.path.join(self.temp_dir.name, "downloads")
+        os.makedirs(download_dir, exist_ok=True)
+        pathname = os.path.join(download_dir, "download.bin")
+        metadata = {"file_size": 4, "http_headers": {"Content-Length": 4}}
+        if extra:
+            metadata.update(extra)
+        with open(pathname + ".info.json", "w", encoding="utf-8") as outfile:
+            json.dump(metadata, outfile)
+        return pathname
+
+    def test_missing_file_rematerializes_without_marking_changed(self):
+        """Missing file + unchanged version + download_missing_file default:
+        re-fetch the file but keep download_changed False."""
+        pathname = self._write_info_json()
+        self.processor.env["CHECK_FILESIZE_ONLY"] = True
+
+        self.run_download(b"data", {"Content-Length": "4"})
+
+        self.assertFalse(self.processor.env["download_changed"])
+        self.assertTrue(os.path.isfile(pathname))
+        with open(pathname, "rb") as infile:
+            self.assertEqual(infile.read(), b"data")
+
+    def test_missing_file_metadata_only_skip_when_dmf_false(self):
+        """Missing file + unchanged + download_missing_file=false: skip; the
+        file stays absent and download_changed is False."""
+        pathname = self._write_info_json()
+        self.processor.env["CHECK_FILESIZE_ONLY"] = True
+        self.processor.env["download_missing_file"] = "false"
+
+        self.run_download(b"data", {"Content-Length": "4"})
+
+        self.assertFalse(self.processor.env["download_changed"])
+        self.assertFalse(os.path.isfile(pathname))
+
+    def test_missing_file_skip_reuses_stored_hashes(self):
+        """download_missing_file=false + COMPUTE_HASHES + missing file: no crash;
+        hashes come from .info.json."""
+        pathname = self._write_info_json(
+            {"file_sha1": "aaa", "file_sha256": "bbb", "file_md5": "ccc"}
+        )
+        self.processor.env["CHECK_FILESIZE_ONLY"] = True
+        self.processor.env["download_missing_file"] = "false"
+        self.processor.env["COMPUTE_HASHES"] = True
+
+        self.run_download(b"data", {"Content-Length": "4"})
+
+        self.assertFalse(self.processor.env["download_changed"])
+        self.assertFalse(os.path.isfile(pathname))
+        self.assertEqual(self.processor.env["file_sha1"], "aaa")
+        self.assertEqual(self.processor.env["file_sha256"], "bbb")
+        self.assertEqual(self.processor.env["file_md5"], "ccc")
+
+    def test_missing_file_skip_without_stored_hashes_does_not_crash(self):
+        """Same but no stored hashes: still no crash, hashes skipped."""
+        pathname = self._write_info_json()
+        self.processor.env["CHECK_FILESIZE_ONLY"] = True
+        self.processor.env["download_missing_file"] = "false"
+        self.processor.env["COMPUTE_HASHES"] = True
+
+        self.run_download(b"data", {"Content-Length": "4"})  # must not raise
+
+        self.assertFalse(self.processor.env["download_changed"])
+        self.assertFalse(os.path.isfile(pathname))
+        self.assertNotIn("file_sha1", self.processor.env)
+
     def test_missing_validator_headers_preserve_download(self):
         body = b"download without validators"
 

--- a/Code/tests/test_urldownloaderpython.py
+++ b/Code/tests/test_urldownloaderpython.py
@@ -20,6 +20,7 @@ import os
 import ssl
 import tempfile
 import unittest
+from email.message import Message
 from hashlib import md5, sha1, sha256
 from unittest.mock import patch
 
@@ -30,29 +31,17 @@ from tests import get_processor_module
 URLDOWNLOADERPYTHON_MODULE = get_processor_module("URLDownloaderPython")
 
 
-class CaseInsensitiveHeaders:
-    def __init__(self, headers):
-        self.headers = {
-            str(key).lower(): (str(key), str(value)) for key, value in headers.items()
-        }
-
-    def get(self, key, default=None):
-        return self.headers.get(str(key).lower(), (None, default))[1]
-
-    def __getitem__(self, key):
-        value = self.get(key)
-        if value is None:
-            raise KeyError(key)
-        return value
-
-    def __str__(self):
-        return str({name: value for name, value in self.headers.values()})
+def case_insensitive_headers(headers):
+    message = Message()
+    for name, value in headers.items():
+        message[name] = str(value)
+    return message
 
 
 class FakeHTTPResponse:
     def __init__(self, body, headers, url=None):
         self.body = io.BytesIO(body)
-        self.headers = CaseInsensitiveHeaders(headers)
+        self.headers = case_insensitive_headers(headers)
         self.url = url
 
     def info(self):
@@ -101,7 +90,7 @@ class TestURLDownloaderPython(unittest.TestCase):
         self.processor.env["HEADERS_TO_TEST"] = ["Content-Length"]
 
         changed = self.processor.download_changed(
-            CaseInsensitiveHeaders({"Content-Length": "100"})
+            case_insensitive_headers({"Content-Length": "100"})
         )
 
         self.assertTrue(changed)
@@ -130,6 +119,7 @@ class TestURLDownloaderPython(unittest.TestCase):
         with open(info_path, encoding="utf-8") as infile:
             metadata = json.load(infile)
         self.assertEqual(metadata["file_sha256"], sha256(body).hexdigest())
+        self.assertEqual(self.processor.env["download_info"], metadata)
 
     def test_cache_hit_populates_hash_outputs(self):
         cached_body = b"cached download content"
@@ -182,12 +172,42 @@ class TestURLDownloaderPython(unittest.TestCase):
         pathname = self._write_info_json()
         self.processor.env["CHECK_FILESIZE_ONLY"] = True
 
-        self.run_download(b"data", {"Content-Length": "4"})
+        with patch.object(self.processor, "output") as mock_output:
+            self.run_download(b"data", {"Content-Length": "4"})
 
         self.assertFalse(self.processor.env["download_changed"])
         self.assertTrue(os.path.isfile(pathname))
         with open(pathname, "rb") as infile:
             self.assertEqual(infile.read(), b"data")
+        with open(pathname + ".info.json", encoding="utf-8") as infile:
+            metadata = json.load(infile)
+        self.assertEqual(metadata["download_url"], self.processor.env["url"])
+        self.assertIn("url_downloader_summary_result", self.processor.env)
+        self.assertTrue(
+            any(
+                "Re-downloaded missing file" in call.args[0]
+                for call in mock_output.call_args_list
+            )
+        )
+
+    def test_headers_to_test_does_not_leak_from_size_only_check(self):
+        self.processor.env["CHECK_FILESIZE_ONLY"] = True
+        self.processor.env["HEADERS_TO_TEST"] = ["ETag"]
+
+        self.run_download(b"data", {"Content-Length": "4"})
+
+        self.assertEqual(self.processor.env["HEADERS_TO_TEST"], ["ETag"])
+
+    def test_custom_header_is_stored_for_next_run(self):
+        self.processor.env["HEADERS_TO_TEST"] = ["X-Release"]
+
+        self.run_download(b"data", {"Content-Length": "4", "X-Release": "2026.08"})
+
+        with open(
+            self.processor.env["pathname"] + ".info.json", encoding="utf-8"
+        ) as infile:
+            metadata = json.load(infile)
+        self.assertEqual(metadata["http_headers"]["X-Release"], "2026.08")
 
     def test_missing_file_metadata_only_skip_when_dmf_false(self):
         """Missing file + unchanged + download_missing_file=false: skip; the
@@ -247,6 +267,17 @@ class TestURLDownloaderPython(unittest.TestCase):
         self.assertEqual(metadata["http_headers"]["ETag"], "")
         self.assertEqual(metadata["http_headers"]["Last-Modified"], "")
 
+    def test_content_length_mismatch_warns(self):
+        with patch.object(self.processor, "output") as mock_output:
+            self.run_download(b"data", {"Content-Length": "5"})
+
+        self.assertTrue(
+            any(
+                "file size != content-length header" in call.args[0]
+                for call in mock_output.call_args_list
+            )
+        )
+
     def test_store_hashes_in_env_sets_env_vars(self):
         self.processor.env = {}
 
@@ -287,61 +318,13 @@ class TestURLDownloaderPython(unittest.TestCase):
             with self.assertRaisesRegex(ProcessorError, "not readable"):
                 self.processor.ssl_context_certifi()
 
-    def test_store_download_info_json_writes_valid_json(self):
-        download_info = {
-            "download_url": "https://example.com/download.bin",
-            "file_name": "download.bin",
-            "file_size": 12,
-            "http_headers": {"ETag": "test-tag"},
-        }
-        with tempfile.TemporaryDirectory() as temp_dir:
-            pathname = os.path.join(temp_dir, "download.bin")
-            self.processor.env["pathname"] = pathname
-
-            self.processor.store_download_info_json(download_info)
-
-            info_path = pathname + ".info.json"
-            self.assertTrue(os.path.exists(info_path))
-            with open(info_path, encoding="utf-8") as infile:
-                contents = infile.read()
-            self.assertIn("\n    ", contents)
-            self.assertEqual(json.loads(contents), download_info)
-
-    def test_get_download_info_json_returns_parsed_dict(self):
-        expected_info = {
-            "download_url": "https://example.com/download.bin",
-            "file_name": "download.bin",
-            "file_size": 12,
-            "http_headers": {"ETag": "test-tag"},
-        }
-        with tempfile.TemporaryDirectory() as temp_dir:
-            pathname = os.path.join(temp_dir, "download.bin")
-            with open(pathname + ".info.json", "w", encoding="utf-8") as outfile:
-                json.dump(expected_info, outfile)
-            self.processor.env["pathname"] = pathname
-
-            download_info = self.processor.get_download_info_json()
-
-        self.assertEqual(download_info, expected_info)
-
-    def test_get_download_info_json_missing_file_returns_none(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            self.processor.env["pathname"] = os.path.join(temp_dir, "download.bin")
-
-            with patch.object(self.processor, "output") as mock_output:
-                download_info = self.processor.get_download_info_json()
-
-        self.assertIsNone(download_info)
-        mock_output.assert_called_once()
-        self.assertIn("WARNING: missing download info", mock_output.call_args.args[0])
-
     def test_download_changed_returns_true_when_file_missing(self):
         self.processor.env["pathname"] = os.path.join(
             self.temp_dir.name, "missing-download.bin"
         )
 
         changed = self.processor.download_changed(
-            CaseInsensitiveHeaders({"Content-Length": "10"})
+            case_insensitive_headers({"Content-Length": "10"})
         )
 
         self.assertTrue(changed)
@@ -354,7 +337,7 @@ class TestURLDownloaderPython(unittest.TestCase):
             self.processor.env["pathname"] = pathname
 
             changed = self.processor.download_changed(
-                CaseInsensitiveHeaders({"Content-Length": "200"})
+                case_insensitive_headers({"Content-Length": "200"})
             )
 
         self.assertTrue(changed)
@@ -370,10 +353,53 @@ class TestURLDownloaderPython(unittest.TestCase):
             self.processor.env["HEADERS_TO_TEST"] = ["ETag"]
 
             changed = self.processor.download_changed(
-                CaseInsensitiveHeaders({"ETag": "response-tag"})
+                case_insensitive_headers({"ETag": "response-tag"})
             )
 
         self.assertTrue(changed)
+
+    def test_download_changed_matches_configured_header_case_insensitively(self):
+        pathname = os.path.join(self.temp_dir.name, "download.bin")
+        with open(pathname, "wb") as outfile:
+            outfile.write(b"test data")
+        with open(pathname + ".info.json", "w", encoding="utf-8") as outfile:
+            json.dump(
+                {
+                    "http_headers": {
+                        "ETag": "cached-tag",
+                        "Last-Modified": "Mon, 01 Jan 2024 00:00:00 GMT",
+                    }
+                },
+                outfile,
+            )
+        self.processor.env["pathname"] = pathname
+
+        for name, value in (
+            ("etag", "cached-tag"),
+            ("last-modified", "Mon, 01 Jan 2024 00:00:00 GMT"),
+        ):
+            with self.subTest(name=name):
+                self.processor.env["HEADERS_TO_TEST"] = [name]
+                self.assertFalse(
+                    self.processor.download_changed(
+                        case_insensitive_headers({name: value})
+                    )
+                )
+
+    def test_download_changed_falls_back_to_cached_file_size(self):
+        pathname = os.path.join(self.temp_dir.name, "download.bin")
+        with open(pathname, "wb") as outfile:
+            outfile.write(b"test data")
+        with open(pathname + ".info.json", "w", encoding="utf-8") as outfile:
+            json.dump({"http_headers": {"ETag": "", "Last-Modified": ""}}, outfile)
+        self.processor.env["pathname"] = pathname
+        self.processor.env["HEADERS_TO_TEST"] = ["ETag", "Last-Modified"]
+
+        changed = self.processor.download_changed(
+            case_insensitive_headers({"Content-Length": str(len(b"test data"))})
+        )
+
+        self.assertFalse(changed)
 
     def test_download_changed_missing_content_length_header_warns(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -384,7 +410,9 @@ class TestURLDownloaderPython(unittest.TestCase):
             self.processor.env["HEADERS_TO_TEST"] = ["Content-Length"]
 
             with patch.object(self.processor, "output") as mock_output:
-                self.processor.download_changed(CaseInsensitiveHeaders({"ETag": "tag"}))
+                self.processor.download_changed(
+                    case_insensitive_headers({"ETag": "tag"})
+                )
 
         self.assertTrue(
             any(

--- a/Code/tests/test_urldownloaderpython.py
+++ b/Code/tests/test_urldownloaderpython.py
@@ -50,9 +50,10 @@ class CaseInsensitiveHeaders:
 
 
 class FakeHTTPResponse:
-    def __init__(self, body, headers):
+    def __init__(self, body, headers, url=None):
         self.body = io.BytesIO(body)
         self.headers = CaseInsensitiveHeaders(headers)
+        self.url = url
 
     def info(self):
         return self.headers


### PR DESCRIPTION
Aligns `URLDownloader` and `URLDownloaderPython` around shared cache metadata and change detection.

New inputs/outputs:
- `HEADERS_TO_TEST` selects the response headers used for change detection. Values are persisted in `.info.json`. Defaults to ETag, Last-Modified, and Content-Length.
- `download_missing_file` defaults to true and re-downloads a missing cached file without marking the remote version as changed. Set it to false for a metadata-only cache hit.
- `download_url` reports the final URL after redirects.
- `download_info` reports metadata from the previous or current download.

Also:
- Both processors now share case-insensitive header comparison, file-size fallback, metadata persistence, and summary reporting.
- Boolean inputs accept booleans and common string forms (`true`/`false`, `yes`/`no`, `on`/`off`, `1`/`0`). Null uses the declared default; a blank string is false. Invalid `prefetch_filename` values point users to `filename`.
- Missing-file refreshes rewrite `.info.json`, publish current metadata and hashes, and report the re-download.
- `CHECK_FILESIZE_ONLY` no longer mutates `HEADERS_TO_TEST` in the shared recipe environment.
- Malformed Content-Length values warn and are treated as changed rather than crashing.

Compatibility note: stricter boolean parsing exposes recipes that previously supplied arbitrary strings to boolean flags, and correctly treats the string `False` as false. Follow-up recipe fixes are open in autopkg/NickETH-recipes#11 and autopkg/flywire-recipes#24.