### PR TITLE
Preserve URLDownloaderPython downloads when the server omits Content-Length

### DIFF
--- a/Code/autopkglib/URLDownloaderPython.py
+++ b/Code/autopkglib/URLDownloaderPython.py
@@ -334,28 +334,23 @@ class URLDownloaderPython(URLDownloader):
             download_dictionary["file_sha256"] = hashes[1].hexdigest()
             download_dictionary["file_md5"] = hashes[2].hexdigest()
         download_dictionary["download_url"] = url
-        # download_dictionary['http_headers'] = response.info()
-        try:
-            # save http header info to dict
-            download_dictionary["http_headers"] = {}
-            download_dictionary["http_headers"]["Content-Length"] = int(
-                response.headers["content-length"]
+        # Record whichever validators the server actually sent. All three are
+        # optional: Content-Length is absent on chunked responses, and a
+        # missing header must not discard a download that already succeeded.
+        download_dictionary["http_headers"] = {}
+        for header in ("Content-Length", "ETag", "Last-Modified"):
+            value = response.headers.get(header)
+            if value is None:
+                self.output(f"WARNING: '{header}' missing from response headers", 1)
+                continue
+            download_dictionary["http_headers"][header] = (
+                int(value) if header == "Content-Length" else value
             )
-            download_dictionary["http_headers"]["ETag"] = response.headers["ETag"]
-            download_dictionary["http_headers"]["Last-Modified"] = response.headers[
-                "Last-Modified"
-            ]
-            if download_dictionary["http_headers"]["Content-Length"] != size:
-                # should this be a halting error?
-                self.output("WARNING: file size != content-length header")
-        except (KeyError, TypeError) as err:
-            # probably need to handle a missing header better than this
-            self.output(
-                "ERROR: header issue ({err_type})\n{err}\n".format(
-                    err=err, err_type=type(err).__name__
-                )
-            )
-            return None
+
+        content_length = download_dictionary["http_headers"].get("Content-Length")
+        if content_length is not None and content_length != size:
+            # should this be a halting error?
+            self.output("WARNING: file size != content-length header")
 
         if self.env.get("download_changed", None):
             # Move the new temporary download file to the pathname

--- a/Code/tests/test_urldownloaderpython.py
+++ b/Code/tests/test_urldownloaderpython.py
@@ -1,0 +1,139 @@
+#!/usr/local/autopkg/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import email.message
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from autopkglib.URLDownloaderPython import URLDownloaderPython
+
+# autopkglib re-exports the class under the module's own name, so patch the
+# module object directly rather than by dotted path.
+URLDOWNLOADERPYTHON = sys.modules[URLDownloaderPython.__module__]
+
+
+def build_response(payload, headers):
+    """Return a stand-in for the object urlopen() hands back."""
+    message = email.message.Message()
+    for key, value in headers.items():
+        message[key] = value
+
+    class FakeResponse:
+        """Minimal urlopen() response exposing read() and headers."""
+
+        def __init__(self):
+            self._chunks = [payload, b""]
+
+        def read(self, _size=None):
+            return self._chunks.pop(0)
+
+        @property
+        def headers(self):
+            return message
+
+        def info(self):
+            return message
+
+    return FakeResponse()
+
+
+class TestURLDownloaderPython(unittest.TestCase):
+    """Test class for URLDownloaderPython Processor."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.payload = b"downloaded package contents"
+        self.processor = URLDownloaderPython()
+        self.processor.env = {
+            "url": "http://example.com/file.pkg",
+            "filename": "file.pkg",
+            "RECIPE_CACHE_DIR": self.temp_dir,
+            "download_dir": self.temp_dir,
+            "pathname": os.path.join(self.temp_dir, "file.pkg"),
+        }
+
+    def tearDown(self):
+        """Clean up after tests."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def download(self, headers):
+        """Run download_and_hash() against a response with the given headers."""
+        temp_file = os.path.join(self.temp_dir, "tempfile")
+        with patch.object(URLDOWNLOADERPYTHON, "urlopen") as mock_urlopen, patch.object(
+            self.processor, "download_changed", return_value=True
+        ), patch.object(self.processor, "store_headers"), patch.object(
+            self.processor, "move_temp_file"
+        ) as mock_move:
+            mock_urlopen.return_value = build_response(self.payload, headers)
+            result = self.processor.download_and_hash(temp_file)
+        return result, mock_move
+
+    def test_download_moved_into_place_with_all_headers(self):
+        """A response carrying every validator is moved into place and recorded."""
+        result, mock_move = self.download(
+            {
+                "Content-Length": str(len(self.payload)),
+                "ETag": 'W/"abc123"',
+                "Last-Modified": "Tue, 21 Jul 2026 09:11:48 GMT",
+            }
+        )
+
+        mock_move.assert_called_once()
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result["http_headers"],
+            {
+                "Content-Length": len(self.payload),
+                "ETag": 'W/"abc123"',
+                "Last-Modified": "Tue, 21 Jul 2026 09:11:48 GMT",
+            },
+        )
+
+    def test_download_moved_into_place_without_content_length(self):
+        """A chunked response has no Content-Length, but the download still lands.
+
+        Regression test: the missing header used to raise TypeError and return
+        early, abandoning a complete download in its temp file while leaving a
+        stale artefact at pathname.
+        """
+        result, mock_move = self.download(
+            {
+                "ETag": 'W/"abc123"',
+                "Last-Modified": "Tue, 21 Jul 2026 09:11:48 GMT",
+                "Transfer-Encoding": "chunked",
+            }
+        )
+
+        mock_move.assert_called_once()
+        self.assertIsNotNone(result)
+        self.assertNotIn("Content-Length", result["http_headers"])
+        self.assertEqual(result["http_headers"]["ETag"], 'W/"abc123"')
+        self.assertEqual(result["file_size"], len(self.payload))
+
+    def test_download_moved_into_place_without_any_validators(self):
+        """A response with no cache validators at all still lands the download."""
+        result, mock_move = self.download({})
+
+        mock_move.assert_called_once()
+        self.assertIsNotNone(result)
+        self.assertEqual(result["http_headers"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1065.

## What

`URLDownloaderPython.download_and_hash()` treated `Content-Length`, `ETag` and `Last-Modified` as required response headers. All three are optional, and CDNs routinely omit `Content-Length` on chunked responses, in which case `int(response.headers["content-length"])` raised `TypeError`. The handler for that returned `None` — and the early return sits *above* the `self.move_temp_file(file_save_path)` call, so a download that had already completed successfully was abandoned in its temp file.

Because `self.env["download_changed"]` was set earlier and never reset, `main()` then carried on as though the download had worked: it wrote an `info.json` containing the literal `null` and printed `Downloaded <pathname>`, while `pathname` still held the previous run's artefact. Downstream processors consumed the stale file, and the `null` info.json meant the next run could never match cached headers, so the recipe re-downloaded and re-failed every time.

This changes the header handling to best-effort: record whichever validators the server actually sent, warn about the ones it didn't, and always move the temp file into place when the download succeeded. The `file size != content-length header` warning is kept, but only when a `Content-Length` was actually supplied.

`download_changed()` already tolerates missing headers — it skips any that raise `KeyError`/`TypeError` and falls back to `return True` when nothing could be compared — so a partial `http_headers` dict degrades gracefully to "always re-download" rather than breaking caching.

## Test plan

Added `Code/tests/test_urldownloaderpython.py` with three cases covering a response with all validators, one without `Content-Length` (chunked), and one with no validators at all. Each asserts the download is moved into place and the recorded headers match what the server sent. The two new-behaviour cases fail against the unpatched processor with `Expected 'move_temp_file' to have been called once. Called 0 times.`

- `python -m unittest discover -s tests -p "test_*.py"` → 742 tests pass
- `black`, `isort`, `flake8` clean on both changed files

Verified end-to-end against a live chunked host (Synaptics behind Cloudflare, `transfer-encoding: chunked`, no `content-length`), with a stand-in for a previously downloaded version already at `pathname`.

Before:

```
URLDownloaderPython: ERROR: header issue (TypeError)
URLDownloaderPython: Downloaded .../downloads/ChunkedRepro.pkg

      29  ChunkedRepro.pkg             <- the stand-in, untouched
       5  ChunkedRepro.pkg.info.json   <- contains "null"
10398712  tmp_4o9a_q7                  <- the real download, orphaned
```

After:

```
URLDownloaderPython: WARNING: 'Content-Length' missing from response headers
URLDownloaderPython: Downloaded .../downloads/ChunkedRepro.pkg

10398712  ChunkedRepro.pkg
     341  ChunkedRepro.pkg.info.json
```

`pkgutil --check-signature` on the resulting package passes, and the recorded metadata keeps caching working:

```json
{
    "file_name": "ChunkedRepro.pkg",
    "file_size": 10398712,
    "http_headers": {
        "ETag": "W/\"6a5f37d4-9eabf8\"",
        "Last-Modified": "Tue, 21 Jul 2026 09:11:48 GMT"
    }
}
```

A second run against the unchanged URL correctly short-circuits with `Nothing downloaded, packaged or imported.` and leaves no temp files behind, so `StopProcessingIf download_changed == False` still behaves as intended.

Made with Cursor
